### PR TITLE
Project Hackmode assets to canonical StarIntel documents

### DIFF
--- a/source/hackmode-core/assets.lisp
+++ b/source/hackmode-core/assets.lisp
@@ -22,13 +22,21 @@
 (defgeneric asset-requires-parent-p (asset)
   (:documentation "Whether ASSET identity requires a parent asset id."))
 
+(defgeneric asset->starintel-document (asset &key dataset)
+  (:documentation
+   "Project ASSET to the canonical StarIntel document model when supported."))
+
 (defmethod asset-requires-parent-p ((asset t))
   (declare (ignore asset))
   nil)
 
+(defmethod asset->starintel-document ((asset t) &key dataset)
+  (declare (ignore asset dataset))
+  nil)
+
 (defun normalize-name (value)
   (string-downcase
-   (string-trim '(#\Space #\Tab #\Newline #\Return) value)))
+   (string-trim '(#\Space #\Tab #\Newline #\Return) (or value ""))))
 
 (defun normalize-domain-name (value)
   (string-right-trim '(#\.) (normalize-name value)))
@@ -36,7 +44,7 @@
 (defmethod asset-kind ((asset domain)) "domain")
 (defmethod normalize-asset ((asset domain))
   (setf (domain-name asset) (normalize-domain-name (domain-name asset))
-        (domain-type asset) (string-upcase (string-trim " " (domain-type asset)))
+        (domain-type asset) (string-upcase (string-trim " " (or (domain-type asset) "")))
         (doc-type asset) "domain")
   asset)
 (defmethod asset-canonical-value ((asset domain))
@@ -45,20 +53,22 @@
 (defmethod asset-kind ((asset host)) "host")
 (defmethod normalize-asset ((asset host))
   (setf (doc-host asset) (normalize-domain-name (doc-host asset))
-        (doc-ip asset) (string-trim " " (doc-ip asset))
+        (doc-ip asset) (string-trim " " (or (doc-ip asset) ""))
         (doc-type asset) "host")
   asset)
 (defmethod asset-canonical-value ((asset host))
-  ;; StarIntel's canonical host model prefers IP identity. Preserve unresolved
-  ;; hostnames without collapsing them all onto an empty-IP digest.
+  ;; StarIntel's current host identity is IP-based. Preserve unresolved hostnames
+  ;; locally until they can be projected without collapsing onto the empty IP.
   (if (plusp (length (doc-ip asset)))
       (doc-ip asset)
       (doc-host asset)))
 
 (defmethod asset-kind ((asset url)) "url")
 (defmethod normalize-asset ((asset url))
-  (setf (url-scheme asset) (normalize-name (url-scheme asset))
+  (setf (url-scheme asset) (normalize-name (or (url-scheme asset) "http"))
         (url-host asset) (normalize-domain-name (url-host asset))
+        (url-path asset) (or (url-path asset) "")
+        (url-query asset) (or (url-query asset) "")
         (doc-type asset) "url")
   asset)
 (defmethod asset-canonical-value ((asset url))
@@ -103,26 +113,44 @@
   (declare (ignore asset))
   t)
 
-(defun asset-deterministic-id (asset &key parent-id)
-  "Return a deterministic id using StarIntel's canonical digest primitive.
+(defun asset-starintel-id (asset)
+  "Return StarIntel's canonical document ID for ASSET when projection exists."
+  (let ((document (asset->starintel-document asset)))
+    (when document
+      (starintel:doc-id document))))
 
-PARENT-ID is required for assets such as ports whose value is not globally
-unique. Exact StarIntel document projection remains the asset-registry layer's
-responsibility; this function deliberately reuses STARINTEL:DIGEST-ID instead of
-inventing another hashing convention."
+(defun asset-deterministic-id (asset &key parent-id)
+  "Return the canonical deterministic ID for ASSET.
+
+When ASSET projects to a StarIntel document, use that document's own ID rule so
+local Hackmode and central StarIntel address the same logical record identically.
+PARENT-ID is required for child assets such as ports that have no standalone
+canonical StarIntel document identity yet. Unsupported compatibility assets use
+STARINTEL:DIGEST-ID as a local deterministic fallback."
   (when (and (asset-requires-parent-p asset) (not parent-id))
     (error "Asset type ~a requires :PARENT-ID for deterministic identity."
            (asset-kind asset)))
-  (if parent-id
-      (starintel:digest-id (asset-kind asset)
-                           parent-id
-                           (asset-canonical-value asset))
-      (starintel:digest-id (asset-kind asset)
-                           (asset-canonical-value asset))))
+  (or (and (null parent-id) (asset-starintel-id asset))
+      (if parent-id
+          (starintel:digest-id (asset-kind asset)
+                               parent-id
+                               (asset-canonical-value asset))
+          (starintel:digest-id (asset-kind asset)
+                               (asset-canonical-value asset)))))
 
 (defun bind-asset-operation (asset)
   (when (and (string= (doc-operation asset) "") *current-operation*)
     (setf (doc-operation asset) (operation-name *current-operation*)))
+  asset)
+
+(defun publish-legacy-asset-hook (asset)
+  "Dispatch persisted ASSET to compatibility hooks.
+
+New code should subscribe to `*asset-event-hook*'. These hooks remain only for
+older recon/client integrations while they migrate to the generic event stream."
+  (typecase asset
+    (domain (nhooks:run-hook *domain-hook* asset))
+    (finding (nhooks:run-hook *finding-hook* asset)))
   asset)
 
 (defun publish-asset-event (event-type asset)
@@ -133,6 +161,7 @@ inventing another hashing convention."
                 :operation (doc-operation asset)
                 :timestamp (unix-now))))
     (nhooks:run-hook *asset-event-hook* event)
+    (publish-legacy-asset-hook asset)
     event))
 
 (defun subscribe-asset-events (handler)
@@ -167,6 +196,22 @@ observe an asset that is absent from the local operation store."
           (when publish
             (publish-asset-event :discovered asset))
           (values asset t)))))
+
+(defun record-recon-asset (asset &key (database *db*) parent-id)
+  "Accept ASSET from a recon provider without forcing a standalone DB mode.
+
+When DATABASE is open, route through the canonical persisted discovery path and
+return ASSET, CREATED-P, T. Without an operation store, normalize the object and
+run only the legacy compatibility hook, returning ASSET, NIL, NIL. Generic asset
+events are never published for unpersisted results."
+  (if (and database (tek9:db-is-open-p database))
+      (multiple-value-bind (stored created-p)
+          (discover-asset asset :database database :parent-id parent-id)
+        (values stored created-p t))
+      (progn
+        (normalize-asset asset)
+        (publish-legacy-asset-hook asset)
+        (values asset nil nil))))
 
 (defun query-assets (&key (database *db*) type predicate)
   "Return operation-local assets matching TYPE and PREDICATE.

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -11,6 +11,7 @@
                :nhooks
                #:tek9
                #:starintel
+               #:jsown
                #:cl-ppcre
                #:dexador
                #:shellpool)
@@ -21,6 +22,7 @@
                (:file "database")
                (:file "operations")
                (:file "assets")
+               (:file "starintel-documents")
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -111,10 +111,17 @@
    :asset-canonical-value
    :asset-deterministic-id
    :asset-requires-parent-p
+   :asset->starintel-document
+   :asset->starintel-json
+   :asset-starintel-id
+   :asset-starintel-supported-p
+   :*starintel-dataset*
    :store-asset
    :discover-asset
+   :record-recon-asset
    :query-assets
    :publish-asset-event
+   :publish-legacy-asset-hook
    :subscribe-asset-events))
 
 (in-package :hackmode)

--- a/source/hackmode-core/starintel-documents.lisp
+++ b/source/hackmode-core/starintel-documents.lisp
@@ -1,0 +1,60 @@
+(in-package :hackmode)
+
+(defparameter *starintel-dataset* "star-intel"
+  "Default StarIntel dataset used when projecting Hackmode assets.")
+
+(defun asset-starintel-provenance (asset)
+  "Return StarIntel provenance metadata for ASSET."
+  (let ((provenance (jsown:empty-object)))
+    (when (plusp (length (doc-operation asset)))
+      (setf (jsown:val provenance "operation") (doc-operation asset)))
+    (when (plusp (length (doc-tool asset)))
+      (setf (jsown:val provenance "producer") (doc-tool asset)))
+    provenance))
+
+(defun asset-starintel-common-initargs (asset)
+  "Return shared StarIntel document initargs for ASSET."
+  (list :tags (copy-list (doc-tags asset))
+        :provenance (asset-starintel-provenance asset)))
+
+(defmethod asset->starintel-document ((asset domain) &key (dataset *starintel-dataset*))
+  (normalize-asset asset)
+  (apply #'starintel:new-domain
+         dataset
+         :record (domain-name asset)
+         :record-type (domain-type asset)
+         :resolved (copy-list (domain-ips asset))
+         (asset-starintel-common-initargs asset)))
+
+(defmethod asset->starintel-document ((asset host) &key (dataset *starintel-dataset*))
+  (normalize-asset asset)
+  ;; star-cl currently hashes HOST identity from IP only. Do not project an
+  ;; unresolved hostname as an empty-IP canonical document because every such
+  ;; hostname would collapse to the same StarIntel ID.
+  (when (plusp (length (doc-ip asset)))
+    (apply #'starintel:new-host
+           dataset
+           :hostname (doc-host asset)
+           :ip (doc-ip asset)
+           (asset-starintel-common-initargs asset))))
+
+(defmethod asset->starintel-document ((asset url) &key (dataset *starintel-dataset*))
+  (normalize-asset asset)
+  (apply #'starintel:new-url
+         dataset
+         :url (asset-canonical-value asset)
+         :path (url-path asset)
+         :query (url-query asset)
+         (asset-starintel-common-initargs asset)))
+
+(defun asset->starintel-json (asset &key (dataset *starintel-dataset*))
+  "Return ASSET encoded as a canonical StarIntel v0.9 JSON object.
+
+Return NIL when the compatibility asset has no safe StarIntel projection yet."
+  (let ((document (asset->starintel-document asset :dataset dataset)))
+    (when document
+      (starintel:encode document))))
+
+(defun asset-starintel-supported-p (asset)
+  "Return true when ASSET currently has a safe StarIntel document projection."
+  (not (null (asset->starintel-document asset))))

--- a/source/hackmode-core/tests/core-state.lisp
+++ b/source/hackmode-core/tests/core-state.lisp
@@ -54,11 +54,47 @@
       (remove-test-path root)
       (remove-test-path workspace))))
 
+(defun run-starintel-projection-test ()
+  (let* ((asset (make-instance 'hackmode:domain
+                               :record "Example.COM."
+                               :record-type "a"
+                               :operation "op-alpha"
+                               :tool "crt.sh"
+                               :tags '("dns" "ct")))
+         (_normalized (hackmode:normalize-asset asset))
+         (document (hackmode:asset->starintel-document asset))
+         (json (hackmode:asset->starintel-json asset)))
+    (declare (ignore _normalized))
+    (assert (typep document 'starintel:domain))
+    (assert-equal "example.com" (starintel:domain-record document)
+                  "StarIntel domain record")
+    (assert-equal "A" (starintel:domain-record-type document)
+                  "StarIntel record type")
+    (assert-equal (starintel:doc-id document)
+                  (hackmode:asset-deterministic-id asset)
+                  "shared canonical domain id")
+    (assert-equal "domain" (jsown:val json "dtype") "wire dtype")
+    (assert-equal "example.com"
+                  (jsown:val (jsown:val json "data") "record")
+                  "wire domain record")
+    (assert-equal "op-alpha"
+                  (jsown:val (jsown:val json "provenance") "operation")
+                  "wire operation provenance"))
+  (let ((unresolved (make-instance 'hackmode:host
+                                   :hostname "Pending.Example"
+                                   :ip "")))
+    (hackmode:normalize-asset unresolved)
+    (assert (null (hackmode:asset->starintel-document unresolved)) ()
+            "Unresolved host must not collapse onto StarIntel empty-IP identity.")))
+
 (defun run-asset-lifecycle-test ()
   (let* ((root (fresh-test-path "hackmode-assets"))
          (db (tek9:new-database "assets" :path root))
          (events 0)
+         (legacy-domain-events 0)
          (hackmode:*asset-event-hook*
+           (make-instance 'nhooks:hook-any :handlers nil))
+         (hackmode:*domain-hook*
            (make-instance 'nhooks:hook-any :handlers nil)))
     (unwind-protect
          (progn
@@ -72,22 +108,33 @@
                 (assert persisted ()
                         "Asset event fired before local persistence."))
               (incf events)))
+           (nhooks:add-hook hackmode:*domain-hook*
+                            (lambda (domain)
+                              (declare (ignore domain))
+                              (incf legacy-domain-events)))
            (let ((first (make-instance 'hackmode:domain
                                        :record "Example.COM."
                                        :record-type "a"))
                  (second (make-instance 'hackmode:domain
                                         :record "example.com"
                                         :record-type "A")))
-             (multiple-value-bind (stored created-p)
-                 (hackmode:discover-asset first :database db)
+             (multiple-value-bind (stored created-p persisted-p)
+                 (hackmode:record-recon-asset first :database db)
                (assert created-p)
+               (assert persisted-p)
                (assert-equal "example.com" (hackmode:domain-name stored)
-                             "normalized domain"))
-             (multiple-value-bind (stored created-p)
-                 (hackmode:discover-asset second :database db)
+                             "normalized domain")
+               (assert-equal (starintel:doc-id
+                              (hackmode:asset->starintel-document stored))
+                             (hackmode:doc-id stored)
+                             "persisted canonical StarIntel id"))
+             (multiple-value-bind (stored created-p persisted-p)
+                 (hackmode:record-recon-asset second :database db)
                (declare (ignore stored))
+               (assert persisted-p)
                (assert (not created-p)))
              (assert (= events 1))
+             (assert (= legacy-domain-events 1))
              (assert (= 1 (length (hackmode:query-assets
                                    :database db
                                    :type :domain))))))
@@ -98,6 +145,7 @@
 (defun run-tests ()
   (run-instance-state-test)
   (run-operation-registry-test)
+  (run-starintel-projection-test)
   (run-asset-lifecycle-test)
   (format t "Hackmode core tests passed.~%")
   t)

--- a/source/hackmode-tools/recon/recon-dns/certsh.lisp
+++ b/source/hackmode-tools/recon/recon-dns/certsh.lisp
@@ -1,33 +1,48 @@
 (in-package :recon.dns)
 
-
 (defun cert.sh (domain)
-  (remove-duplicates (flatten (loop for result in  (jsown:parse (dex:get (format nil "https://crt.sh/?q=~a&output=json" domain) :headers '(("User-Agent" . "Hackmode") ("Accept" . "Application/json"))))
-                                    for domain = (jsown:val result "name_value")
-                                    if (not (str:containsp "@" domain))
-                                      collect (str:words (cl-ppcre:regex-replace-all "\\*\\."  domain "")))) :test #'string=))
+  "Return unique domain names observed by crt.sh for DOMAIN."
+  (remove-duplicates
+   (flatten
+    (loop for result in
+            (jsown:parse
+             (dex:get
+              (format nil "https://crt.sh/?q=~a&output=json" domain)
+              :headers '(("User-Agent" . "Hackmode")
+                         ("Accept" . "Application/json"))))
+          for name = (jsown:val result "name_value")
+          unless (str:containsp "@" name)
+            collect
+            (str:words
+             (cl-ppcre:regex-replace-all "\\*\\." name ""))))
+   :test #'string=))
 
+(defvar *cert.sh-setup-hook*
+  (make-instance 'nhooks:hook-void :handlers nil)
+  "Hook called before crt.sh lookup runs.")
 
-(defvar *cert.sh-setup-hook* (make-instance 'nhooks:hook-void
-                                            :handlers nil)
-  "Hook That is called before cert.sh is ran.")
-
-(defvar *cert.sh-finish-hook* (make-instance 'nhooks:hook-any
-                                             :handlers nil)
-  "Hook That is called after cert.sh is finished. Argument must accept list of DOMAIN objects.")
-
-
+(defvar *cert.sh-finish-hook*
+  (make-instance 'nhooks:hook-any :handlers nil)
+  "Hook called with the list of discovered DOMAIN objects.")
 
 (defun cert.sh* (domain)
+  "Query crt.sh and route domains through Hackmode's canonical asset lifecycle."
   (nhooks:run-hook *cert.sh-setup-hook*)
-  (let ((resp (loop for domain in (cert.sh domain)
-                    for result = (make-instance 'domain :id (format nil "~a" (sxhash domain)) :record domain  :tool "cert.sh" :tags '("crt.sh" "domain"))
-                    do (nhooks:run-hook *domain-hook* result)
-                    collect result)))
-
-    (nhooks:run-hook *cert.sh-finish-hook* resp)
-    resp))
+  (let ((response
+          (loop for name in (cert.sh domain)
+                unless (string= name "")
+                  collect
+                  (multiple-value-bind (stored created-p persisted-p)
+                      (record-recon-asset
+                       (make-instance 'domain
+                                      :record name
+                                      :tool "crt.sh"
+                                      :tags '("crt.sh" "domain")))
+                    (declare (ignore created-p persisted-p))
+                    stored))))
+    (nhooks:run-hook *cert.sh-finish-hook* response)
+    response))
 
 (lish:defcommand cert.sh ((domain string))
-  (loop for domain in  (cert.sh* domain)
-        do (format t "~a~%" (domain-name domain))))
+  (loop for result in (cert.sh* domain)
+        do (format t "~a~%" (domain-name result))))

--- a/source/hackmode-tools/recon/recon-dns/dns.lisp
+++ b/source/hackmode-tools/recon/recon-dns/dns.lisp
@@ -1,60 +1,74 @@
 (in-package :recon-dns)
 
-;; TODO wrape up shell tool creation into a macro since its just calling it from the shell
+;; Provider wrappers remain callable as plain Lisp functions; typed persistence
+;; is handled by RECORD-RECON-ASSET instead of ad-hoc IDs/hooks.
 
 (defun subfinder (&rest args)
-  "run subfinder"
+  "Run subfinder and return its raw stdout."
   (nth 0 (apply #'make-command "subfinder" "-silent" args)))
 
-(defvar *subfinder-setup-hook* (make-instance 'nhooks:hook-void
-                                              :handlers nil)
-  "Hook That is called before subfinder is ran.")
+(defvar *subfinder-setup-hook*
+  (make-instance 'nhooks:hook-void :handlers nil)
+  "Hook called before subfinder runs.")
 
-(defvar *subfinder-finish-hook* (make-instance 'nhooks:hook-void
-                                               :handlers nil)
-  "Hook That is called after subfinder is finished.")
+(defvar *subfinder-finish-hook*
+  (make-instance 'nhooks:hook-void :handlers nil)
+  "Hook called after subfinder finishes.")
 
-(defvar *oam-subs-setup-hook* (make-instance 'nhooks:hook-void
-                                             :handlers nil)
-  "Hook That is called before oam-subs is ran.")
+(defvar *oam-subs-setup-hook*
+  (make-instance 'nhooks:hook-void :handlers nil)
+  "Hook called before oam-subs runs.")
 
-(defvar *oam-subs-finish-hook* (make-instance 'nhooks:hook-void
-                                              :handlers nil)
-  "Hook That is called after oam-subs is finished.")
-
-
-
-
+(defvar *oam-subs-finish-hook*
+  (make-instance 'nhooks:hook-any :handlers nil)
+  "Hook called with the list of domain objects after oam-subs finishes.")
 
 (defun subfinder* (&rest args)
-  "run subfinder and save output to database"
+  "Run subfinder and route discovered domains through Hackmode asset lifecycle."
   (nhooks:run-hook *subfinder-setup-hook*)
   (let* ((output (uiop:split-string (apply #'subfinder args) :separator "\n"))
-         (docs (loop for domain in output
-                     for record = (make-instance 'domain :id (format nil "~a" (sxhash domain)) :tags '("dns" "subfinder") :dtype "domain" :record domain)
-                     do (nhooks:run-hook *domain-hook* record)
-                     collect record)))
-
+         (docs
+           (loop for name in output
+                 unless (string= name "")
+                   collect
+                   (multiple-value-bind (stored created-p persisted-p)
+                       (record-recon-asset
+                        (make-instance 'domain
+                                       :tags '("dns" "subfinder")
+                                       :tool "subfinder"
+                                       :dtype "domain"
+                                       :record name))
+                     (declare (ignore created-p persisted-p))
+                     stored))))
     (nhooks:run-hook *subfinder-finish-hook*)
     docs))
 
-
-
 (defun oam-subs (&rest args)
-  (uiop:split-string  (nth 0 (shellpool:run (apply #'make-command "oam_subs" "-o /dev/stdout -names" args))) :separator "\n"))
+  (uiop:split-string
+   (nth 0
+        (shellpool:run
+         (apply #'make-command "oam_subs" "-o /dev/stdout -names" args)))
+   :separator "\n"))
 
-;; TODO fix gopath and test this
+;; TODO fix gopath and test the external binary itself.
 (defun oam-subs* (&rest args)
   (nhooks:run-hook *oam-subs-setup-hook*)
-  (let* ((output (apply 'oam-subs args))
+  (let* ((output (apply #'oam-subs args))
          (domains
-           (loop for domain in output
-                 for record = (make-instance 'domain :id (format nil "~a" (sxhash domain)) :tags '("dns" "oam-subs") :dtype "domain" :record domain)
-                 do (nhooks:run-hook *domain-hook* record))))
+           (loop for name in output
+                 unless (string= name "")
+                   collect
+                   (multiple-value-bind (stored created-p persisted-p)
+                       (record-recon-asset
+                        (make-instance 'domain
+                                       :tags '("dns" "oam-subs")
+                                       :tool "oam-subs"
+                                       :dtype "domain"
+                                       :record name))
+                     (declare (ignore created-p persisted-p))
+                     stored))))
     (nhooks:run-hook *oam-subs-finish-hook* domains)
     domains))
 
-
-
 (defun dnsrecon (&rest args)
-  (nth 0  (apply #'make-command "dnsrecon" args)))
+  (nth 0 (apply #'make-command "dnsrecon" args)))


### PR DESCRIPTION
## Summary
Completes the canonical runtime/document boundary for #6 by aligning Hackmode local asset identity with the actual `star-cl` document model and routing existing DNS recon discoveries through the canonical local lifecycle.

### Canonical StarIntel projection
Adds `starintel-documents.lisp` with provider-neutral projection for:
- domain -> `starintel:domain`
- resolved host -> `starintel:host`
- URL -> `starintel:url`

Projection carries Hackmode operation/producer metadata in StarIntel provenance and encodes through `starintel:encode`.

Unresolved hosts are deliberately not projected yet: `star-cl` currently hashes host identity from IP only, and empty-IP hosts would collide. `lost-rob0t/star-cl#9` tracks the schema fix.

### Identity convergence
For assets with a safe StarIntel projection, `asset-deterministic-id` now uses the projected document's own `starintel:doc-id`. Local Hackmode and central StarIntel therefore address the same domain/host/URL with the same logical ID.

Unsupported compatibility assets retain deterministic local `starintel:digest-id` fallback identity; child assets such as ports still require a parent ID.

### Recon ingestion boundary
Adds `record-recon-asset`:
- open operation DB -> normalize, deterministic identity, dedupe, persist, generic event, compatibility hook
- no operation DB -> normalize + compatibility hook only; no fake persisted event

Existing DNS adapters now use it:
- `subfinder*`
- `oam-subs*`
- `cert.sh*`

This removes ad-hoc `sxhash` IDs and fixes the `oam-subs` finish-hook/collection path.

### Verification executed
Current head `2d04b1993b9a4349ea77710e0139fbe5261b39b7`:
- `core / common-lisp-core`: PASS — executes `(asdf:test-system :hackmode)` on a clean runner
- `monorepo / hygiene`: PASS

The Common Lisp suite covers canonical domain projection, shared Hackmode/StarIntel ID, v0.9 wire encoding and operation provenance, unresolved-host collision guard, and recon-result persistence/deduplication/event behavior.

Closes #6.
Unresolved-host schema follow-up: lost-rob0t/star-cl#9.
Emacs runtime-client convergence: #17.