### PR TITLE
Run Common Lisp core regression tests in clean CI

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,0 +1,74 @@
+name: core
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: common-lisp-core
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Hackmode
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Checkout pinned Tek9
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: lost-rob0t/tek9
+          ref: 6ff2e40a6f7e3a5eadafef94c2779c74566b7fd7
+          path: deps/tek9-ci
+          fetch-depth: 1
+
+      - name: Checkout pinned StarIntel Common Lisp schema
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: lost-rob0t/star-cl
+          ref: b8dfbe2f9f56065ace8c3313b92ca748a115cdfa
+          path: deps/star-cl-ci
+          fetch-depth: 1
+
+      - name: Install native dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            sbcl \
+            liblmdb-dev \
+            libffi-dev \
+            libssl-dev \
+            curl
+
+      - name: Install Quicklisp
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --retry 5 --retry-all-errors -fsSLo "$RUNNER_TEMP/quicklisp.lisp" \
+            https://beta.quicklisp.org/quicklisp.lisp
+          sbcl --non-interactive \
+            --load "$RUNNER_TEMP/quicklisp.lisp" \
+            --eval '(quicklisp-quickstart:install :path (merge-pathnames "quicklisp/" (user-homedir-pathname)))'
+
+      - name: Load Hackmode and run ASDF tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          sbcl --non-interactive \
+            --load "$HOME/quicklisp/setup.lisp" \
+            --eval '(asdf:load-asd (truename "deps/tek9-ci/src/tek9.asd"))' \
+            --eval '(asdf:load-asd (truename "deps/star-cl-ci/src/starintel.asd"))' \
+            --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode.asd"))' \
+            --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode-tests.asd"))' \
+            --eval '(ql:quickload :hackmode-tests)' \
+            --eval '(asdf:test-system :hackmode)'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -38,6 +38,18 @@ jobs:
           path: deps/star-cl-ci
           fetch-depth: 1
 
+      - name: Checkout pinned cms-ulid
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --filter=blob:none --no-checkout \
+            https://gitlab.com/colinstrickland/cms-ulid.git \
+            deps/cms-ulid-ci
+          git -C deps/cms-ulid-ci fetch --depth=1 origin \
+            fff84302dee5db42fb90aafd834af3ffbfd6c2bb
+          git -C deps/cms-ulid-ci checkout --detach \
+            fff84302dee5db42fb90aafd834af3ffbfd6c2bb
+
       - name: Install native dependencies
         shell: bash
         run: |
@@ -66,6 +78,7 @@ jobs:
           set -euo pipefail
           sbcl --non-interactive \
             --load "$HOME/quicklisp/setup.lisp" \
+            --eval '(push (truename "deps/cms-ulid-ci/") asdf:*central-registry*)' \
             --eval '(asdf:load-asd (truename "deps/tek9-ci/src/tek9.asd"))' \
             --eval '(asdf:load-asd (truename "deps/star-cl-ci/src/starintel.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode.asd"))' \

