### PR TITLE
Curate hackmode-scripts into the monorepo

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -40,6 +40,17 @@ jobs:
             exit 1
           fi
 
+      - name: Reject executable legacy migration sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          bad="$(git ls-files -s tools/legacy 2>/dev/null | awk '$1 == "100755" {print $4}' || true)"
+          if [[ -n "$bad" ]]; then
+            echo 'Legacy migration sources must remain non-executable:' >&2
+            echo "$bad" >&2
+            exit 1
+          fi
+
       - name: Reject unexpectedly large tracked files
         shell: bash
         run: |

--- a/docs/migration/hackmode-scripts.org
+++ b/docs/migration/hackmode-scripts.org
@@ -1,0 +1,55 @@
+#+title: hackmode-scripts Migration Inventory
+
+* Source
+Historical source repository: =lost-rob0t/hackmode-scripts=.
+
+This migration is intentionally curated. The old repository mixed useful recon ideas with shell glue, generated Lisp artifacts, huge copied binaries, incomplete Prolog experiments, and functionality that does not belong in the current recon security boundary.
+
+* Migrated as quarantined reference source
+The following source is retained under =tools/legacy/recon/= with executable bits removed:
+- =alt.py= — domain word/permutation logic
+- =bbot.sh= — BBOT provider orchestration
+- =dex.sh= — fan-out recon workflow prototype; useful mainly as actor/event decomposition input
+- =dns-up.sh= — massdns resolution/filtering
+- =dork.sh= — domain-scoped public search wrapper
+- =parse-nmap.py= — Nmap XML conversion prototype
+- =photon-scan.sh= — crawler wrapper
+
+These are *not runtime dependencies*. Ports should use typed assets and the canonical Hackmode operation store.
+
+* Intentionally not migrated
+** Generated/compiled artifacts
+Rejected completely:
+- =source/rules/main.fasl=
+- =source/rules/ralp.fasl=
+- =source/rules/ralp= and duplicate copied =ralp= binaries under nested local-bin trees
+
+The old repo contains binaries tens of MiB in size. The monorepo CI rejects this artifact class.
+
+** Credential/cracking helpers
+Not migrated into the recon architecture:
+- =source/recon/git-dorks.sh= — specifically searches public code for passwords, private keys, tokens, credentials and similar secrets
+- =source/cracking/combo.awk= and cracking-oriented helpers
+
+These are outside this migration's stated recon boundary and should only be reconsidered under a separate explicit design/safety review.
+
+** BBRF state wrappers
+=source/bbrf/resolve-all.sh= is not migrated. BBRF is compatibility input, not canonical state; issue #6/#3 replace direct BBRF state with Hackmode's typed asset protocol and local store.
+
+** Rules prototype
+The old =source/rules/= Prolog/Lisp material is not copied into the active tree in this slice. Inspection found malformed/incomplete experiments mixed with generated artifacts. Any useful expert-system knowledge should be re-expressed against StarIntel/Hackmode typed facts rather than preserved as an opaque rule dump.
+
+* Port order
+1. DNS/massdns provider -> DomainSupervisor
+2. Nmap import -> HostSupervisor parser adapter
+3. BBOT provider -> provider actor emitting typed assets
+4. Photon/URL crawling -> WebSupervisor
+5. domain word/permutation generator -> DomainSupervisor
+6. domain-scoped search wrapper -> ProviderSupervisor
+7. decompose =dex.sh= ideas into asset events/recon subscriptions instead of a shell FIFO manager
+
+* Definition of done for deleting/archive-only use of the old repo
+- every retained source file is present here or intentionally rejected above
+- no generated binaries/FASLs enter the monorepo
+- no active code imports the old repository
+- follow-up provider ports refer to these monorepo paths, not the old repo

