### PR TITLE
Establish Hackmode monorepo foundation

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -23,6 +23,8 @@ jobs:
           test -d emacs
           test -d templates
           test -f docs/architecture/monorepo.org
+          test -f emacs/hackmode.el
+          test -f emacs/hackmode-ac.el
           test -f templates/bounty/assets.org
           test -f templates/htb/notes.org
           test -f templates/htb/tasks.org
@@ -52,3 +54,18 @@ jobs:
             fi
           done < <(git ls-files -z)
           exit "$bad"
+
+      - name: Install Emacs for Lisp syntax checks
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends emacs-nox
+
+      - name: Check migrated Emacs Lisp syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          for file in emacs/hackmode.el emacs/hackmode-ac.el; do
+            emacs -Q --batch \
+              --eval "(with-temp-buffer (insert-file-contents \"$file\") (emacs-lisp-mode) (check-parens))"
+          done

--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -1,0 +1,54 @@
+name: monorepo
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify canonical monorepo layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d source
+          test -d emacs
+          test -d templates
+          test -f docs/architecture/monorepo.org
+          test -f templates/bounty/assets.org
+          test -f templates/htb/notes.org
+          test -f templates/htb/tasks.org
+
+      - name: Reject generated binaries and compiled Lisp artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bad="$(git ls-files | grep -E '(^|/)ralp$|\.(fasl|fas|o|so|a)$' || true)"
+          if [[ -n "$bad" ]]; then
+            echo 'Generated/compiled artifacts are not allowed in the Hackmode monorepo:' >&2
+            echo "$bad" >&2
+            exit 1
+          fi
+
+      - name: Reject unexpectedly large tracked files
+        shell: bash
+        run: |
+          set -euo pipefail
+          bad=0
+          while IFS= read -r -d '' file; do
+            [[ -f "$file" ]] || continue
+            size="$(stat -c '%s' "$file")"
+            if (( size > 10485760 )); then
+              echo "tracked file exceeds 10 MiB: $file ($size bytes)" >&2
+              bad=1
+            fi
+          done < <(git ls-files -z)
+          exit "$bad"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 /old-archive/
 /package.fasl
+*.fasl
+*.fas
+*.o
+*.so
+*.a
 *.mdb
+
+# Generated/helper binaries must not be committed during hackmode-scripts migration.
+tools/legacy/**/ralp
+tools/legacy/**/.local/bin/

--- a/README.org
+++ b/README.org
@@ -1,48 +1,91 @@
-#+title: Readme
+#+title: Hackmode
 
+[[./ralp.jpg]]
+#+CAPTION: Ralp the red teaming Lisp alien
 
 * Hackmode
-[[./ralp.jpg]]
-#+CAPTION: Ralp The red teaming lisp alien
+Hackmode is a Common Lisp, actor-oriented investigation and reconnaissance environment built to work with StarIntel.
 
-hackmode is a metaframework for running pentesting tools and exploits.
+This repository is now the canonical Hackmode monorepo. Hackmode-owned runtime code, shell integration, Emacs integration, operation templates, and maintained helper tooling belong here. StarIntel Server, Quasar, Quasar UI, Tek9, and user dotfiles remain separate repositories and integrate through protocols/APIs rather than being vendored into this tree.
 
+* Monorepo layout
+- =source/= :: Common Lisp runtime, operation model, local storage, recon capabilities, and shell integration.
+- =emacs/= :: Hackmode Emacs package. Migration from =lost-rob0t/emacs-hackmode= is tracked by issue #4.
+- =templates/= :: Operation templates migrated from =lost-rob0t/hackmode-templates=.
+- =tools/= :: Maintained helpers and explicitly temporary legacy script compatibility. Curated migration from =lost-rob0t/hackmode-scripts= is tracked separately; generated binaries/FASLs are not accepted.
+- =docs/architecture/= :: Architecture and repository-boundary decisions.
+
+See =docs/architecture/monorepo.org= before adding a new Hackmode repository.
+
+* Architecture direction
+Hackmode is local-first. An operation must keep working when StarIntel Server is unavailable. The Common Lisp runtime is becoming the canonical owner of operation and typed asset state; Emacs and shell clients should call that boundary instead of maintaining parallel state.
+
+The intended flow is:
+
+#+begin_example
+recon actor
+    |
+    v
+operation mailbox/event stream
+    |
+    v
+local operation store
+    |
+    v
+normalize + construct StarIntel-compatible document
+    |
+    v
+persistent outbox
+    |
+    v
+StarIntel ingest bridge
+    |
+    v
+starintel-server
+#+end_example
 
 * Install
-** TODO Setup git artifacts/release downloads
-** Install from source
-*** Install deps
-**** Debian/Kali
+** Dependencies
+*** Debian/Kali
 #+begin_src shell
 sudo apt install sbcl git
 #+end_src
-**** Arch
+
+*** Arch
 #+begin_src shell
 sudo pacman -S sbcl git
 #+end_src
-**** Nixos
-install direnv
+
+*** NixOS
+Install direnv, then allow the repository environment:
 #+begin_src shell
-nix-shell -p direnv
 direnv allow
 #+end_src
-It should install deps everytime you enter the project dir.
-*** Install
+
+** Build
 #+begin_src shell
 make build
 #+end_src
+
 #+begin_src shell
 sudo make install
 #+end_src
 
+* Configure
+Hackmode follows the Lisp tradition of a user init file so the environment can be extended without forking the runtime.
 
