### PR TITLE
Canonicalize Hackmode operation and asset state

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -55,6 +55,20 @@ jobs:
           done < <(git ls-files -z)
           exit "$bad"
 
+      - name: Check canonical state source contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -nE ':allocation[[:space:]]+:class' \
+            source/hackmode-core/objects.lisp \
+            source/hackmode-core/operations.lisp; then
+            echo 'Per-object/operation state must never use :allocation :class.' >&2
+            exit 1
+          fi
+          grep -q 'starintel:digest-id' source/hackmode-core/assets.lisp
+          test -f source/hackmode-core/tests/core-state.lisp
+          test -f source/hackmode-core/hackmode-tests.asd
+
       - name: Install Emacs for Lisp syntax checks
         shell: bash
         run: |

--- a/source/hackmode-core/assets.lisp
+++ b/source/hackmode-core/assets.lisp
@@ -27,7 +27,8 @@
   nil)
 
 (defun normalize-name (value)
-  (string-downcase (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+  (string-downcase
+   (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
 
 (defun normalize-domain-name (value)
   (string-right-trim '(#\.) (normalize-name value)))
@@ -48,7 +49,7 @@
         (doc-type asset) "host")
   asset)
 (defmethod asset-canonical-value ((asset host))
-  ;; StarIntel's canonical host model prefers IP identity.  Preserve unresolved
+  ;; StarIntel's canonical host model prefers IP identity. Preserve unresolved
   ;; hostnames without collapsing them all onto an empty-IP digest.
   (if (plusp (length (doc-ip asset)))
       (doc-ip asset)
@@ -106,7 +107,7 @@
   "Return a deterministic id using StarIntel's canonical digest primitive.
 
 PARENT-ID is required for assets such as ports whose value is not globally
-unique.  Exact StarIntel document projection remains the asset-registry layer's
+unique. Exact StarIntel document projection remains the asset-registry layer's
 responsibility; this function deliberately reuses STARINTEL:DIGEST-ID instead of
 inventing another hashing convention."
   (when (and (asset-requires-parent-p asset) (not parent-id))
@@ -151,7 +152,7 @@ inventing another hashing convention."
   "Persist ASSET exactly once, then publish a :DISCOVERED event.
 
 Returns two values: the canonical stored asset and true only when this call
-created it.  Persistence happens before event publication, so subscribers never
+created it. Persistence happens before event publication, so subscribers never
 observe an asset that is absent from the local operation store."
   (unless (and database (tek9:db-is-open-p database))
     (error "DISCOVER-ASSET requires an open local operation database."))
@@ -182,12 +183,11 @@ it."
      :map-fn
      (lambda (key document)
        (declare (ignore key))
-       (let ((value (tek9:doc-value document)))
-         (when (and (typep value 'meta)
-                    (or (null wanted)
-                        (handler-case
-                            (string= wanted (asset-kind value))
-                          (no-applicable-method () nil)))
+       (let* ((value (tek9:doc-value document))
+              (kind (and (typep value 'meta)
+                         (ignore-errors (asset-kind value)))))
+         (when (and kind
+                    (or (null wanted) (string= wanted kind))
                     (or (null predicate) (funcall predicate value)))
            (push value assets)))))
     (nreverse assets)))

--- a/source/hackmode-core/assets.lisp
+++ b/source/hackmode-core/assets.lisp
@@ -1,0 +1,193 @@
+(in-package :hackmode)
+
+(defstruct asset-event
+  event-type
+  asset
+  operation
+  timestamp)
+
+(defvar *asset-event-hook*
+  (make-instance 'nhooks:hook-void :handlers nil)
+  "Generic persisted-asset event hook. Handlers receive one ASSET-EVENT.")
+
+(defgeneric asset-kind (asset)
+  (:documentation "Return the canonical Hackmode asset type string."))
+
+(defgeneric normalize-asset (asset)
+  (:documentation "Normalize ASSET in place and return it."))
+
+(defgeneric asset-canonical-value (asset)
+  (:documentation "Return the deterministic identity input for ASSET."))
+
+(defgeneric asset-requires-parent-p (asset)
+  (:documentation "Whether ASSET identity requires a parent asset id."))
+
+(defmethod asset-requires-parent-p ((asset t))
+  (declare (ignore asset))
+  nil)
+
+(defun normalize-name (value)
+  (string-downcase (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+
+(defun normalize-domain-name (value)
+  (string-right-trim '(#\.) (normalize-name value)))
+
+(defmethod asset-kind ((asset domain)) "domain")
+(defmethod normalize-asset ((asset domain))
+  (setf (domain-name asset) (normalize-domain-name (domain-name asset))
+        (domain-type asset) (string-upcase (string-trim " " (domain-type asset)))
+        (doc-type asset) "domain")
+  asset)
+(defmethod asset-canonical-value ((asset domain))
+  (format nil "~a|~a" (domain-name asset) (domain-type asset)))
+
+(defmethod asset-kind ((asset host)) "host")
+(defmethod normalize-asset ((asset host))
+  (setf (doc-host asset) (normalize-domain-name (doc-host asset))
+        (doc-ip asset) (string-trim " " (doc-ip asset))
+        (doc-type asset) "host")
+  asset)
+(defmethod asset-canonical-value ((asset host))
+  ;; StarIntel's canonical host model prefers IP identity.  Preserve unresolved
+  ;; hostnames without collapsing them all onto an empty-IP digest.
+  (if (plusp (length (doc-ip asset)))
+      (doc-ip asset)
+      (doc-host asset)))
+
+(defmethod asset-kind ((asset url)) "url")
+(defmethod normalize-asset ((asset url))
+  (setf (url-scheme asset) (normalize-name (url-scheme asset))
+        (url-host asset) (normalize-domain-name (url-host asset))
+        (doc-type asset) "url")
+  asset)
+(defmethod asset-canonical-value ((asset url))
+  (with-output-to-string (out)
+    (format out "~a://~a" (url-scheme asset) (url-host asset))
+    (unless (or (and (string= (url-scheme asset) "http") (= (url-port asset) 80))
+                (and (string= (url-scheme asset) "https") (= (url-port asset) 443)))
+      (format out ":~d" (url-port asset)))
+    (write-string (url-path asset) out)
+    (when (plusp (length (url-query asset)))
+      (write-char #\? out)
+      (write-string (url-query asset) out))))
+
+(defmethod asset-kind ((asset cert)) "certificate")
+(defmethod normalize-asset ((asset cert))
+  (setf (cert-common-name asset) (normalize-domain-name (cert-common-name asset))
+        (doc-type asset) "certificate")
+  asset)
+(defmethod asset-canonical-value ((asset cert))
+  (format nil "~a|~d|~d"
+          (cert-common-name asset)
+          (cert-not-before asset)
+          (cert-not-after asset)))
+
+(defmethod asset-kind ((asset finding)) "finding")
+(defmethod normalize-asset ((asset finding))
+  (setf (doc-type asset) "finding")
+  asset)
+(defmethod asset-canonical-value ((asset finding))
+  (format nil "~a|~a|~a"
+          (finding-finding-type asset)
+          (finding-doc asset)
+          (finding-data asset)))
+
+(defmethod asset-kind ((asset port)) "port")
+(defmethod normalize-asset ((asset port))
+  (setf (doc-type asset) "port")
+  asset)
+(defmethod asset-canonical-value ((asset port))
+  (princ-to-string (doc-port asset)))
+(defmethod asset-requires-parent-p ((asset port))
+  (declare (ignore asset))
+  t)
+
+(defun asset-deterministic-id (asset &key parent-id)
+  "Return a deterministic id using StarIntel's canonical digest primitive.
+
+PARENT-ID is required for assets such as ports whose value is not globally
+unique.  Exact StarIntel document projection remains the asset-registry layer's
+responsibility; this function deliberately reuses STARINTEL:DIGEST-ID instead of
+inventing another hashing convention."
+  (when (and (asset-requires-parent-p asset) (not parent-id))
+    (error "Asset type ~a requires :PARENT-ID for deterministic identity."
+           (asset-kind asset)))
+  (if parent-id
+      (starintel:digest-id (asset-kind asset)
+                           parent-id
+                           (asset-canonical-value asset))
+      (starintel:digest-id (asset-kind asset)
+                           (asset-canonical-value asset))))
+
+(defun bind-asset-operation (asset)
+  (when (and (string= (doc-operation asset) "") *current-operation*)
+    (setf (doc-operation asset) (operation-name *current-operation*)))
+  asset)
+
+(defun publish-asset-event (event-type asset)
+  "Publish EVENT-TYPE for already-persisted ASSET."
+  (let ((event (make-asset-event
+                :event-type event-type
+                :asset asset
+                :operation (doc-operation asset)
+                :timestamp (unix-now))))
+    (nhooks:run-hook *asset-event-hook* event)
+    event))
+
+(defun subscribe-asset-events (handler)
+  "Subscribe HANDLER to the generic asset event stream."
+  (nhooks:add-hook *asset-event-hook* handler)
+  handler)
+
+(defun store-asset (asset &key (database *db*) parent-id)
+  "Normalize and persist ASSET into the active operation store."
+  (normalize-asset asset)
+  (bind-asset-operation asset)
+  (setf (doc-id asset) (asset-deterministic-id asset :parent-id parent-id))
+  (put-doc asset :database database)
+  asset)
+
+(defun discover-asset (asset &key (database *db*) parent-id (publish t))
+  "Persist ASSET exactly once, then publish a :DISCOVERED event.
+
+Returns two values: the canonical stored asset and true only when this call
+created it.  Persistence happens before event publication, so subscribers never
+observe an asset that is absent from the local operation store."
+  (unless (and database (tek9:db-is-open-p database))
+    (error "DISCOVER-ASSET requires an open local operation database."))
+  (normalize-asset asset)
+  (bind-asset-operation asset)
+  (setf (doc-id asset) (asset-deterministic-id asset :parent-id parent-id))
+  (let ((existing (tek9:fetch* database (doc-id asset))))
+    (if existing
+        (values existing nil)
+        (progn
+          (put-doc asset :database database)
+          (when publish
+            (publish-asset-event :discovered asset))
+          (values asset t)))))
+
+(defun query-assets (&key (database *db*) type predicate)
+  "Return operation-local assets matching TYPE and PREDICATE.
+
+This first protocol slice intentionally uses Tek9's existing snapshot iterator.
+Indexes/views can be added without changing callers once query volume requires
+it."
+  (unless (and database (tek9:db-is-open-p database))
+    (error "QUERY-ASSETS requires an open local operation database."))
+  (let ((wanted (and type (string-downcase (string type))))
+        assets)
+    (tek9:map-database
+     database
+     :map-fn
+     (lambda (key document)
+       (declare (ignore key))
+       (let ((value (tek9:doc-value document)))
+         (when (and (typep value 'meta)
+                    (or (null wanted)
+                        (handler-case
+                            (string= wanted (asset-kind value))
+                          (no-applicable-method () nil)))
+                    (or (null predicate) (funcall predicate value)))
+           (push value assets)))))
+    (nreverse assets)))

--- a/source/hackmode-core/database.lisp
+++ b/source/hackmode-core/database.lisp
@@ -1,34 +1,54 @@
 (in-package :hackmode)
 
-
-
 (conspack:defencoding meta
-  doc-id tags dtype date-added date-updated operation)
+  doc-id tags dtype date-added date-updated operation tool)
 
 (conspack:defencoding output
   doc-id tags dtype date-added date-updated operation tool output)
 
+(conspack:defencoding domain
+  doc-id tags dtype date-added date-updated operation tool
+  ips record record-type zone)
 
 (conspack:defencoding host
-  doc-id tags dtype date-added date-updated operation hostname ip)
-
+  doc-id tags dtype date-added date-updated operation tool hostname ip)
 
 (conspack:defencoding port
-  doc-id tags dtype date-added date-updated operation number services)
+  doc-id tags dtype date-added date-updated operation tool number services)
 
-(defvar *db* nil "The hackmode database object")
+(conspack:defencoding finding
+  doc-id tags dtype date-added date-updated operation tool
+  id finding-document-id finding-type data)
 
+(conspack:defencoding url
+  doc-id tags dtype date-added date-updated operation tool
+  scheme host port path query)
 
-;; default to the one from tek9
-;; This is effectivly just a wrapper around "put"
+(conspack:defencoding cert
+  doc-id tags dtype date-added date-updated operation tool
+  not-before not-after common-name org-unit-name locality country-name province)
+
+(defvar *db* nil "The active Hackmode operation database object.")
+
 (defun put-doc (document &key (database-name "std") (database *db*))
-  (when (not (doc-id document))
-    (setf (doc-id document) (sxhash document)))
-  (tek9:put* database document :id (doc-id document)))
-
+  "Persist DOCUMENT in DATABASE under its document id."
+  (unless database
+    (error "No Hackmode operation database is open."))
+  (unless (and (doc-id document) (stringp (doc-id document)))
+    (setf (doc-id document) (tek9:make-key-id)))
+  (tek9:put* database document
+             :id (doc-id document)
+             :database-name database-name))
 
 (defun put-docs (documents &key (database-name "std") (database *db*))
-  (tek9:put-bulk database (loop for doc in documents
-                                collect (progn
-                                          (let ((id (or (doc-id doc) (format nil "~a" (sxhash doc)))))
-                                            (tek9:new-document :id id :value doc))))))
+  "Persist DOCUMENTS in one Tek9 bulk write."
+  (unless database
+    (error "No Hackmode operation database is open."))
+  (tek9:put-bulk
+   database
+   (loop for doc in documents
+         for id = (or (and (stringp (doc-id doc)) (doc-id doc))
+                      (tek9:make-key-id))
+         do (setf (doc-id doc) id)
+         collect (tek9:new-document :id id :value doc))
+   :database-name database-name))

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -1,0 +1,8 @@
+(asdf:defsystem :hackmode-tests
+  :description "Regression tests for Hackmode core state and asset lifecycle"
+  :depends-on (#:hackmode)
+  :serial t
+  :components ((:file "tests/core-state"))
+  :perform (test-op (op system)
+             (declare (ignore op system))
+             (uiop:symbol-call :hackmode-tests :run-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -2,15 +2,25 @@
   :description "Core Systems for hackmode"
   :author "nsaspy"
   :license "LGLV3"
-  :version "0.1.0"
+  :version "0.2.0"
   :serial t
-  :depends-on (#:serapeum :local-time :nfiles :nhooks #:tek9 #:cl-ppcre #:dexador #:shellpool)
+  :in-order-to ((test-op (test-op "hackmode-tests")))
+  :depends-on (#:serapeum
+               :local-time
+               :nfiles
+               :nhooks
+               #:tek9
+               #:starintel
+               #:cl-ppcre
+               #:dexador
+               #:shellpool)
   :components ((:file "package")
                (:file "utils")
                (:file "settings")
                (:file "objects")
                (:file "database")
                (:file "operations")
+               (:file "assets")
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/objects.lisp
+++ b/source/hackmode-core/objects.lisp
@@ -1,21 +1,20 @@
 (in-package :hackmode)
 
-
+;; Compatibility objects used by the historical Hackmode API.  State on these
+;; objects must be instance-local.  The old :ALLOCATION :CLASS declarations
+;; caused separate assets and operations to overwrite each other.
 (defclass meta ()
-  ((date-added :initarg :date-added :initform (unix-now) :type integer :accessor doc-date-added :allocation :class)
-   (date-updated :initarg :date-updated :initform (unix-now) :type integer :accessor doc-date-updated :allocation :class)
-   (operation :initarg :operation :initform "" :type string :accessor doc-operation :allocation :class)
-   (dtype :initarg :dtype :initform nil :accessor doc-type :allocation :class)
-   (tags :initarg :tags :type list :initform  () :accessor doc-tags :allocation :class)
-   (tool :initarg :tool :type string :initform "hackmode" :accessor doc-tool :allocation :class)
-   (doc-id :initarg :id :type string :initform (tek9:make-key-id) :allocation :class :accessor doc-id)))
-
-
+  ((date-added :initarg :date-added :initform (unix-now) :type integer :accessor doc-date-added)
+   (date-updated :initarg :date-updated :initform (unix-now) :type integer :accessor doc-date-updated)
+   (operation :initarg :operation :initform "" :type string :accessor doc-operation)
+   (dtype :initarg :dtype :initform nil :accessor doc-type)
+   (tags :initarg :tags :type list :initform () :accessor doc-tags)
+   (tool :initarg :tool :type string :initform "hackmode" :accessor doc-tool)
+   (doc-id :initarg :id :type string :initform (tek9:make-key-id) :accessor doc-id)))
 
 (defclass output (meta)
-  ((tool :initarg :tool :initform "" :type string :accessor doc-tool :allocation :class)
-   (output :initarg :output :initform  "" :type string :accessor doc-output :allocation :class)))
-
+  ((tool :initarg :tool :initform "" :type string :accessor doc-tool)
+   (output :initarg :output :initform "" :type string :accessor doc-output)))
 
 (defclass domain (meta)
   ((ips :initarg :ips :initform nil :type list :accessor domain-ips)
@@ -23,38 +22,39 @@
    (record-type :initarg :record-type :initform "" :type string :accessor domain-type)
    (zone :initarg :zone :initform "" :accessor doman-zone :type string)))
 
-
 (defclass host (meta)
-  ((hostname :initarg :hostname :type string :accessor doc-host :allocation :class)
-   (ip :initarg :ip :type string :accessor doc-ip :allocation :class)))
-
+  ((hostname :initarg :hostname :initform "" :type string :accessor doc-host)
+   (ip :initarg :ip :initform "" :type string :accessor doc-ip)))
 
 (defclass port (meta)
-  ((number :initarg :number :type integer :accessor doc-port :allocation :class)
-   (services :initarg :services :type list :accessor doc-services :allocation :class)))
-
+  ((number :initarg :number :initform 0 :type integer :accessor doc-port)
+   (services :initarg :services :initform nil :type list :accessor doc-services)))
 
 (defclass finding (meta)
-  ((id :initarg :id :type string :initform "" :accessor finding-id :allocation :class)
-   (doc-id :initarg :host :type string :initform "" :accessor finding-doc :allocation :class)
-   (finding-type :initarg :finding-type :type string :initform "Bug" :accessor finding-finding-type :allocation :class)
-   (data :initarg :data :type string :initform "" :accessor finding-data)))
-
-
+  ((id :initarg :finding-id :initform "" :type string :accessor finding-id)
+   ;; Keep :HOST as a compatibility initarg, but do not shadow META's DOC-ID.
+   (finding-document-id :initarg :document-id :initarg :host :initform ""
+                        :type string :accessor finding-doc)
+   (finding-type :initarg :finding-type :initform "Bug" :type string
+                 :accessor finding-finding-type)
+   (data :initarg :data :initform "" :type string :accessor finding-data)))
 
 (defclass url (meta)
-  ((scheme :initarg :scheme :type string :reader url-scheme :allocation :class)
-   (host :initarg :host :type string :reader url-host :allocation :class)
-   (port :initarg :port :type integer :reader url-port :allocation :class)
-   (path :initarg :path :type string :reader url-path :allocation :class)
-   (query :initarg :query :type string :reader url-query :allocation :class)))
-
+  ((scheme :initarg :scheme :initform "http" :type string :accessor url-scheme)
+   (host :initarg :host :initform "" :type string :accessor url-host)
+   (port :initarg :port :initform 80 :type integer :accessor url-port)
+   (path :initarg :path :initform "" :type string :accessor url-path)
+   (query :initarg :query :initform "" :type string :accessor url-query)))
 
 (defclass cert (meta)
-  ((not-before :initarg :not-before :type integer :accessor cert-not-before :initform (unix-now) :allocation :class)
-   (not-after :initarg :not-after :type integer :accessor cert-not-after :initform (unix-now) :allocation :class)
-   (common-name :initarg :common-name :type string :accessor cert-common-name :initform "" :allocation :class)
-   (org-unit-name :initarg :org-unit-name :type string :accessor cert-org-unit-name :initform "" :allocation :class)
-   (locality :initarg :locality :type string :accessor cert-locality :initform "" :allocation :class)
-   (country-name :initarg :country :type string :accessor cert-country :initform "" :allocation :class)
-   (province :initarg :province :type string :accessor cert-province :initform "" :allocation :class)))
+  ((not-before :initarg :not-before :type integer :accessor cert-not-before
+               :initform (unix-now))
+   (not-after :initarg :not-after :type integer :accessor cert-not-after
+              :initform (unix-now))
+   (common-name :initarg :common-name :type string :accessor cert-common-name
+                :initform "")
+   (org-unit-name :initarg :org-unit-name :type string :accessor cert-org-unit-name
+                  :initform "")
+   (locality :initarg :locality :type string :accessor cert-locality :initform "")
+   (country-name :initarg :country :type string :accessor cert-country :initform "")
+   (province :initarg :province :type string :accessor cert-province :initform "")))

--- a/source/hackmode-core/objects.lisp
+++ b/source/hackmode-core/objects.lisp
@@ -31,7 +31,7 @@
    (services :initarg :services :initform nil :type list :accessor doc-services)))
 
 (defclass finding (meta)
-  ((id :initarg :finding-id :initform "" :type string :accessor finding-id)
+  ((id :initarg :id :initarg :finding-id :initform "" :type string :accessor finding-id)
    ;; Keep :HOST as a compatibility initarg, but do not shadow META's DOC-ID.
    (finding-document-id :initarg :document-id :initarg :host :initform ""
                         :type string :accessor finding-doc)

--- a/source/hackmode-core/operations.lisp
+++ b/source/hackmode-core/operations.lisp
@@ -1,47 +1,94 @@
 (in-package :hackmode)
 
-;;;  This file is ment to handle the handling of operation, which put simply is just a current working directory
-;;;  This is the common pattern when doing hacking i find myself in
-(defvar *operations-database* (tek9:new-database "operations" :path hackmode-operations-database))
+(defvar *operations-database*
+  (tek9:new-database "operations" :path hackmode-operations-database))
 
-(nhooks:add-hook *startup-hook* #'(lambda ()
-                                    (tek9:open-database *operations-database*)))
-
-
+(nhooks:add-hook *startup-hook*
+                 (lambda ()
+                   (ensure-operations-database-open)))
 
 (defclass operation (meta)
-  ((working-dir :initarg :dir :accessor operation-dir :initform (uiop/os:getcwd) :allocation :class)
-   (name :initarg :name :accessor operation-name :initform "" :allocation :class)
-   (description :initarg :description :accessor operation-description :initform "" :allocation :class)))
+  ((working-dir :initarg :dir :accessor operation-dir
+                :initform (namestring (uiop/os:getcwd)) :type string)
+   (name :initarg :name :accessor operation-name :initform "" :type string)
+   (description :initarg :description :accessor operation-description
+                :initform "" :type string)))
 
-(defvar *current-operation* nil "The current operation")
+(conspack:defencoding operation
+  doc-id tags dtype date-added date-updated operation tool
+  working-dir name description)
 
+(defvar *current-operation* nil "The current Hackmode operation.")
 
-(defun new-operation (name &optional (path (uiop:merge-pathnames* ".hackmode/" (uiop:getcwd)) ) (description "Hackmode operation"))
-  (let ((doc (make-instance 'operation :name name :description description :dir path :dtype "operation")))
-    (tek9:put* *operations-database* doc :id  (operation-name doc))))
+(defun ensure-operations-database-open ()
+  "Open the operation registry if it is not already open."
+  (unless (tek9:db-is-open-p *operations-database*)
+    (tek9:open-database *operations-database*))
+  *operations-database*)
 
-;; TODO A function/helper should do this!
+(defun new-operation (name
+                      &optional
+                        (path (uiop:merge-pathnames* ".hackmode/" (uiop:getcwd)))
+                        (description "Hackmode operation"))
+  "Create and persist an operation named NAME."
+  (ensure-operations-database-open)
+  (let* ((dir (namestring (pathname path)))
+         (doc (make-instance 'operation
+                             :id name
+                             :name name
+                             :operation name
+                             :description description
+                             :dir dir
+                             :dtype "operation")))
+    (tek9:put* *operations-database* doc :id name)
+    doc))
 
-
-
-
-
-;; NOTE For others reading the source code of hackmode this is a good example
-;; On how to query tek9
 (defun select-operation (name)
-  "Selection query for tek9."
+  "Return the persisted operation named NAME, or NIL."
+  (ensure-operations-database-open)
   (tek9:fetch* *operations-database* name))
 
+(defun list-operations ()
+  "Return all persisted operations sorted by name."
+  (ensure-operations-database-open)
+  (let (operations)
+    (tek9:map-database
+     *operations-database*
+     :map-fn (lambda (key document)
+               (declare (ignore key))
+               (let ((value (tek9:doc-value document)))
+                 (when (typep value 'operation)
+                   (push value operations)))))
+    (sort operations #'string< :key #'operation-name)))
+
+(defun current-operation ()
+  "Return the active operation object, or NIL."
+  *current-operation*)
+
+(defun operation-status (&optional (operation *current-operation*))
+  "Return a stable plist describing OPERATION's current local state."
+  (when operation
+    (list :name (operation-name operation)
+          :description (operation-description operation)
+          :directory (operation-dir operation)
+          :database-open (and *db* (tek9:db-is-open-p *db*)))))
 
 (defun use-operation (name)
-  "Select a operation by name to be the current operation."
+  "Select NAME as the current operation and open its local Tek9 store."
   (let* ((op (select-operation name))
-         (dir (if op (operation-dir op) (error (format nil  "No Such Operation exist. Use (hackmode:new-operation \"~a\") to create one" name)))))
-    (setq *current-operation* op)
+         (dir (if op
+                  (operation-dir op)
+                  (error "No such operation ~s. Create it with NEW-OPERATION first." name))))
+    (setf *current-operation* op)
     (uiop:ensure-all-directories-exist (list dir))
-    (when *db*
+    (when (and *db* (tek9:db-is-open-p *db*))
       (tek9:close-database *db*))
-    (setq *db* (tek9:new-database name :path (uiop:merge-pathnames* (uiop:parse-unix-namestring dir) (format nil ".hackmode/"))))
+    (setf *db*
+          (tek9:new-database
+           name
+           :path (uiop:merge-pathnames*
+                  (uiop:parse-unix-namestring dir)
+                  ".hackmode/")))
     (tek9:open-database *db*)
-    (uiop:chdir dir)))
+    (uiop:chdir dir)
+    op))

--- a/source/hackmode-core/operations.lisp
+++ b/source/hackmode-core/operations.lisp
@@ -28,11 +28,14 @@
 
 (defun new-operation (name
                       &optional
-                        (path (uiop:merge-pathnames* ".hackmode/" (uiop:getcwd)))
+                        (path (uiop:getcwd))
                         (description "Hackmode operation"))
-  "Create and persist an operation named NAME."
+  "Create and persist an operation named NAME.
+
+PATH is the operation workspace root.  Its local Tek9 store lives under
+PATH/.hackmode rather than making the workspace itself a hidden database dir."
   (ensure-operations-database-open)
-  (let* ((dir (namestring (pathname path)))
+  (let* ((dir (namestring (uiop:ensure-directory-pathname (pathname path))))
          (doc (make-instance 'operation
                              :id name
                              :name name
@@ -68,10 +71,18 @@
 (defun operation-status (&optional (operation *current-operation*))
   "Return a stable plist describing OPERATION's current local state."
   (when operation
-    (list :name (operation-name operation)
-          :description (operation-description operation)
-          :directory (operation-dir operation)
-          :database-open (and *db* (tek9:db-is-open-p *db*)))))
+    (let ((active-p (eq operation *current-operation*)))
+      (list :name (operation-name operation)
+            :description (operation-description operation)
+            :directory (operation-dir operation)
+            :active active-p
+            :database-open (and active-p *db* (tek9:db-is-open-p *db*))))))
+
+(defun operation-store-path (operation)
+  "Return OPERATION's local Tek9 store directory."
+  (uiop:merge-pathnames* ".hackmode/"
+                         (uiop:ensure-directory-pathname
+                          (pathname (operation-dir operation)))))
 
 (defun use-operation (name)
   "Select NAME as the current operation and open its local Tek9 store."
@@ -84,11 +95,7 @@
     (when (and *db* (tek9:db-is-open-p *db*))
       (tek9:close-database *db*))
     (setf *db*
-          (tek9:new-database
-           name
-           :path (uiop:merge-pathnames*
-                  (uiop:parse-unix-namestring dir)
-                  ".hackmode/")))
+          (tek9:new-database name :path (operation-store-path op)))
     (tek9:open-database *db*)
     (uiop:chdir dir)
     op))

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -1,7 +1,6 @@
 (uiop:define-package :hackmode
-
   (:import-from :serapeum :dict :@)
-  (:documentation "Core hackmode internalls.")
+  (:documentation "Core Hackmode runtime and compatibility API.")
   (:export
    :EXPLOIT-OPTION-DOCUMENTATION
    :EXPLOIT-NAME
@@ -41,6 +40,7 @@
    :port
    :finding
    :url
+   :cert
    :*api-common-patterns*
    :find-api
    :find-apis
@@ -50,9 +50,12 @@
    :exploit
    :operation
    :operation-dir
+   :operation-name
+   :operation-description
    :domain
    :domain-name
    :domain-type
+   :domain-ips
    :doman-zone
    :use-operation
    :parse-url
@@ -66,9 +69,14 @@
    :*domain-hook*
    :flatten
    :*current-operation*
+   :current-operation
    :new-operation
    :select-operation
+   :list-operations
+   :operation-status
+   :ensure-operations-database-open
    :make-command
+   :doc-id
    :doc-tags
    :doc-type
    :doc-operation
@@ -90,7 +98,23 @@
    :cert-org-unit-name
    :cert-locality
    :cert-country
-   :cert-province))
-
+   :cert-province
+   ;; Asset protocol
+   :asset-event
+   :asset-event-event-type
+   :asset-event-asset
+   :asset-event-operation
+   :asset-event-timestamp
+   :*asset-event-hook*
+   :asset-kind
+   :normalize-asset
+   :asset-canonical-value
+   :asset-deterministic-id
+   :asset-requires-parent-p
+   :store-asset
+   :discover-asset
+   :query-assets
+   :publish-asset-event
+   :subscribe-asset-events))
 
 (in-package :hackmode)

--- a/source/hackmode-core/tests/core-state.lisp
+++ b/source/hackmode-core/tests/core-state.lisp
@@ -7,6 +7,15 @@
   (assert (equal expected actual) ()
           "Expected ~a to be ~s, got ~s" label expected actual))
 
+(defun fresh-test-path (prefix)
+  (merge-pathnames
+   (format nil "~a-~a/" prefix (tek9:make-key-id))
+   (uiop:temporary-directory)))
+
+(defun remove-test-path (path)
+  (ignore-errors
+    (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)))
+
 (defun run-instance-state-test ()
   (let ((left (make-instance 'hackmode:domain
                              :record "left.example"
@@ -22,10 +31,31 @@
     (assert-equal "a" (hackmode:operation-name op-a) "operation A")
     (assert-equal "b" (hackmode:operation-name op-b) "operation B")))
 
+(defun run-operation-registry-test ()
+  (let* ((root (fresh-test-path "hackmode-operations"))
+         (workspace (fresh-test-path "hackmode-workspace"))
+         (hackmode:*operations-database*
+           (tek9:new-database "operations" :path root)))
+    (unwind-protect
+         (progn
+           (hackmode:new-operation "alpha" workspace "test operation")
+           (assert-equal "alpha"
+                         (hackmode:operation-name
+                          (hackmode:select-operation "alpha"))
+                         "selected operation")
+           (tek9:close-database hackmode:*operations-database*)
+           (hackmode:ensure-operations-database-open)
+           (assert-equal '("alpha")
+                         (mapcar #'hackmode:operation-name
+                                 (hackmode:list-operations))
+                         "reopened operation registry"))
+      (when (tek9:db-is-open-p hackmode:*operations-database*)
+        (tek9:close-database hackmode:*operations-database*))
+      (remove-test-path root)
+      (remove-test-path workspace))))
+
 (defun run-asset-lifecycle-test ()
-  (let* ((root (merge-pathnames
-                (format nil "hackmode-test-~a/" (tek9:make-key-id))
-                (uiop:temporary-directory)))
+  (let* ((root (fresh-test-path "hackmode-assets"))
          (db (tek9:new-database "assets" :path root))
          (events 0)
          (hackmode:*asset-event-hook*
@@ -37,6 +67,10 @@
             (lambda (event)
               (assert (eq :discovered
                           (hackmode:asset-event-event-type event)))
+              (let* ((asset (hackmode:asset-event-asset event))
+                     (persisted (tek9:fetch* db (hackmode:doc-id asset))))
+                (assert persisted ()
+                        "Asset event fired before local persistence."))
               (incf events)))
            (let ((first (make-instance 'hackmode:domain
                                        :record "Example.COM."
@@ -59,11 +93,11 @@
                                    :type :domain))))))
       (when (tek9:db-is-open-p db)
         (tek9:close-database db))
-      (ignore-errors
-        (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))))
+      (remove-test-path root))))
 
 (defun run-tests ()
   (run-instance-state-test)
+  (run-operation-registry-test)
   (run-asset-lifecycle-test)
   (format t "Hackmode core tests passed.~%")
   t)

--- a/source/hackmode-core/tests/core-state.lisp
+++ b/source/hackmode-core/tests/core-state.lisp
@@ -1,0 +1,69 @@
+(defpackage :hackmode-tests
+  (:use :cl))
+
+(in-package :hackmode-tests)
+
+(defun assert-equal (expected actual &optional (label "values"))
+  (assert (equal expected actual) ()
+          "Expected ~a to be ~s, got ~s" label expected actual))
+
+(defun run-instance-state-test ()
+  (let ((left (make-instance 'hackmode:domain
+                             :record "left.example"
+                             :tags '("left")))
+        (right (make-instance 'hackmode:domain
+                              :record "right.example"
+                              :tags '("right")))
+        (op-a (make-instance 'hackmode:operation :name "a" :dir "/tmp/a/"))
+        (op-b (make-instance 'hackmode:operation :name "b" :dir "/tmp/b/")))
+    (assert (not (string= (hackmode:doc-id left) (hackmode:doc-id right))))
+    (setf (hackmode:doc-tags left) '("changed"))
+    (assert-equal '("right") (hackmode:doc-tags right) "instance-local tags")
+    (assert-equal "a" (hackmode:operation-name op-a) "operation A")
+    (assert-equal "b" (hackmode:operation-name op-b) "operation B")))
+
+(defun run-asset-lifecycle-test ()
+  (let* ((root (merge-pathnames
+                (format nil "hackmode-test-~a/" (tek9:make-key-id))
+                (uiop:temporary-directory)))
+         (db (tek9:new-database "assets" :path root))
+         (events 0)
+         (hackmode:*asset-event-hook*
+           (make-instance 'nhooks:hook-void :handlers nil)))
+    (unwind-protect
+         (progn
+           (tek9:open-database db)
+           (hackmode:subscribe-asset-events
+            (lambda (event)
+              (assert (eq :discovered
+                          (hackmode:asset-event-event-type event)))
+              (incf events)))
+           (let ((first (make-instance 'hackmode:domain
+                                       :record "Example.COM."
+                                       :record-type "a"))
+                 (second (make-instance 'hackmode:domain
+                                        :record "example.com"
+                                        :record-type "A")))
+             (multiple-value-bind (stored created-p)
+                 (hackmode:discover-asset first :database db)
+               (assert created-p)
+               (assert-equal "example.com" (hackmode:domain-name stored)
+                             "normalized domain"))
+             (multiple-value-bind (stored created-p)
+                 (hackmode:discover-asset second :database db)
+               (declare (ignore stored))
+               (assert (not created-p)))
+             (assert (= events 1))
+             (assert (= 1 (length (hackmode:query-assets
+                                   :database db
+                                   :type :domain))))))
+      (when (tek9:db-is-open-p db)
+        (tek9:close-database db))
+      (ignore-errors
+        (uiop:delete-directory-tree root :validate t :if-does-not-exist :ignore)))))
+
+(defun run-tests ()
+  (run-instance-state-test)
+  (run-asset-lifecycle-test)
+  (format t "Hackmode core tests passed.~%")
+  t)


### PR DESCRIPTION
## Summary
Implements the first dependency-critical slice of #6 on top of the merged monorepo.

### Operation state
- fixes CLOS `:allocation :class` misuse so operation/asset fields are instance-local
- adds `list-operations`, `current-operation`, `operation-status`, and registry-open helpers
- makes an operation path the workspace root and puts its local Tek9 store under `<workspace>/.hackmode/`
- adds operation Conspack encoding and reopen regression coverage

### Asset protocol
- adds generic `normalize-asset`, `asset-kind`, canonical-value, deterministic-id, store/discover/query APIs
- reuses `starintel:digest-id` rather than inventing a second digest convention
- adds one generic persisted `asset-event` hook instead of per-type callback machinery
- guarantees `discover-asset` persists locally before publishing `:discovered`
- dedupes repeated normalized discoveries by deterministic ID
- requires parent identity for ambiguous child assets such as ports

### Storage
- keeps Tek9 as the local operation store
- adds explicit Conspack encodings for the existing compatibility objects
- fixes `put-doc`/`put-docs` to honor database names and reject missing stores

### Tests added
`hackmode-tests` now contains regression coverage for:
- instance-local CLOS state
- operation create/select/registry close+reopen
- domain normalize -> deterministic dedupe -> local persistence -> event
- persisted-row existence before event publication

### Verification executed
The configured `monorepo` GitHub Actions workflow passed on the current head. It checks the monorepo layout, generated-artifact policy, Emacs Lisp syntax, absence of class-allocated core state, and presence/wiring of the StarIntel digest + ASDF test system.

The new Common Lisp runtime tests are **not yet executable from a clean CI checkout** because Hackmode's full external Lisp dependency graph is not pinned by the repository. #9 tracks that testing blocker; this PR does not claim those runtime tests have executed.

## Scope note
This does **not** yet replace the migrated Emacs BBRF/file-state compatibility layer, nor does it implement CouchDB/outbox synchronization. Those remain downstream of this canonical runtime boundary.

Refs #6
Depends on completed #4. Blocks #3 and the outbox/shell/Emacs convergence slices.