--- a/tools/legacy/recon/README.org
+++ b/tools/legacy/recon/README.org
@@ -1,0 +1,25 @@
+#+title: Legacy Recon Migration Sources
+
+These files were migrated from =lost-rob0t/hackmode-scripts= as *non-executable reference source*.
+
+They are not installed, loaded, or called by Hackmode. Their purpose is to preserve useful behavior while the monorepo ports it into typed Common Lisp providers/actors.
+
+Do not build new workflows on these scripts.
+
+* Port map
+| File | Useful behavior | Target |
+|-
+| alt.py | word/stem variations for domain permutations | DomainSupervisor / domain permutation provider |
+| bbot.sh | BBOT subdomain/cloud/web wrapper | provider actor returning typed assets |
+| dex.sh | prototype fan-out recon workflow and FIFO queue ideas | ReconSupervisor + asset events; do not port shell queue bugs literally |
+| dns-up.sh | massdns resolution/filtering | DNS actor/provider |
+| dork.sh | domain-scoped public search queries | search provider actor |
+| parse-nmap.py | Nmap XML parsing | typed Nmap import/parser adapter |
+| photon-scan.sh | crawler wrapper | WebSupervisor crawler provider |
+
+* Rules
+- Files in this directory are mode =100644= deliberately: legacy source must not silently become executable runtime code.
+- Any port must emit typed assets through =discover-asset= rather than write ad-hoc findings files.
+- Provider failures must be isolated and observable.
+- Secrets/credentials must not be exposed to frontend clients.
+- Credential-hunting helpers from the old scripts repository were intentionally not migrated into the Hackmode recon architecture.

--- a/tools/legacy/recon/alt.py
+++ b/tools/legacy/recon/alt.py
@@ -1,0 +1,46 @@
+import sys
+import argparse
+from nltk.stem import PorterStemmer
+import fileinput
+
+
+def generate_variations_with_stem(word):
+    variations = set()
+    # Add the original word
+    variations.add(word)
+    # Get the stem using Porter Stemmer
+    stemmer = PorterStemmer()
+    stem = stemmer.stem(word)
+    variations.add(stem)
+    if len(word) > 3:
+        for i in range(1, len(word)):
+            variations.add(word[:i])
+            variations.add(word[i:])
+
+    return variations
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate variations for a word.")
+    parser.add_argument(
+        "word", nargs="?", help="Word for which variations need to be generated"
+    )
+    args = parser.parse_args()
+
+    if not sys.stdin.isatty():
+        # Read from stdin if data is being piped
+        for line in fileinput.input():
+            for word in generate_variations_with_stem(line.rstrip()):
+                print(word)
+    elif args.word:
+        # Use the CLI argument if provided
+        word = args.word
+        variations = set()
+        # Generate variations for the whole word
+        variations.update(generate_variations_with_stem(word))
+        for word in variations:
+            print(word)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/legacy/recon/bbot.sh
+++ b/tools/legacy/recon/bbot.sh
@@ -1,0 +1,13 @@
+#!/bin/env sh
+
+# input url lis
+
+function crawl () {
+	now=$(date '+%Y-%m-%d')
+	base=$(basename $1)
+	dir="$PWD/scans/$now/bbot"
+	echo $dir
+	bbot --force -y -t $1 --blacklist blacklist.txt --name $1  -f subdomain-enum  cloud-enum web-basic   -m gowitness httpx   --output-module human csv json -o "$dir"
+}
+
+crawl $1