-* TODO Configure
-Hackmode follows the lisp tradition of using a initfile for configuration, which allows you to fully extend hackmode to any use case. Hackmode tools are written in CL and with the idea that they may be called outside of the [[https://github.com/nibbula/yew/tree/master/lish][lisp shell]] that is provided for you.
+The default init file is =~/.config/hackmode/init.lisp=.
 
-The initfile is located at =/home/username/.config/hackmode/init.lisp=
+The shell work is inspired by LISH and should operate on typed Hackmode objects, not only strings. Existing commands remain callable as Common Lisp functions outside the interactive shell.
 
+* Migration status
+- Common Lisp runtime: already here.
+- Tek9-backed operation/local database: already here; being hardened rather than replaced casually.
+- Emacs package: migration in progress under issue #4.
+- Operation templates: migrated into =templates/= by issue #4.
+- Script collection: source-only curation tracked by issue #5; do not import compiled/generated artifacts.
+- Canonical operation/asset protocol: issue #6.
+- CouchDB/BBRF asset convergence: issue #3.
 
 * Contributions
-+ XMR: 8AhCtQzxMN63GmK6t1tsSzQmwWpuzFiCrFgMT1AZxrf23NHB9B8GJvYJJYB3Pq95xEHAYiKQt2g6ieDwJXb6P2Dk1wjQHFu
-+ PR/Issues alway welcome
-+ Spread the word
+PRs and issues are welcome. New functionality should reuse existing Hackmode/StarIntel protocols and actors before creating another repository or provider implementation.

--- a/docs/architecture/monorepo.org
+++ b/docs/architecture/monorepo.org
@@ -1,0 +1,87 @@
+#+title: Hackmode Monorepo Ownership
+
+* Decision
+=lost-rob0t/hackmode= is the canonical repository for Hackmode-owned code and assets.
+
+The monorepo decision fixes an existing architectural split: the Common Lisp runtime, Emacs integration, templates, and helper scripts had evolved in separate repositories and duplicated operation/asset state.
+
+* What belongs here
+** Runtime
+- typed Hackmode objects/assets
+- operation lifecycle
+- local operation storage
+- actor/event protocols
+- recon supervisors/providers owned by Hackmode
+- LISH/Hackmode shell integration
+- persistent outbox and StarIntel ingest bridge
+
+** Interfaces
+- Hackmode Emacs package
+- typed shell commands and pipelines
+- client protocol code specific to Hackmode
+
+** Assets
+- operation templates
+- maintained rules/fixtures
+- curated helper source that has not yet been promoted to Common Lisp
+
+* What stays external
+** starintel-server
+Central StarIntel document storage, server-side actors, RabbitMQ/CouchDB services, ingest APIs, collaboration services that are StarIntel-wide rather than Hackmode-specific.
+
+Hackmode integrates with it; it is not vendored.
+
+** tek9
+Reusable local document/query/index/view library. Hackmode depends on it for operation-local storage where appropriate. Hackmode-specific views belong in Hackmode; generally reusable storage/query primitives belong in Tek9.
+
+** quasar
+Separate Common Lisp investigation/control-plane product. Reuse provider/actor protocols instead of copying provider implementations.
+
+** quasar-ui
+Browser UI. It receives only the web/API boundary required to invoke reusable backend capabilities. Provider secrets never belong in browser code.
+
+** dotfiles
+User configuration. Shared StarIntel Emacs configuration may live there as =starintel.el=, but reusable Hackmode package code belongs under =emacs/= in this monorepo.
+
+* Migration sources
+| Repository | Status | Monorepo destination | Policy |
+|-
+| lost-rob0t/emacs-hackmode | active migration source | emacs/ | migrate package, then stop feature development in old repo |
+| lost-rob0t/hackmode-templates | active migration source | templates/ | migrate source templates |
+| lost-rob0t/hackmode-scripts | active migration source | source/ or tools/legacy/ | curate; never copy binaries/FASLs blindly |
+| lost-rob0t/hackmode-server | archived prototype | none by default | mine for requirements only; do not revive blindly |
+| lost-rob0t/hackmode-dotfiles | archived prototype | none by default | mine for useful configuration only |
+| lost-rob0t/yew-for-hackmode | dependency fork | deps/ only if still required | dependency, not a Hackmode product boundary |
+
+* Canonical state rule
+The Common Lisp runtime is the target canonical owner of operation and typed asset lifecycle.
+
+Temporary duplicate state exists today:
+- runtime operation registry/local store through Tek9
+- Emacs =current-op=/=op-path= files and BBRF command state
+
+Issue #6 removes that split behind a stable protocol. Until then, new stateful features must not add a third model.
+
+* Dependency order
+#+begin_example
+#4 monorepo layout
+ |
+ +--> #5 script curation
+ |
+ +--> #6 canonical operation + asset protocol
+        |
+        +--> #3 CouchDB/StarIntel-compatible asset registry
+        +--> persistent outbox / StarIntel ingest
+        +--> typed LISH shell
+        +--> asynchronous Emacs client
+        +--> shared Quasar actor/provider integration
+#+end_example
+
+* Migration rules
+1. Reuse before rewriting.
+2. Move Hackmode-owned code here; keep reusable libraries/products external.
+3. No generated binaries, FASLs, or vendored tool payloads in source migrations.
+4. Do not preserve repository boundaries that only exist due to history.
+5. Preserve provenance: migration commits and docs must name source repositories.
+6. Do not make Emacs, shell, and Quasar each own separate recon provider implementations.
+7. Do not introduce a second StarIntel document schema.

--- a/emacs/README.org
+++ b/emacs/README.org
@@ -1,0 +1,9 @@
+#+title: Hackmode Emacs Integration
+
+This directory is the canonical destination for the Hackmode Emacs package.
+
+The active historical implementation is being migrated from =lost-rob0t/emacs-hackmode= under Hackmode issue #4. Do not add new Hackmode Emacs features to the old repository while the migration is in progress.
+
+The migrated package must converge on the Common Lisp runtime rather than preserve duplicate state indefinitely. In particular, direct operation metadata files and BBRF-backed asset state are compatibility behavior, not the target architecture. Issue #6 defines the canonical runtime boundary.
+
+Long-running recon/network operations must be asynchronous and must not freeze Emacs.

--- a/emacs/README.org
+++ b/emacs/README.org
@@ -1,9 +1,21 @@
 #+title: Hackmode Emacs Integration
 
-This directory is the canonical destination for the Hackmode Emacs package.
+This directory is the canonical home of the Hackmode Emacs package, migrated from =lost-rob0t/emacs-hackmode=.
 
-The active historical implementation is being migrated from =lost-rob0t/emacs-hackmode= under Hackmode issue #4. Do not add new Hackmode Emacs features to the old repository while the migration is in progress.
+* Migrated source
+- =hackmode.el= — operation/workspace UX, capture helpers, BBRF compatibility, transients.
+- =hackmode-ac.el= — completion support for the current BBRF-backed compatibility layer.
+- =TODO.org= and =changelog.org= — historical backlog/context from the former standalone repository.
 
-The migrated package must converge on the Common Lisp runtime rather than preserve duplicate state indefinitely. In particular, direct operation metadata files and BBRF-backed asset state are compatibility behavior, not the target architecture. Issue #6 defines the canonical runtime boundary.
+The old standalone repository is now a migration source, not the place for new Hackmode Emacs features.
 
-Long-running recon/network operations must be asynchronous and must not freeze Emacs.
+* Architecture debt carried intentionally
+The source was migrated before redesign so behavior is not lost. It still duplicates state that already exists in the Common Lisp runtime:
+- =current-op= / =op-path= files
+- operation directories as the primary registry
+- direct BBRF commands and per-type BBRF hooks
+
+Issue #6 replaces this split with the canonical Common Lisp operation/asset protocol. Do not deepen the duplicate state model while that work is pending.
+
+* Async requirement
+Long-running network/recon operations must use asynchronous Emacs processes/requests and must not freeze the editor. The migrated BBRF compatibility functions that use synchronous shell calls are technical debt to replace as the runtime API lands.

--- a/emacs/TODO.org
+++ b/emacs/TODO.org
@@ -1,0 +1,34 @@
+#+title: Todo
+* TODO make more snippets
+These will need multiple for eshell/org-mode
+
+** Network Discovery & Mapping
+*** Nmap Scans
+*** Network Tech Analysis
+*** Service Enumeration
+*** Subdomain Discovery
+** Web Security Assessment
+*** SQL Injection
+*** Path Traversal Methods
+*** File Upload Security Bypass
+*** ZAP support
+*** Mitmproxy support
+** Password Security Testing
+*** Hashcat
+** Privilege Escalation Techniques
+*** Linux System
+*** Windows
+** Wireless Network Testing
+*** WPA/WPA2 Capture Methods
+*** Deauthentication Attacks
+*** Rogue Access Point Setup
+** Post-Exploitation Tools
+*** Reverse Shell Commands
+*** Data Exfiltration Methods
+**** Linux NC
+**** Windows TBD
+* IDEA Use a lisp data file for listing out all operations, so TRAMP can be supported
+Currently the dumb way i do things is throw all the ops into a dir, in  it would be simpler to just read and write a A-list/plist or even a sqlite database.
+It would be nice to use a remote host uinstead of the local vm.
+* IDEA Org roam Support?
+HackMode can be integrated into an existing Roam database or exist as a separate one. The concept allows for more fine-grained workflows when creating writeups. For example, users can visualize relevant notes through a graph view. Currently, hackmode utilizes org-capture through a dynamic variable let.

--- a/emacs/changelog.org
+++ b/emacs/changelog.org
@@ -1,0 +1,16 @@
+* Changelog
+** [2024-03-04 Mon 01:49] 0.0.7
+Added Hackmode Capture, rss reader elfeed with hackmode-rss.
+Its just org capture but wrapped for context of hackmode.
+[[file:~/Documents/Projects/emacs-hackmode/hackmode.el::;; Version: 0.0.7]]
+** [2023-12-01 Fri 05:00] 0.0.5
+I forgot to update the versions but this is where it is now
++ Added checklists
++ updated docs.
+** [2023-08-03 Thu 16:19] 0.0.2
+Improved Searchploit interface
+
+** [2023-06-25 Sun 04:50] 0.0.2
+Add pwncat-cs command that runs in vterm
+
+[[file:~/Documents/Projects/emacs-hackmode/hackmode.el::;; Version: 0.0.2]]

--- a/emacs/hackmode-ac.el
+++ b/emacs/hackmode-ac.el
@@ -1,0 +1,265 @@
+;;; bbrf-autocomplete.el --- Autocomplete for BBRF targets and hosts -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; Author: nsaspy
+;; Keywords: convenience, completion, security, osint
+;; Version: 0.0.1
+;; Package-Requires: ((emacs "26.1"))
+
+;;; Commentary:
+
+;; This package provides autocompletion for BBRF (Bug Bounty Reconnaissance Framework)
+;; targets, hosts, and IPs. It caches data from hackmode-bbrf and provides
+;; filtering completion for OSINT and penetration testing workflows.
+
+;;; Code:
+
+(require 'json)
+(require 'subr-x)
+(require 'hackmode)
+(defgroup hackmode-autocomplete nil
+  "Autocomplete for BBRF targets and hosts."
+  :group 'convenience
+  :prefix "hackmode-ac-")
+
+(defcustom hackmode-ac-hackmode-path
+  (or (getenv "HACKMODE_PATH")
+      (expand-file-name "~/.hackmode"))
+  "Path to hackmode directory."
+  :type 'string
+  :group 'hackmode-autocomplete)
+
+(defcustom hackmode-ac-cache-duration 300
+  "Cache duration in seconds (default: 5 minutes)."
+  :type 'integer
+  :group 'hackmode-autocomplete)
+
+(defcustom hackmode-ac-completion-styles '(domains ips urls services)
+  "Types of completion data to include."
+  :type '(repeat (choice (const domains)
+                         (const ips)
+                         (const urls)
+                         (const services)))
+  :group 'hackmode-autocomplete)
+
+(defvar hackmode-ac-cache nil
+  "Cache for BBRF data.")
+
+(defvar hackmode-ac-cache-timestamp nil
+  "Timestamp of last cache update.")
+
+(defvar hackmode-ac-completion-data nil
+  "Processed completion data.")
+
+(defun hackmode-ac-cache-valid-p ()
+  "Check if cache is still valid."
+  (and hackmode-ac-cache-timestamp
+       (< (- (float-time) hackmode-ac-cache-timestamp)
+          hackmode-ac-cache-duration)))
+
+(defun hackmode-ac-get-targets-file ()
+  "Get path to targets.txt file."
+  (expand-file-name "targets.txt" (hackmode-get-config-path hackmode-operation)))
+
+(defun hackmode-ac-read-targets-file ()
+  "Read targets from hackmode targets.txt file."
+  (let ((targets-file (hackmode-ac-get-targets-file)))
+    (when (file-exists-p targets-file)
+      (with-temp-buffer
+        (insert-file-contents targets-file)
+        (split-string (buffer-string) "\n" t)))))
+
+
+
+(defun hackmode-ac-get-bbrf-data ()
+  "Retrieve data from bbrf."
+  (let ((data (make-hash-table :test 'equal)))
+
+    (when (memq 'domains hackmode-ac-completion-styles)
+      (let ((domains (hackmode-bbrf-list-domains)))
+        (when domains
+          (puthash 'domains domains data))))
+
+    (when (memq 'ips hackmode-ac-completion-styles)
+      (let ((ips (hackmode-bbrf-list-ips)))
+        (when ips
+          (puthash 'ips ips data))))
+
+    (when (memq 'urls hackmode-ac-completion-styles)
+      (let ((urls (hackmode-bbrf-list-urls)))
+        (when urls
+          (puthash 'urls urls data))))
+
+    (when (memq 'services hackmode-ac-completion-styles)
+      (let ((services (hackmode-bbrf-list-services)))
+        (when services
+          (puthash 'services services data))))
+
+    data))
+
+(defun hackmode-ac-process-bbrf-entry (entry type)
+  "Process a single BBRF entry based on type."
+  (cond
+   ((eq type 'domains)
+    (if (hash-table-p entry)
+        (gethash "domain" entry)
+      entry))
+   ((eq type 'ips)
+    (if (hash-table-p entry)
+        (gethash "ip" entry)
+      entry))
+   ((eq type 'urls)
+    (if (hash-table-p entry)
+        (gethash "url" entry)
+      entry))
+   ((eq type 'services)
+    (if (hash-table-p entry)
+        (format "%s:%s"
+                (gethash "ip" entry)
+                (gethash "port" entry))
+      entry))
+   (t (format "%s" entry))))
+
+(defun hackmode-ac-flatten-data (data)
+  "Flatten and process BBRF data into completion candidates."
+  (let ((candidates '()))
+    (maphash (lambda (type entries)
+               (let ((entry-list (cond
+                                  ((vectorp entries) (append entries nil))
+                                  ((listp entries) entries)
+                                  (t (list entries)))))
+                 (dolist (entry entry-list)
+                   (let ((processed (hackmode-ac-process-bbrf-entry entry type)))
+                     (when (and processed (stringp processed))
+                       (push (cons processed type) candidates))))))
+             data)
+
+    (let ((seen (make-hash-table :test 'equal))
+          (unique-candidates '()))
+      (dolist (candidate candidates)
+        (let ((key (car candidate)))
+          (unless (gethash key seen)
+            (puthash key t seen)
+            (push candidate unique-candidates))))
+      unique-candidates)))
+
+(defun hackmode-ac-update-cache ()
+  "Update the cache with fresh data."
+  (message "Updating BBRF cache...")
+  (let ((targets-data (hackmode-ac-read-targets-file))
+        (bbrf-data (hackmode-ac-get-bbrf-data)))
+
+    (when targets-data
+      (let ((target-entries (mapcar (lambda (target)
+                                      (cons target 'targets))
+                                    targets-data)))
+        (setq hackmode-ac-completion-data
+              (append target-entries
+                      (hackmode-ac-flatten-data bbrf-data)))))
+
+    (unless targets-data
+      (setq hackmode-ac-completion-data (hackmode-ac-flatten-data bbrf-data)))
+
+    (setq hackmode-ac-cache-timestamp (float-time))
+    (message "BBRF cache updated (%d entries)" (length hackmode-ac-completion-data))))
+
+(defun hackmode-ac-get-completion-data ()
+  "Get completion data, updating cache if necessary."
+  (unless (hackmode-ac-cache-valid-p)
+    (hackmode-ac-update-cache))
+  hackmode-ac-completion-data)
+
+(defun hackmode-ac-completion-function (string predicate action)
+  "Completion function for BBRF targets."
+  (let ((candidates (hackmode-ac-get-completion-data)))
+    (cond
+     ((eq action 'metadata)
+      '(metadata (category . bbrf-target)
+        (annotation-function . hackmode-ac-annotate)))
+     ((eq action 'lambda)
+      (test-completion string candidates predicate))
+     ((eq action t)
+      (all-completions string candidates predicate))
+     ((eq action nil)
+      (try-completion string candidates predicate)))))
+
+(defun hackmode-ac-annotate (candidate)
+  "Annotate completion candidate with type information."
+  (let* ((data (hackmode-ac-get-completion-data))
+         (entry (assoc candidate data)))
+    (when entry
+      (format " [%s]" (cdr entry)))))
+
+(defun hackmode-ac-completing-read (prompt &optional initial-input)
+  "Read a target using completion."
+  (let ((completion-extra-properties
+         '(:annotation-function hackmode-ac-annotate)))
+    (completing-read prompt #'hackmode-ac-completion-function
+                     nil nil initial-input)))
+
+;;;###autoload
+(defun hackmode-ac-insert-target ()
+  "Insert a target at point using completion."
+  (interactive)
+  (let ((target (hackmode-ac-completing-read "Target: ")))
+    (when target
+      (insert target))))
+
+;;;###autoload
+(defun hackmode-ac-copy-target ()
+  "Copy a target to kill ring using completion."
+  (interactive)
+  (let ((target (hackmode-ac-completing-read "Copy target: ")))
+    (when target
+      (kill-new target)
+      (message "Copied: %s" target))))
+
+;;;###autoload
+(defun hackmode-ac-refresh-cache ()
+  "Manually refresh the BBRF cache."
+  (interactive)
+  (setq hackmode-ac-cache-timestamp nil)
+  (hackmode-ac-update-cache))
+
+(defun hackmode-ac-company-backend (command &optional arg &rest ignored)
+  "Company backend for BBRF completion."
+  (interactive (list 'interactive))
+  (cl-case command
+    (interactive (company-begin-backend 'hackmode-ac-company-backend))
+    (prefix (and (derived-mode-p 'text-mode 'prog-mode)
+                 (company-grab-symbol)))
+    (candidates (let ((candidates (hackmode-ac-get-completion-data)))
+                  (cl-remove-if-not
+                   (lambda (candidate)
+                     (string-prefix-p arg (car candidate)))
+                   candidates)))
+    (annotation (hackmode-ac-annotate arg))
+    (meta (format "BBRF target: %s" arg))))
+
+(defvar hackmode-ac-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c b i") 'hackmode-ac-insert-target)
+    (define-key map (kbd "C-c b c") 'hackmode-ac-copy-target)
+    (define-key map (kbd "C-c b r") 'hackmode-ac-refresh-cache)
+    map)
+  "Keymap for BBRF autocomplete mode.")
+
+;;;###autoload
+(define-minor-mode hackmode-ac-mode
+  "Minor mode for BBRF target autocompletion."
+  :lighter " BBRF"
+  :keymap hackmode-ac-mode-map
+  (when hackmode-ac-mode
+    (hackmode-ac-update-cache)))
+
+;;;###autoload
+(defun hackmode-ac-setup ()
+  "Setup BBRF autocomplete globally."
+  (interactive)
+  (hackmode-ac-mode 1)
+  (when (featurep 'company)
+    (add-to-list 'company-backends 'hackmode-ac-company-backend)))
+
+(provide 'hackmode-autocomplete)
+;;; hackmode-autocomplete.el ends here

--- a/emacs/hackmode.el
+++ b/emacs/hackmode.el
@@ -1,0 +1,835 @@
+;;; hackmode.el --- Pentesters Lil lisp redpill -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2023
+;;
+;; Author:  <nsaspy@fedora.email>
+;; Maintainer:  <nsaspy@fedora.email>
+;; Created: May 21, 2023
+;; Modified: July 14, 2025
+;; Version: 0.0.10
+;; Keywords: security pentesting reporting automation org
+;; Homepage: https://github.com/lost-rob0t/emacs-hackmode
+;; Package-Requires: ((emacs "28.2") (emacs-async "1.97") (f "v0.20.0"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  Cyber Security tool automation, asset tracking and more.
+;;  BBRF Is currently the standard for asset tracking in this package.
+;;
+;;
+;;; Code:
+(require 'async)
+;;  TODO Remove f.el deps
+(require 'f)
+(require 'transient)
+
+
+
+(defcustom hackmode-data-dir (f-expand "~/.local/share/hackmode/")
+  "The directory to be used to hold current state stating what and where the current operation is."
+  :group 'hackmode
+  :type 'string)
+
+
+(defcustom hackmode-path-file (f-join hackmode-data-dir "op-path") "File with contents pointing to current hackmode path."
+  :group 'hackmode
+  :type 'string)
+
+
+(defcustom hackmode-operation-file (f-join hackmode-data-dir "current-op") "File with contents the name of current hackmode op. The contests is just op-name. eg TMobile, forest.htb, ect "
+  :group 'hackmode
+  :type 'string)
+
+
+(defcustom hackmode-dir "~/hackmode"
+  "The base directory to store operation workspace in."
+  :group 'hackmode :type 'string)
+
+(defcustom hackmode-checklists nil "Alist of files . name to be used for checklists."
+  :group 'hackmode)
+
+
+(defcustom hackmode-capture-templates nil "Org Capture templates specific to hackmode,."
+  :group 'hackmode
+  :type 'list)
+
+(defun hackmode--ensure-data-dir ()
+  (unless (f-directory? hackmode-data-dir)
+    (f-mkdir hackmode-data-dir)
+    (f-touch hackmode-operation-file)
+    (f-touch hackmode-path-file)))
+
+(defun hackmode--get-current-operation ()
+  "Read the current operation from the `hackmode-operation-file`"
+  (hackmode--ensure-data-dir)
+  (with-temp-buffer
+    (insert-file-contents hackmode-operation-file)
+    (buffer-string)))
+
+;;; Common var Setups
+(defcustom hackmode-default-operation (hackmode--get-current-operation)
+  "The default operation to use."
+  :group 'hackmode
+  :type 'string)
+
+(defvar hackmode-operation hackmode-default-operation
+  "Current operation name. Do not set this, instead use 'hackmode-menu' or 'hackmode-switch-op'.")
+
+
+(defcustom hackmode-operation-hook nil
+  "Hook that runs when the Hackmode operation changes."
+  :type 'hook
+  :group 'hackmode)
+
+
+(defcustom hackmode-tools-dir (f-join hackmode-dir ".hackmode-tools/")
+  "The Default path where tools to be uploaded will be pulled from."
+  :group 'hackmode
+  :type 'string)
+
+(defcustom hackmode-interface "tun0"
+  "Network interface to use by default."
+  :group 'hackmode
+  :type 'string)
+
+
+;;;TODO Suggest skeltor templates maybe?
+(defcustom hackmode-templates (f-expand "~/.config/hackmode/templates")
+  "Path to templates directory."
+  :group 'hackmode
+  :type 'list)
+
+(defcustom hackmode-wordlist-dir "~/wordlists/"
+  "The directory for where wordlists are stored."
+  :group 'hackmode
+  :type 'string)
+
+;;; Check Lists
+(defun hackmode-create-checklist-entry (checklist-file)
+  "Create an entry in the 'check-lists.org' file linking to CHECKLIST-FILE."
+  (let* ((todo-file (f-join default-directory "check-lists.org"))
+         (entry (format "\n* TODO %s\n  [[file:%s]]" (f-filename checklist-file) checklist-file)))
+    (unless (f-exists? todo-file)
+      (f-write-text "" 'utf-8 todo-file))
+    (with-temp-buffer
+      (insert-file-contents todo-file)
+      (goto-char (point-max))
+      (insert entry)
+      (write-region (point-min) (point-max) todo-file))))
+
+
+(defun hackmode-use-checklist ()
+  "Read a target from the user and copy the checklist file."
+  (interactive)
+  (let* ((target (or hackmode-target (hackmode-select-target)))
+         (dir  (or default-directory (hackmode-get-operation-path  hackmode-operation)))
+         (file-path (cdr (assoc (completing-read "Select a checklist: " hackmode-checklists nil t) hackmode-checklists)))
+         (destination-dir (f-join dir "checklists"))
+         (destination-file (f-join destination-dir (concat (string-replace "/" "-"
+                                                                           target) "-checklist.org"))))
+    (unless (f-exists? destination-dir)
+      (f-mkdir destination-dir))
+    (f-copy file-path destination-file)
+    (hackmode-create-checklist-entry destination-file)
+    (message "Checklist for %s copied to %s" target destination-file)))
+
+;;; Hackmode capture from hacmode loot
+
+(defun hackmode-capture ()
+  "Capture a thought/data before it is lost to entropy."
+  (interactive)
+  (let* ((default-directory (hackmode-get-operation-path hackmode-operation))
+         (org-directory default-directory)
+         ;; NOTE you need to ensure this file is up to date.
+         (org-capture-templates hackmode-capture-templates))
+    (call-interactively #'org-capture)))
+
+;; Operations and managment functions
+
+(defun hackmode-get-operation-path (operation)
+  "Get the full path for a OPERATION."
+  (f-full (f-expand (f-join hackmode-dir operation))))
+
+(defun hackmode-create-op-config (operation)
+  "Create the config dirs for hackmode OPERATION and gloabl if not exists."
+  (let* ((path (hackmode-get-operation-path operation))
+         (default-directory path))
+    (f-mkdir-full-path hackmode-data-dir)
+    (f-mkdir-full-path (f-join path ".config/"))
+    (f-mkdir-full-path (f-join path "findings/"))
+    (f-touch (f-join path "findings/" ".keep"))))
+;;  you can use either file
+
+
+
+(defun hackmode-get-finds-path (operation)
+  "Get the path to the OPERATION .config/."
+  (f-join (hackmode-get-operation-path operation) "findings/"))
+
+
+(defun hackmode-get-config-path (operation)
+  "Get the path to the OPERATION .config."
+  (f-join (hackmode-get-operation-path operation) ".config/"))
+
+
+
+
+(defun hackmode-read-config-file (operation filename)
+  "Read OPERATION config file."
+  (with-temp-buffer (insert-file-contents-literally
+                     (f-join (hackmode-get-config-path operation) filename))
+                    (buffer-string)))
+
+
+(defun hackmode-write-operation-config (operation config-filename strings)
+  "Write to the OPERATION's config."
+  (f-write-text strings 'utf-8 (f-join  (hackmode-get-config-path operation) config-filename)))
+
+
+
+(defun hackmode-create-envrc (operation)
+  "Creates the .envrc for direnv for OPERATION."
+  (let* ((op-path (hackmode-get-operation-path operation))
+         (envrc-file (f-expand (f-join op-path ".envrc"))))
+    (message "Writing envrc to: %s" envrc-file)
+    (f-write-text (format  "export HACKMODE_PATH=%s; export HACKMODE_OP=%s " op-path operation) 'utf-8 envrc-file)))
+
+(defun hackmode-create-targets-file (operation)
+  "Create The targets file for OPERATION."
+  (let ((targets (f-join (hackmode-get-config-path operation) "targets.txt")))
+    (f-touch targets)))
+
+(defun hackmode-set-env (operation)
+  "Set env vars for OPERATION."
+  (setenv "PATH" (concat (getenv "PATH") ":" (f-full (f-expand hackmode-tools-dir))))
+  (setenv "HACKMODE_OP" operation)
+  (setenv "HACKMODE_PATH" (hackmode-get-operation-path operation)))
+
+(defun hackmode-set-metadata (operation)
+  "Create the metadata for OPERATION."
+  (hackmode-create-op-config operation)
+  (f-write-text (hackmode-get-operation-path operation) 'utf-8 (f-join hackmode-data-dir "op-path"))
+  (f-write-text operation 'utf-8 (f-join hackmode-data-dir "current-op"))
+  (hackmode-set-env operation))
+
+(defun hackmode-operations ()
+  "Return a list of operations."
+  (mapcar #'f-base (f-directories (f-full hackmode-dir))))
+
+
+;;;###autoload
+(defun hackmode-switch-op (&optional op)
+  "Switch operation."
+  (interactive (list (completing-read "Select operation: " (hackmode-operations) nil nil)))
+  (setq hackmode-operation op)
+  (hackmode-set-metadata op)
+  (run-hooks 'hackmode-operation-hook))
+
+(defun hackmode-new-operation ()
+  "Create a new operation to group tasks"
+  (interactive)
+  (let ((name (read-string "Enter Operation Name: ")))
+    (if (file-directory-p (hackmode-get-operation-path name))
+        (message (format "operation %s already exists" name))
+      (progn
+        (make-directory (hackmode-get-operation-path name))
+        (message (format "operation %s created" name))))))
+
+;;;###autoload
+(defun hackmode-goto-operation ()
+  "Go to the operation directory."
+  (interactive)
+  (find-file (hackmode-get-operation-path hackmode-operation)))
+
+;;; Utils
+(defun hackmode--get-interface-ip (interface)
+  "Get the IP address of a network interface."
+  (let ((output (shell-command-to-string (concat "ip addr show dev " interface " | grep 'inet '"))))
+    (when (string-match "\\([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\\)" output)
+      (match-string 1 output))))
+
+(defun hackmode--get-interfaces ()
+  "Get a list of network interface names."
+  (let ((output (shell-command-to-string "ip addr show | awk '/^[0-9]+:/ {gsub(/:/,\"\"); print $2}'")))
+    (split-string output "\n" t)))
+
+(defun hackmode-add-host (hostname address)
+  "Add a Host to /etc/hosts"
+  (interactive "sEnter hostname: \nEnter IP: ")
+  (append-to-file (format "%s\t%s\n" address hostname) nil "/sudo::/etc/hosts"))
+
+
+(defun hackmode-init-metadata (operation-name)
+  "Write the hackmode metadata to ~/.local/share/hackmode/."
+  (let ((path (hackmode-get-operation-path operation-name)))
+    (f-write-text path 'utf-8)))
+
+(defun hackmode-get-scan-dir (operation)
+  "Return The path to the output directoy for scans."
+  (f-expand (f-join (hackmode-get-operation-path operation) "scans")))
+
+(defun hackmode--ensure-scans-dir (operation &optional dir)
+  "Ensure the the scans folder is created for the hackmode operation."
+  (let ((dir (if dir (f-join (hackmode-get-scan-dir operation))) (hackmode-get-scan-dir operation)))
+    (condition-case _
+        (unless (f-directory? dir)
+          (f-mkdir-full-path dir))
+      (message "Failed to create scans directory %s: %s" dir (error-message-string err)))))
+
+(defun hackmode-create-output-dir (operation tool-name)
+  "Create the output directory for scan output."
+  (let ((dir (f-expand (f-join (hackmode-get-scan-dir operation) tool-name (number-to-string (floor (time-to-seconds (current-time))))))))
+    (unless (f-exists? dir)
+      (f-mkdir-full-path dir))
+    dir))
+
+;;;###autoload
+(defun hackmode-create-operation ()
+  "Interactivly create a operation."
+  (interactive)
+  (let* ((template (completing-read "Select Template: " (f-directories hackmode-templates)))
+         (operation (read-string "Enter Operaton Operation: "))
+         (op-path (hackmode-get-operation-path operation)))
+    (f-copy template op-path)
+    (f-symlink op-path default-directory)
+    ;; TODO Move this stuff to a function
+    (setf hackmode-operation operation)
+    (hackmode-create-envrc operation)
+    (hackmode-create-targets-file operation)
+    (hackmode-set-metadata operation)
+    (run-hooks 'hackmode-operation-hook)
+    (hackmode-goto-operation)))
+
+;; TODO allow for buffer local targets like gptel transient menu.
+
+(defvar hackmode-target nil "The currect active host or url or target.")
+(defvar hackmode-targets-file "targets.txt"
+  "The path to save targets under the HACKMODE_OP/.config/<file>.")
+
+
+
+
+
+(defun hackmode-select-target ()
+  "Select a target from a text-file, defaults to the $HACKMODE_OP/.config/targets.txt file."
+  (interactive)
+  (let* ((targets-file (read-file-name "Select Targets File: " (hackmode-get-config-path hackmode-operation) hackmode-targets-file)))
+    (setf hackmode-target (completing-read "Select Target: " (remove-if #'(lambda (x)
+                                                                            (= (length x) 0))
+                                                                        (split-string (with-temp-buffer
+                                                                                        (insert-file-contents-literally targets-file)
+                                                                                        (buffer-string)) "\n"))))))
+
+
+
+(defun hackmode-add-target (&optional arg)
+  "Prompt to save a target to the targets file."
+  (interactive "sEnter Target: ")
+  (append-to-file (concat  arg "\n") nil (expand-file-name hackmode-targets-file (hackmode-get-config-path hackmode-operation))))
+
+
+(defun hackmode-add-targets-region (&optional beg end)
+  "Prompt to save a target to the targets file."
+  (interactive "r")
+  (append-to-file beg (concat end "\n") (expand-file-name hackmode-targets-file (hackmode-get-config-path hackmode-operation))))
+
+
+
+(defun hackmode-kill-wordlist ()
+  "Copy the path of a wordlist to the kill ring"
+  (interactive)
+  (kill-new (f-expand (read-file-name "Select Wordlist: " (f-expand hackmode-wordlist-dir)))))
+
+;; TODO Move this to a yasnippet
+
+(defun hackmode-insert-wordlist ()
+  "Copy the path of a wordlist to the kill ring."
+  (interactive)
+  (insert (f-expand (read-file-name "Select Wordlist: " (f-expand hackmode-wordlist-dir)))))
+
+
+(defun hackmode-upload-file ()
+  "Copy a wget or curl command that can be used to upload a file."
+  (interactive)
+  (let* ((filename (f-relative (read-file-name "Tool to download: " hackmode-tools-dir "linpeas.sh") hackmode-tools-dir))
+         (i-name (completing-read "interface: " (hackmode--get-interfaces)))
+         (ip (hackmode--get-interface-ip i-name))
+         (port (read-string "port: " "8000"))
+         (download-cmd (read-string "Cmd to use to download: " "wget"))
+         (cmd (format "%s http://%s:%s/%s" download-cmd ip port filename)))
+    (message cmd)
+    (kill-new cmd)
+    cmd))
+
+;;; BBRF Asset Tracking.
+
+(defvar hackmode-bbrf-tags nil
+  "Current tags to be added to bbrf documents.")
+
+(defvar hackmode-bbrf-last-command nil
+  "The last command ran.")
+
+(defun hackmode-bbrf-build-command (sub &rest args)
+  "Build the command string to run bbrf commands."
+  (string-join
+   (append
+    '("bbrf")
+    (list sub)
+    (when (and hackmode-bbrf-tags (member "add" args))
+      (cl-loop for (key . val) in hackmode-bbrf-tags
+               collect "-t"
+               collect (format "%s:%s" key val)))
+    args)
+   " "))
+
+(defun hackmode-bbrf-execute-command (subcommand &rest args)
+  "Execute SUBCOMMAND with optional ARGS (list of strings). If USE-TAGS is non-nil, include tags."
+  (let ((command (apply #'hackmode-bbrf-build-command subcommand args)))
+    (setq hackmode-bbrf-last-command command)
+    (message "%s" command)
+    (let ((result (shell-command-to-string command)))
+      (string-trim result))))
+
+
+(defun hackmode-bbrf-list-programs ()
+  "Returns a list of programs in bbrf."
+  (let ((result (hackmode-bbrf-execute-command "programs")))
+    (string-split result)))
+
+(defun hackmode-bbrf-read-program (prompt &optional predicate require-match initial-input hist def inherit-input-method)
+  "Read a bbrf program name."
+  (completing-read prompt (hackmode-bbrf-list-programs) predicate require-match initial-input hist def inherit-input-method))
+
+
+
+(defun hackmode-bbrf-list (type)
+  "List assets by TYPE from BBRF. TYPE can be 'domains', 'ips', 'urls', or 'services'."
+  (let* ((cmd (hackmode-bbrf-build-command type))
+         (output (shell-command-to-string cmd)))
+    (if (string-empty-p (string-trim output))
+        nil
+      (let ((lines (seq-filter (lambda (line) (not (string-empty-p (string-trim line))))
+                               (split-string (string-trim output) "\n"))))
+        (if (string-equal type "urls")
+            (seq-map (lambda (line)
+                       (car (split-string line " ")))
+                     lines)
+          lines)))))
+
+(defun hackmode-bbrf-list-domains ()
+  "Get a list of all domains from BBRF."
+  (hackmode-bbrf-list "domains"))
+
+(defun hackmode-bbrf-list-ips ()
+  "Get a list of all IPs from BBRF."
+  (hackmode-bbrf-list "ips"))
+
+(defun hackmode-bbrf-list-urls ()
+  "Get a list of all URLs from BBRF."
+  (hackmode-bbrf-list "urls"))
+
+(defun hackmode-bbrf-list-services ()
+  "Get a list of all services from BBRF."
+  (hackmode-bbrf-list "services"))
+
+(defun hackmode-bbrf-list-all-assets ()
+  "Get an alist of all assets from BBRF grouped by type."
+  (list (cons 'domains (hackmode-bbrf-list-domains))
+        (cons 'ips (hackmode-bbrf-list-ips))
+        (cons 'urls (hackmode-bbrf-list-urls))
+        (cons 'services (hackmode-bbrf-list-services))))
+
+(defun hackmode-bbrf-read-asset (type prompt &optional predicate require-match initial-input hist def inherit-input-method)
+  "Read a BBRF asset of TYPE with completion."
+  (completing-read prompt
+                   (hackmode-bbrf-list type)
+                   predicate
+                   require-match
+                   initial-input
+                   hist
+                   def
+                   inherit-input-method))
+
+(defun hackmode-bbrf-read-domain (prompt &optional predicate require-match initial-input hist def inherit-input-method)
+  "Read a domain from BBRF with completion."
+  (hackmode-bbrf-read-asset "domains" prompt predicate require-match initial-input hist def inherit-input-method))
+
+(defun hackmode-bbrf-read-ip (prompt &optional predicate require-match initial-input hist def inherit-input-method)
+  "Read an IP from BBRF with completion."
+  (hackmode-bbrf-read-asset "ips" prompt predicate require-match initial-input hist def inherit-input-method))
+
+(defun hackmode-bbrf-read-url (prompt &optional predicate require-match initial-input hist def inherit-input-method)
+  "Read a URL from BBRF with completion."
+  (hackmode-bbrf-read-asset "urls" prompt predicate require-match initial-input hist def inherit-input-method))
+
+(defun hackmode-bbrf-read-service (prompt &optional predicate require-match initial-input hist def inherit-input-method)
+  "Read a service from BBRF with completion."
+  (hackmode-bbrf-read-asset "services" prompt predicate require-match initial-input hist def inherit-input-method))
+
+;; Interactive functions for quick access
+(defun hackmode-bbrf-show-domains ()
+  "Display all domains in a buffer."
+  (interactive)
+  (let ((domains (hackmode-bbrf-list-domains)))
+    (with-current-buffer (get-buffer-create "*BBRF Domains*")
+      (erase-buffer)
+      (insert (mapconcat 'identity domains "\n"))
+      (goto-char (point-min))
+      (display-buffer (current-buffer)))))
+
+(defun hackmode-bbrf-show-ips ()
+  "Display all IPs in a buffer."
+  (interactive)
+  (let ((ips (hackmode-bbrf-list-ips)))
+    (with-current-buffer (get-buffer-create "*BBRF IPs*")
+      (erase-buffer)
+      (insert (mapconcat 'identity ips "\n"))
+      (goto-char (point-min))
+      (display-buffer (current-buffer)))))
+
+(defun hackmode-bbrf-show-urls ()
+  "Display all URLs in a buffer."
+  (interactive)
+  (let ((urls (hackmode-bbrf-list-urls)))
+    (with-current-buffer (get-buffer-create "*BBRF URLs*")
+      (erase-buffer)
+      (insert (mapconcat 'identity urls "\n"))
+      (goto-char (point-min))
+      (display-buffer (current-buffer)))))
+
+(defun hackmode-bbrf-show-services ()
+  "Display all services in a buffer."
+  (interactive)
+  (let ((services (hackmode-bbrf-list-services)))
+    (with-current-buffer (get-buffer-create "*BBRF Services*")
+      (erase-buffer)
+      (insert (mapconcat 'identity services "\n"))
+      (goto-char (point-min))
+      (display-buffer (current-buffer)))))
+
+(defun hackmode-bbrf-show-all ()
+  "Display all assets in a formatted buffer."
+  (interactive)
+  (let ((all-assets (hackmode-bbrf-list-all-assets)))
+    (with-current-buffer (get-buffer-create "*BBRF All Assets*")
+      (erase-buffer)
+      (dolist (asset-type all-assets)
+        (let ((type (car asset-type))
+              (assets (cdr asset-type)))
+          (insert (format "=== %s ===\n" (upcase (symbol-name type))))
+          (if assets
+              (insert (mapconcat 'identity assets "\n"))
+            (insert "No assets found"))
+          (insert "\n\n")))
+      (goto-char (point-min))
+      (display-buffer (current-buffer)))))
+
+(defgroup hackmode nil
+  "HACKMODE customization group."
+  :group 'tools
+  :prefix "hackmode-")
+
+(defcustom hackmode-bbrf-program-added-hook nil
+  "Hook run when a program is added to HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-domain-added-hook nil
+  "Hook run when a domain is added to HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-ip-added-hook nil
+  "Hook run when an IP is added to HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-url-added-hook nil
+  "Hook run when a URL is added to HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-service-added-hook nil
+  "Hook run when a service is added to HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-program-removed-hook nil
+  "Hook run when a program is removed from HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-domain-removed-hook nil
+  "Hook run when a domain is removed from HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-ip-removed-hook nil
+  "Hook run when an IP is removed from HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-url-removed-hook nil
+  "Hook run when a URL is removed from HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-service-removed-hook nil
+  "Hook run when a service is removed from HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-program-updated-hook nil
+  "Hook run when a program is updated in HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-domain-updated-hook nil
+  "Hook run when a domain is updated in HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-ip-updated-hook nil
+  "Hook run when an IP is updated in HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-url-updated-hook nil
+  "Hook run when a URL is updated in HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+(defcustom hackmode-bbrf-service-updated-hook nil
+  "Hook run when a service is updated in HACKMODE-BBRF."
+  :type 'hook
+  :group 'hackmode)
+
+
+(defun hackmode-bbrf-create-program (name)
+  "Create a new BBRF program with NAME and optional OPTIONS."
+  (interactive
+   (let ((name (read-string "Enter Program name: " hackmode-operation)))))
+  (hackmode-bbrf-execute-command "new" name nil)
+  (run-hooks 'hackmode-bbrf-program-added-hook)
+  (message "Created new program: %s" name))
+
+
+
+(defun hackmode-bbrf-set-program (name)
+  "Set the current BBRF program to NAME."
+  (interactive
+   (list (hackmode-bbrf-read-program "Select a program: ")))
+  (hackmode-bbrf-execute-command "use" name)
+  (message "Set current program to: %s" name))
+
+
+
+(defun hackmode-bbrf-add-inscope (domains)
+  "Add DOMAINS to inscope for the current program."
+  (interactive "sDomains to add to inscope (space-separated): ")
+  (hackmode-bbrf-execute-command "inscope " "add" domains)
+  (message "Added domains to inscope: %s" domains))
+
+(defun hackmode-bbrf-add-outscope (domains)
+  "Add DOMAINS to outscope for the current program."
+  (interactive "sDomains to add to outscope (space-separated): ")
+  (hackmode-bbrf-execute-command "outscope" "add" domains)
+  (message "Added domains to outscope: %s" domains))
+
+
+(defun hackmode-bbrf-add-domains (domains)
+  "Add DOMAINS to the current program."
+  (interactive "sDomains to add (space-separated): ")
+  (hackmode-bbrf-execute-command "domain" "add" domains)
+  (run-hooks 'hackmode-bbrf-domain-added-hook)
+
+  (message "Added domains %s" domains))
+
+
+
+(defun hackmode-bbrf-add-ips (ips)
+  "Add IPS to the current program."
+  (interactive "sIPS to add (space-separated): ")
+  (hackmode-bbrf-execute-command "ip" "add" ips)
+  (run-hooks 'hackmode-bbrf-ip-added-hook)
+  (message "Added ips %s" ips))
+
+
+(defun hackmode-bbrf-add-urls (urls)
+  "Add URLS to the current program."
+  (interactive "sURLS to add (space-separated): ")
+  (hackmode-bbrf-execute-command "url" "add" urls)
+  (run-hooks 'hackmode-bbrf-url-added-hook)
+  (message "Added urls %s" urls))
+
+(defun hackmode-bbrf-add-services (srvs)
+  "add SRVS to the current program."
+  (interactive "sServices to add (space-separated): ")
+  (run-hooks 'hackmode-bbrf-service-added-hook)
+  (hackmode-bbrf-execute-command "service" "add" srvs))
+
+(defun hackmode-bbrf-remove-services (srvs)
+  "Remove SRVS from the current program."
+  (interactive "sServices to add (space-separated): ")
+  (run-hooks 'hackmode-bbrf-service-removed-hook)
+  (hackmode-bbrf-execute-command "service" "remove" srvs))
+
+(defun hackmode-bbrf-remove-inscope (domains)
+  "Remove DOMAINS to inscope for the current program."
+  (interactive "sDomains to remove to inscope (space-separated): ")
+  (hackmode-bbrf-execute-command "inscope" "remove" (split-string domains))
+  (message "Removed domains to inscope: %s" domains))
+
+(defun hackmode-bbrf-remove-outscope (domains)
+  "Remove DOMAINS to outscope for the current program."
+  (interactive "sDomains to remove to outscope (space-separated): ")
+  (hackmode-bbrf-execute-command "outscope" "remove" (split-string domains))
+  (message "Removed domains to outscope: %s" domains))
+
+
+(defun hackmode-bbrf-remove-domains (domains)
+  "Remove DOMAINS to the current program."
+  (interactive "sDomains to remove (space-separated): ")
+  (hackmode-bbrf-execute-command "domain" "remove" domains)
+  (run-hooks 'hackmode-bbrf-domain-removed-hook)
+  (message "Removed domains %s" domains))
+
+(defun hackmode-bbrf-remove-ips (ips)
+  "Remove IPS to the current program."
+  (interactive "sIPS to remove (space-separated): ")
+  (hackmode-bbrf-execute-command "ip" "remove" ips)
+  (run-hooks 'hackmode-bbrf-ip-removed-hook)
+  (message "Removed ips %s" ips))
+
+(defun hackmode-bbrf-remove-urls (urls)
+  "Remove URLS to the current program."
+  (interactive "sURLS to remove (space-separated): ")
+  (hackmode-bbrf-execute-command "url" "remove" urls)
+  (run-hooks 'hackmode-bbrf-url-removed-hook)
+  (message "Removed urls %s" urls))
+
+;; TODO add-bulk domains command
+
+
+(defun hackmode-bbrf-domains-from-region (start end)
+  "Add domains from the selected region to BBRF."
+  (interactive "r")
+  (let ((domains (split-string (buffer-substring-no-properties start end) "\n")))
+    (mapcar #'hackmode-bbrf-add-domains domains)))
+
+(defun hackmode-bbrf-inscope-from-region (start end)
+  "Add inscope from the selected region to BBRF."
+  (interactive "r")
+  (let ((scopes (split-string (buffer-substring-no-properties start end) "\n")))
+    (mapcar #'hackmode-bbrf-add-inscope scopes)))
+
+(defun hackmode-bbrf-outscope-from-region (start end)
+  "Add outscope from the selected region to BBRF."
+  (interactive "r")
+  (let ((scopes (split-string (buffer-substring-no-properties start end) "\n")))
+    (mapcar #'hackmode-bbrf-add-outscope scopes)))
+
+(defun hackmode-bbrf-ips-from-region (start end)
+  "Add domains from the selected region to BBRF."
+  (interactive "r")
+  (let ((ips (split-string (buffer-substring-no-properties start end) "\n")))
+    (mapcar #'hackmode-bbrf-add-ips ips)))
+
+
+(defun hackmode-bbrf-urls-from-region (start end)
+  "Add domains from the selected region to BBRF."
+  (interactive "r")
+  (let ((urls (split-string (buffer-substring-no-properties start end) "\n")))
+    (mapcar #'hackmode-bbrf-add-urls urls)))
+
+(defun hackmode-bbrf-start-listener ()
+  "Run the bbrf listener. launches shell scripts defined in ~/.bbrf/hooks."
+  (interactive)
+  (async-shell-command "while true; do bbrf listen; done" "*bbrf-listen*" "*bbrf-errors*"))
+
+(defun hackmode-bbrf-add-tag (key val)
+  "Add KEY and VAL to HACKMODE-BBRF-TAGS. when interacting with bbrf these will be used."
+  (interactive (list
+                (read-string "Enter key name: ")
+                (read-string "Enter value: ")))
+  (push (cons key val) hackmode-bbrf-tags))
+
+(defun hackmode-bbrf-clear-tags ()
+  "Remove all tags from HACKMODE-BBRF-TAGS."
+  (interactive)
+  (setf hackmode-bbrf-tags nil))
+
+(defun hackmode-bbrf-delete-tag (name)
+  "Delete tag by NAME."
+  (interactive (list
+                (completing-read "Key: " (mapcar #'car hackmode-bbrf-tags))))
+  (setf hackmode-bbrf-tags (assoc-delete-all name hackmode-bbrf-tags)))
+
+(defun hackmode-bbrf--display-tags ()
+  "Formats a display string for the hackmode-bbrf-menu"
+  (string-join (cl-loop for (key . val) in hackmode-bbrf-tags
+                        collect (propertize  (format "%s:%s" key val) 'face 'transient-argument)) " "))
+
+;;;###autoload
+(transient-define-prefix hackmode-bbrf-menu ()
+  "BBRF menu"
+  [["Add To BBRF"
+    ("u" "Add Urls" hackmode-bbrf-add-urls :transient t)
+    ("i" "Add IPS" hackmode-bbrf-add-ips :transient t)
+    ("d" "Add domains" hackmode-bbrf-add-domains :transient t)
+    ("rd" "Add Domains from region" hackmode-bbrf-domains-from-region :transient t)
+    ("ru" "Add urls from region" hackmode-bbrf-urls-from-region :transient t)
+    ("ri" "Add ips from region" hackmode-bbrf-ips-from-region :transient t)]
+
+   ["Tags"
+    (:info #'hackmode-bbrf--display-tags)
+    ("tt" "add a tag" hackmode-bbrf-add-tag :transient t)
+    ("td" "delete a tag" hackmode-bbrf-delete-tag :transient t)
+    ("-td" "delete all tags" hackmode-bbrf-clear-tags :transient t)]
+
+   ["Programs"
+    (" " :info (lambda ()
+                 (propertize (format  "Current: %s" (hackmode-bbrf-execute-command "program" "active")) 'face 'success)))
+    ("c" "Create program" hackmode-bbrf-create-program :transient t)
+    ("s" "Set program" hackmode-bbrf-set-program :transient t)
+    ("I" "Add to inscope" hackmode-bbrf-add-inscope :transient t)
+    ("O" "Add to outscope" hackmode-bbrf-add-outscope :transient t)
+    ("rO" "Outscope from region" hackmode-bbrf-outscope-from-region :transient t)
+    ("rI" "Add to inscope" hackmode-bbrf-inscope-from-region :transient t)
+    ("l" "Start listener" hackmode-bbrf-start-listener :transient t)]])
+
+;;;###autoload
+(transient-define-prefix hackmode-menu ()
+  "Main hackmode menu"
+  [:description (lambda ()
+                  (concat
+                   "[" "Operation: "
+                   (propertize hackmode-operation 'face 'transient-heading)
+                   "]\n"
+                   "["
+                   "Target: "
+                   (if hackmode-target
+                       (propertize hackmode-target 'face 'transient-heading)
+                     (propertize "NO TARGET SELECTED" 'face 'warning))
+                   "]\n"))
+
+                ["Assets"
+                 ("b" "BBRF" hackmode-bbrf-menu)]
+
+                ["Operations"
+                 ("c" "Create operation." hackmode-create-operation :transient t)
+                 ("so" "Select operation." hackmode-switch-op :transient t)
+                 ("g" "Goto current operation." hackmode-goto-operation :transient nil)]
+
+                ["Targets"
+                 ("st" "Select Target" hackmode-select-target :transient t)]])
+
+
+
+
+(provide 'hackmode)
+;;; hackmode.el ends here
+;;;
+;;;

--- a/templates/bounty/assets.org
+++ b/templates/bounty/assets.org
@@ -1,0 +1,8 @@
+#+title: Assets
+
+* Assets
+** Web
+** IP
+** Domain
+** Services
+** HUMINT

--- a/templates/htb/notes.org
+++ b/templates/htb/notes.org
@@ -1,0 +1,1 @@
+#+TITLE: Notes

--- a/templates/htb/tasks.org
+++ b/templates/htb/tasks.org
@@ -1,0 +1,11 @@
+#+title: Tasks
+
+
+* Tasks
+
+These are common tasks i run
+
+#+Name: DorkXNG
+#+begin_src shell :async :results none
+docker run researchanddestroy/searxng:latest
+#+end_src


### PR DESCRIPTION
## What changed
- establishes `lost-rob0t/hackmode` as the canonical Hackmode monorepo
- documents repository boundaries for StarIntel Server, Tek9, Quasar, Quasar UI, and dotfiles
- migrates operation templates from `lost-rob0t/hackmode-templates` into `templates/`
- migrates the active Emacs package sources from `lost-rob0t/emacs-hackmode` into `emacs/`
- adds monorepo hygiene CI: required layout, generated/compiled artifact rejection, large tracked-file rejection, and Emacs Lisp `check-parens`
- hardens `.gitignore` against FASL/generated binary imports before the `hackmode-scripts` curation slice

## Why
Hackmode runtime, Emacs state, templates, and scripts were split across repositories. The split already duplicates operation/asset state and makes the planned actor/local-first architecture harder to evolve coherently.

## Issue
Closes #4.

Follow-ups:
- #5 curate `hackmode-scripts` source-only
- #6 make Common Lisp runtime canonical for operation/asset state
- #3 converge BBRF/CouchDB asset management on the canonical protocol

## Verification
GitHub Actions `monorepo` workflow completed successfully for the current head. It verifies the canonical layout, rejects generated/compiled artifacts and unexpectedly large files, and syntax-checks `emacs/hackmode.el` and `emacs/hackmode-ac.el` with Emacs `check-parens`.

No generated `ralp` binaries or FASLs from `hackmode-scripts` were imported.