--- a/source/hackmode-core/assets.lisp
+++ b/source/hackmode-core/assets.lisp
@@ -7,7 +7,7 @@
   timestamp)
 
 (defvar *asset-event-hook*
-  (make-instance 'nhooks:hook-void :handlers nil)
+  (make-instance 'nhooks:hook-any :handlers nil)
   "Generic persisted-asset event hook. Handlers receive one ASSET-EVENT.")
 
 (defgeneric asset-kind (asset)

--- a/source/hackmode-core/settings.lisp
+++ b/source/hackmode-core/settings.lisp
@@ -1,58 +1,84 @@
-;;;;  This file is ment to be a user facing config options that is ment to be changed,
-;;;;  although everything can be, just these are explitit options
+;;;; User-facing Hackmode configuration.
 (in-package :hackmode)
 
+(defvar config-dir
+  (nfiles:expand (make-instance 'nfiles:config-file :base-path #p"hackmode/"))
+  "Path to user configuration.")
 
-(defvar config-dir (nfiles:expand (make-instance 'nfiles:config-file :base-path #p"hackmode/")) "A Path to user configuration")
+(defvar hackmode-init-file
+  (nfiles:expand
+   (make-instance 'nfiles:config-file
+                  :base-path (uiop:merge-pathnames* config-dir #p"init.lisp")))
+  "Path to the Hackmode init file. Defaults to ~/.config/hackmode/init.lisp.")
 
-(defvar hackmode-init-file (nfiles:expand (make-instance 'nfiles:config-file :base-path (uiop:merge-pathnames* config-dir #p"init.lisp"))) "The path to the init file for hackmode. Defaults to ~/.config/hackmode/init.lisp")
+(defvar data-dir
+  (nfiles:expand (make-instance 'nfiles:data-file :base-path #p"hackmode/"))
+  "Local Hackmode data path. Defaults to ~/.local/share/hackmode.")
 
-(defvar data-dir (nfiles:expand (make-instance 'nfiles:data-file :base-path #p"hackmode/")) "The local data path, defaults to ~/.local/share/hackmode")
+(defvar hackmode-operations-database
+  (nfiles:expand
+   (make-instance 'nfiles:data-file
+                  :base-path (uiop:merge-pathnames* ".db/" data-dir)))
+  "Path to the database that maintains operation workspace records.")
 
-(defvar hackmode-operations-database (nfiles:expand (make-instance 'nfiles:data-file :base-path (uiop:merge-pathnames* ".db/" data-dir ))) "The Path to database file that maintains paths to operations.")
+(defvar RHOST nil "Target host address for a payload.")
+(defvar LHOST nil "Local listen address for a payload.")
+(defvar payloads nil "List of payloads.")
 
-(defvar RHOST nil "The target host address for a payload")
+(defvar wordlist-dir
+  (nfiles:expand
+   (make-instance 'nfiles:data-file
+                  :base-path (uiop:merge-pathnames* "wordlists/" data-dir)))
+  "User wordlist directory.")
 
-(defvar LHOST nil "The target Listen Address for payload")
+(defvar wordlist-alist nil "Alist of tasks/tools to default wordlists.")
+(defvar wordlist nil "Current wordlist; has highest priority.")
+(defvar target-platform nil "Current target platform operating system.")
 
-(defvar payloads nil "A List of payloads.")
+(defvar socks5-proxy-list nil
+  "SOCKS5 proxy addresses in socks5://ip:port form.")
+(defvar http-proxy-list nil
+  "HTTP proxy addresses in http://ip:port form.")
 
-(defvar wordlist-dir (nfiles:expand (make-instance 'nfiles:data-file :base-path (uiop:merge-pathnames* "wordlists/" data-dir))) "The Path to user directory of wordlists, defaults to data-dir/wordlists/")
+(defvar exploits-dir
+  (nfiles:expand
+   (make-instance 'nfiles:data-file
+                  :base-path (uiop:merge-pathnames* "exploits/" data-dir)))
+  "Path to the exploit directory.")
 
-(defvar wordlist-alist nil "An Alist of tasks/tools to default wordlists to be used.")
+(defvar exploits-dependency-dir
+  (nfiles:expand
+   (make-instance 'nfiles:data-file
+                  :base-path (uiop:merge-pathnames* "exploits/" data-dir)))
+  "Path to exploit dependencies.")
 
-(defvar wordlist nil "The current wordlist to use, it has the highest priority")
+(defvar history-dir
+  (nfiles:expand
+   (make-instance 'nfiles:data-file
+                  :base-path (uiop:merge-pathnames* data-dir "history.lisp")))
+  "History file path.")
 
-(defvar target-platform nil "The target platform Operating system.")
+(defvar prompt "HACK$> " "Prompt used for interactive command input.")
 
-;; NOTE Platforms are represented as a symbol
+(defvar dependency-dir
+  (nfiles:expand
+   (make-instance 'nfiles:data-file
+                  :base-path (uiop:merge-pathnames* "deps/" data-dir)))
+  "Path where tool dependencies are downloaded.")
 
-;; TODO Use a scheme://ip:port proxy system
-(defvar socks5-proxy-list nil "List of socks5 proxy addresses. Must be in the format of socks5://ip:port")
+;; Hook contracts matter: HOOK-VOID is only for callbacks that take no
+;; arguments. Finding/domain handlers receive the discovered object, so these
+;; must be HOOK-ANY.
+(defvar *startup-hook*
+  (make-instance 'nhooks:hook-void :handlers nil)
+  "Hook run when Hackmode starts. Handlers take no arguments.")
 
-(defvar http-proxy-list nil "List of http proxy addresses. Must be in the format of http://ip:port")
+(defvar *finding-hook*
+  (make-instance 'nhooks:hook-any :handlers nil)
+  "Compatibility hook run with a discovered finding object.")
 
-(defvar exploits-dir (nfiles:expand (make-instance 'nfiles:data-file :base-path (uiop:merge-pathnames* "exploits/" data-dir))) "Path to exploit dir where exploits are stored.")
+(defvar *domain-hook*
+  (make-instance 'nhooks:hook-any :handlers nil)
+  "Compatibility hook run with a discovered domain object.")
 
-(defvar exploits-dependency-dir (nfiles:expand (make-instance 'nfiles:data-file :base-path (uiop:merge-pathnames* "exploits/" data-dir))) "Path to exploit dir where exploit dependencies are stored.")
-
-(defvar history-dir (nfiles:expand (make-instance 'nfiles:data-file :base-path (uiop:merge-pathnames* data-dir "history.lisp"))) "The history File, defaults to data-dir/history.lisp")
-
-;; Ricing related
-(defvar prompt "HACK$> " "The prompt to be used for command inputs.")
-
-(defvar dependency-dir (nfiles:expand (make-instance 'nfiles:data-file :base-path (uiop:merge-pathnames* "deps/" data-dir)))
-  "The Path for where dependency of tools will be downloaded. ")
-
-;; hackmode internals
-(defvar *startup-hook* (make-instance 'nhooks:hook-void
-                                      :handlers nil) "Hook That is called when hackmode-user is started.")
-(defvar *finding-hook* (make-instance 'nhooks:hook-void
-                                      :handlers nil)
-  "Hook That is called when a finding is found. Takes the finding object as the argument")
-
-(defvar *domain-hook* (make-instance 'nhooks:hook-void
-                                     :handlers nil)
-  "Hook That is called when a domain is found. Takes the domain object as the argument")
-
-(defvar *interactive* nil "Is hackmode being run from a repl/shell?")
+(defvar *interactive* nil "Whether Hackmode is running from a REPL/shell.")

--- a/source/hackmode-core/tests/core-state.lisp
+++ b/source/hackmode-core/tests/core-state.lisp
@@ -59,7 +59,7 @@
          (db (tek9:new-database "assets" :path root))
          (events 0)
          (hackmode:*asset-event-hook*
-           (make-instance 'nhooks:hook-void :handlers nil)))
+           (make-instance 'nhooks:hook-any :handlers nil)))
     (unwind-protect
          (progn
            (tek9:open-database db)


### PR DESCRIPTION
## Summary
Implements #9 by making the Common Lisp core regression suite reproducible from a clean GitHub runner and fixing the real hook-contract bugs that the new test gate exposed.

### Reproducible dependency boundary
- Hackmode remains the monorepo.
- Tek9 remains external and is pinned at `6ff2e40a6f7e3a5eadafef94c2779c74566b7fd7`.
- `star-cl` / ASDF system `starintel` remains the external canonical StarIntel schema library and is pinned at `b8dfbe2f9f56065ace8c3313b92ca748a115cdfa`.
- `cms-ulid` is pinned to the exact commit declared by `star-cl`: `fff84302dee5db42fb90aafd834af3ffbfd6c2bb`.
- third-party Lisp dependencies are resolved from a fresh Quicklisp install.

### Runtime defects found and fixed
The clean test runner exposed an incorrect nhooks contract:
- asset/domain/finding hooks that receive arguments must use `nhooks:hook-any`, not `hook-void`
- the asset lifecycle test itself still rebound the event hook to `hook-void`; that stale test binding is fixed too

### Test execution
The `core` workflow now successfully executes:

`(asdf:test-system :hackmode)`

This runs the regression coverage added by #8 for:
- instance-local CLOS state
- operation create/select/registry close + reopen
- asset normalize -> deterministic dedupe -> local persistence -> event
- persisted-row existence before the discovery event fires

### Verification
Current head `68d2d4cbdf305030e6afbadb212d0b3e7611fd68`:
- `core / common-lisp-core`: PASS
- `monorepo / hygiene`: PASS

Closes #9.