--- a/tools/legacy/recon/dex.sh
+++ b/tools/legacy/recon/dex.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env sh
+
+TARGETS="$1"
+cwd="$PWD"
+FINDINGS="$HACKMODE_PATH/findings"
+tmp="$cwd/.tmp"
+wd=$(dir-setup dex)
+MAX_WORKERS=$(nproc)
+BBTZ_PATH="/usr/local/bin/bbzt"
+RESOLVERS_FILE="$HOME/wordlists/resolvers/resolvers.txt"
+
+function create_queue() {
+    local fifo_name="$1"
+    if [ ! -p "$fifo_name" ]; then
+        mkfifo "$fifo_name"
+    fi
+}
+
+function enq() {
+    local fifo_name="$tmp/$1"
+    local item="$2"
+    echo "$item" >> "$fifo_name"
+}
+
+function spawn() {
+    local fifo_name="$tmp/$1"
+    local consumer_function="$2"
+    typeset -fx "$consumer_function"
+    cat "$fifo_name" | xargs -P "$MAX_WORKERS" -I {} bash "$consumer_function" {}
+}
+
+function send_log() {
+    while read data; do
+        local log_level="$3"
+        local source="$1"
+        local type="$2"
+        data=$(echo "[$source]|[$(date '+%s')]|[$local_level]|[[$data]]")
+        ntfy --title "New $type" --msg "$data" --tags "$type,$source" --topic "$HACKMODE_OP"
+    done
+}
+
+function get_config () {
+    echo "$HACKMODE_PATH/.config/targets"
+}
+
+function check_wildcard() {
+    while read domain; do
+    result=$(dig +short "*.${domain}")
+
+    if [ -n "$result" ]; then
+        return 0 # Wildcard DNS records found
+    else
+        echo "$domain"  # No wildcard DNS records found
+    fi
+    done
+}
+
+function send_alert() {
+    while read data; do
+        local source="$1"
+        local type="$2"
+        ntfy --title "New $type" --msg "$data" --tags "$type,$source" --topic "$HACKMODE_OP"
+    done
+}
+
+function bb_bbot() {
+    bbot -t "$1" --force -y -f safe -f subdomain-enum  cloud-enum web-basic -m httpx  -n bbot -o "$wd" --blacklist "$HACKMODE_PATH/.config/blacklist" | send_log
+    cat "$wd/subdomains.txt" | check_wildcard | grep -vfx "$HACKMODE_PATH/.config/blacklist" | anewer "$FINDINGS/subdomains.txt" | send_alert "bbot" "Domain" | send_log "DNS" ""
+    cat $wd/output.json | jq -r 'select(.type == "TECHNOLOGY") | .data.host + "," + .data.technology' | anewer $FINDINGS/tech.csv | send_alert "bbot" "Tech"
+    cat $wd/output.json | jq -r 'select(.type == "URL") | .data.host' | anewer $FINDINGS/urls.txt | send_alert "bbot" "Url"
+    cat $wd/output.json | jq -r 'select(.type == "FINDING") | .data.host + "," + .data.url + "," + .data.description'  | anewer $FINDINGS/bbot-findings.csv | send_alert "bbot" "Finding"
+    cat $wd/output.json | jq -r 'select(.type == "EMAIL_ADDRESS") | .data' | xargs -I {} echo "$1,{}" | anewer $FINDINGS/emails.csv | send_alert "bbot" "Email"
+    awk -F'\t' '{print $2}' $wd/wordcloud.tsv | anewer $FINDINGS/domain_wordlist.txt
+}
+
+function parse_katana() {
+    while read jdata; do
+        headers=$(jq -r '.response.headers' "$jdata")
+        server=$(jq -r '.server' "$headers")
+        cookies=$(jq -r '.set_cookie' "$headers")
+        url=$(jq -r '.request.endpoint' "$jdata")
+        echo "$url,$server,$cookies" | awk -F, -v OFS=',' '{for(i=1;i<=NF;i++) gsub(/"/, "\\\"", $i); print}' | anewer $FINDINGS/headers.csv
+        echo "$url" | anewer "$FINDINGS"/urls.txt
+    done
+}
+
+function spider() {
+    gau "$target" | anewer $FINDINGS/urls_archived.txt
+    cat $FINDINGS/urls_archived.txt | katana -j -d 5 -kf -jsl -jc -r "$RESOLVERS_FILE" | parse_katana | log
+}
+
+function dns() {
+    local target="$1"
+    subfinder -d "$target" -silent | check_wildcard | grep -vfx "$HACKMODE_PATH/.config/blacklist" | anewer $FINDINGS/subdomains.txt | sent_alert "subfinder" "Domain"
+    cut -d "." -f 1
+}
+
+function wordlists {
+    grep -E "$\.js" $FINDINGS/urls.txt | python3 $BBTZ/getjswords.py | anewer $FINDINGS/js_wordlists.txt
+    cat $FINDINGS/*wordlist.txt | sort -u all_wordlist.txt
+}
+
+function bb_full_recon () {
+    local target="$1"
+    bb_bbot "$target"
+    dns "$target"
+    spider "$target"
+}
+
+function door_kick {
+    local target = "$1"
+    bb_bbot "$target"
+    spider "$target"
+}
+
+if [ -z "$1" ]; then
+    $TARGETS=$(cat "$HACKMODE_PATH/.config/targets")
+fi
+
+if [ ! -d "$HACKMODE_PATH" ]; then
+  mkdir -p "$HACKMODE_PATH"
+fi
+
+if [ ! -d "$FINDINGS" ]; then
+    mkdir -p "$FINDINGS"
+fi

--- a/tools/legacy/recon/dns-up.sh
+++ b/tools/legacy/recon/dns-up.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+dir=$(dir-setup.sh "massdns")
+servers="$HOME/wordlists/resolvers/resolvers.txt"
+file_raw="$dir/massdns.json"
+alive=$dir/alive.txt
+echo "saying raw output to $file_raw"
+massdns -o J -r $servers  -w $file_raw  $1
+
+echo "saying alive domains to $alive"
+cat $file_raw  | jq -r '. | select(.status == "NOERROR") | .name | sub("\\.$";"")' > $alive

--- a/tools/legacy/recon/dork.sh
+++ b/tools/legacy/recon/dork.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env sh
+
+ctrl_c() {
+  echo "Ctrl-C received. Exiting gracefully..."
+  exit 0
+}
+
+trap ctrl_c SIGINT
+
+bulk() {
+    while read -r q; do
+        while read -r domain; do
+            echo "site:$domain AND $q"
+            DorXNG.py -q "site:$domain AND $q" -L 2 -d dorks.db
+        done < "$1"
+    done < "$2"
+}
+
+domain_spray() {
+    while read -r domain; do
+        echo "site:$domain AND $2"
+        DorXNG.py -q "site:"$domain" AND $2" -L 2 -d dorks.db
+    done < $1
+}
+
+case "$1" in
+    "-b" | "--bulk")
+           if [ $# -lt 3 ]; then
+               echo "usage: dork.sh --bulk/-b domains.txt dorks.txt"
+               exit 1
+           fi
+        bulk $2 $3
+        ;;
+    "-s" | "--spray")
+        if [ $# -lt 3 ]; then
+               echo "usage: dork.sh --spray/-s domains.txt <query>"
+               exit 1
+           fi
+        domain_spray $2 $3;;
+    *)
+        echo "Invalid usage: use -b for bulk or -s for spray";;
+esac

--- a/tools/legacy/recon/parse-nmap.py
+++ b/tools/legacy/recon/parse-nmap.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import json
+import xmltodict
+import argparse
+
+"""
+Simple xml to json, fuck xml.
+"""
+def parse(xml):
+    with open(xml, "r") as xmlfile:
+        xml_content = xmlfile.read()
+        jsondata = xmltodict.parse(xml_content)
+        return jsondata
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="input nmap scan xml")
+    parser.add_argument("output", help="output json")
+    parser.add_argument("--pretty", type=bool, help="pretty print?", default=False)
+    args = parser.parse_args()
+    with open(args.output, "w") as outfile:
+        jsondata = parse(args.input)
+        if args.pretty:
+            outfile.write(json.dumps(jsondata, indent=4, sort_keys=True))
+        else:
+            outfile.write(json.dumps(jsondata))
+if __name__ == '__main__':
+    main()

--- a/tools/legacy/recon/photon-scan.sh
+++ b/tools/legacy/recon/photon-scan.sh
@@ -1,0 +1,22 @@
+#!/bin/env sh
+
+# Input URL or file list
+input=$1
+
+function crawl() {
+    dir=$(dir-setup.sh "photon")
+    # Pass any extra arguments to photon by using "$@"
+    full_dir="$dir"/"$(echo $1 | sed 's/\//-/'g | sed 's/--//g' )"
+    mkdir -p $full_dir
+    photon --wayback -l 3 -u "$1" -t 10 -e json  -o "$full_dir" ${@:2}
+}
+
+if [ -f "$input" ]; then
+    # If the input is a file, read each line and crawl
+    while read -r line; do
+        crawl "$line" "${@:2}"
+    done < "$input"
+else
+    # If the input is a single URL, crawl it
+    crawl "$input" "${@:2}"
+fi


### PR DESCRIPTION
## Summary
Completes the source-curation portion of #5 without importing generated junk or turning legacy shell glue into runtime architecture.

### Migrated as non-executable reference source
Under `tools/legacy/recon/`:
- `alt.py`
- `bbot.sh`
- `dex.sh`
- `dns-up.sh`
- `dork.sh`
- `parse-nmap.py`
- `photon-scan.sh`

Each has an explicit actor/provider port target in `tools/legacy/recon/README.org` and `docs/migration/hackmode-scripts.org`.

### Intentionally rejected
- generated `ralp` binaries and FASLs
- credential-hunting `git-dorks.sh`
- cracking helpers
- direct BBRF state wrappers
- malformed/incomplete rules prototypes mixed with generated artifacts

### Safety / architecture
Legacy files are committed mode `100644`, are not installed or invoked, and CI rejects executable files under `tools/legacy/`. Future ports must emit typed assets through the canonical Hackmode operation/asset protocol rather than recreate file/FIFO state.

## Verification
- no generated binary/FASL artifacts added
- no file under `tools/legacy` is executable
- migration manifest records retained and rejected material
- existing monorepo hygiene/Emacs checks remain enabled

Closes #5.