### PR TITLE
Add persistent offline-safe StarIntel operation outbox

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -39,12 +39,18 @@ jobs:
           fetch-depth: 1
 
       - name: Checkout pinned Sento actor runtime
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          repository: mdbergmann/cl-gserver
-          ref: 6a510c5b58469e72e6363bd3a6059d80b9a5c320
-          path: deps/sento-ci
-          fetch-depth: 1
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf deps/sento-ci
+          git clone --filter=blob:none --no-checkout \
+            https://github.com/mdbergmann/cl-gserver.git \
+            deps/sento-ci
+          git -C deps/sento-ci fetch --depth=1 origin \
+            6a510c5b58469e72e6363bd3a6059d80b9a5c320
+          git -C deps/sento-ci checkout --detach \
+            6a510c5b58469e72e6363bd3a6059d80b9a5c320
+          test -f deps/sento-ci/sento.asd
 
       - name: Checkout pinned cms-ulid
         shell: bash

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -38,6 +38,14 @@ jobs:
           path: deps/star-cl-ci
           fetch-depth: 1
 
+      - name: Checkout pinned Sento actor runtime
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          repository: mdbergmann/cl-gserver
+          ref: 6a510c5b58469e72e6363bd3a6059d80b9a5c320
+          path: deps/sento-ci
+          fetch-depth: 1
+
       - name: Checkout pinned cms-ulid
         shell: bash
         run: |
@@ -79,8 +87,10 @@ jobs:
           sbcl --non-interactive \
             --load "$HOME/quicklisp/setup.lisp" \
             --eval '(push (truename "deps/cms-ulid-ci/") asdf:*central-registry*)' \
+            --eval '(push (truename "deps/sento-ci/") asdf:*central-registry*)' \
             --eval '(asdf:load-asd (truename "deps/tek9-ci/src/tek9.asd"))' \
             --eval '(asdf:load-asd (truename "deps/star-cl-ci/src/starintel.asd"))' \
+            --eval '(asdf:load-asd (truename "deps/sento-ci/sento.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode-tests.asd"))' \
             --eval '(ql:quickload :hackmode-tests)' \

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -94,4 +94,14 @@ jobs:
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode-tests.asd"))' \
             --eval '(ql:quickload :hackmode-tests)' \
-            --eval '(asdf:test-system :hackmode)'
+            --eval '(asdf:test-system :hackmode)' \
+            2>&1 | tee "$RUNNER_TEMP/hackmode-core.log"
+
+      - name: Upload Common Lisp diagnostic log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hackmode-core-log
+          path: ${{ runner.temp }}/hackmode-core.log
+          if-no-files-found: warn
+          retention-days: 3

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -2,7 +2,7 @@
   :description "Core Systems for hackmode"
   :author "nsaspy"
   :license "LGLV3"
-  :version "0.2.0"
+  :version "0.3.0"
   :serial t
   :in-order-to ((test-op (test-op "hackmode-tests")))
   :depends-on (#:serapeum
@@ -14,6 +14,7 @@
                #:jsown
                #:cl-ppcre
                #:dexador
+               #:sento
                #:shellpool)
   :components ((:file "package")
                (:file "utils")
@@ -23,6 +24,8 @@
                (:file "operations")
                (:file "assets")
                (:file "starintel-documents")
+               (:file "outbox")
+               (:file "outbox-actor")
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/outbox-actor.lisp
+++ b/source/hackmode-core/outbox-actor.lisp
@@ -1,0 +1,69 @@
+(in-package :hackmode)
+
+(defvar *hackmode-actor-system* nil
+  "Hackmode-owned Sento actor system for local asynchronous workers.")
+
+(defvar *outbox-actor* nil
+  "Current Hackmode outbox actor.")
+
+(defun ensure-hackmode-actor-system ()
+  "Return a Hackmode-owned actor system with a dedicated outbox dispatcher."
+  (or *hackmode-actor-system*
+      (setf *hackmode-actor-system*
+            (sento.actor-system:make-actor-system
+             '(:dispatchers
+               (:outbox (:workers 1 :strategy :random))
+               :timeout-timer
+               (:resolution 100 :max-size 100))))))
+
+(defun stop-hackmode-actor-system ()
+  "Shutdown the Hackmode-owned actor system, if any."
+  (when *hackmode-actor-system*
+    (sento.actor-context:shutdown *hackmode-actor-system*)
+    (setf *hackmode-actor-system* nil
+          *outbox-actor* nil))
+  t)
+
+(defun outbox-actor-handler (database transport)
+  "Return a Sento receive function bound to DATABASE and TRANSPORT."
+  (lambda (message)
+    (destructuring-bind (command &key now (limit 100)) message
+      (case command
+        (:drain
+         (drain-outbox database transport
+                       :now (or now (unix-now))
+                       :limit limit))
+        (otherwise
+         (error "Unknown Hackmode outbox actor command: ~s" command))))))
+
+(defun start-outbox-actor (&key
+                            (database *db*)
+                            (transport (make-starintel-http-transport))
+                            system
+                            dispatcher)
+  "Start an asynchronous outbox actor and return it.
+
+When SYSTEM is omitted Hackmode creates an actor system with a dedicated
+:OUTBOX dispatcher. Callers embedding Hackmode in another actor runtime may
+supply SYSTEM and DISPATCHER explicitly."
+  (unless (and database (tek9:db-is-open-p database))
+    (error "START-OUTBOX-ACTOR requires an open operation database."))
+  (let* ((owned-system-p (null system))
+         (context (or system (ensure-hackmode-actor-system)))
+         (dispatcher-id (or dispatcher (if owned-system-p :outbox :shared))))
+    (setf *outbox-actor*
+          (sento.actor-context:actor-of
+           context
+           :name "hackmode-outbox"
+           :dispatcher dispatcher-id
+           :receive (outbox-actor-handler database transport)))))
+
+(defun drain-outbox-async (&key
+                            (actor *outbox-actor*)
+                            now
+                            (limit 100))
+  "Request asynchronous outbox delivery through ACTOR and return immediately."
+  (unless actor
+    (error "No Hackmode outbox actor is running."))
+  (sento.actor:tell actor (list :drain :now now :limit limit))
+  actor)

--- a/source/hackmode-core/outbox.lisp
+++ b/source/hackmode-core/outbox.lisp
@@ -97,11 +97,11 @@ enqueue calls for byte-identical payloads collapse to one durable record."
 
 (defun make-outbox-entry-for-json (json &key operation (now (unix-now)))
   "Construct an outbox entry for canonical StarIntel JSON object JSON."
-  (let* ((document-id (jsown:val-safe json "id"))
+  (let* ((document-id (jsown:val-safe json "_id"))
          (dtype (jsown:val-safe json "dtype"))
          (payload (jsown:to-json json)))
     (unless (and (stringp document-id) (plusp (length document-id)))
-      (error "Cannot enqueue StarIntel document without a canonical id."))
+      (error "Cannot enqueue StarIntel document without a canonical _id."))
     (unless (and (stringp dtype) (plusp (length dtype)))
       (error "Cannot enqueue StarIntel document without dtype."))
     (make-instance 'outbox-entry

--- a/source/hackmode-core/outbox.lisp
+++ b/source/hackmode-core/outbox.lisp
@@ -1,7 +1,10 @@
 (in-package :hackmode)
 
-(defconstant +outbox-database-name+ "outbox")
-(defconstant +outbox-id-version+ "hackmode-outbox-v1")
+(defparameter +outbox-database-name+ "outbox"
+  "Named Tek9 database used for durable operation outbox records.")
+
+(defparameter +outbox-id-version+ "hackmode-outbox-v1"
+  "Stable namespace/version component used when deriving outbox IDs.")
 
 (defparameter *outbox-max-attempts* 8
   "Maximum delivery attempts before an outbox entry becomes FAILED.")

--- a/source/hackmode-core/outbox.lisp
+++ b/source/hackmode-core/outbox.lisp
@@ -1,0 +1,289 @@
+(in-package :hackmode)
+
+(defconstant +outbox-database-name+ "outbox")
+(defconstant +outbox-id-version+ "hackmode-outbox-v1")
+
+(defparameter *outbox-max-attempts* 8
+  "Maximum delivery attempts before an outbox entry becomes FAILED.")
+
+(defparameter *outbox-backoff-base-seconds* 2
+  "Base delay for deterministic exponential outbox retry backoff.")
+
+(defparameter *outbox-backoff-max-seconds* 300
+  "Maximum outbox retry delay in seconds.")
+
+(defparameter *starintel-ingest-base-url* "http://127.0.0.1:5000"
+  "Default StarIntel Server URL used by the HTTP outbox transport.")
+
+(define-condition outbox-transport-error (error)
+  ((message :initarg :message :reader outbox-transport-error-message))
+  (:report (lambda (condition stream)
+             (format stream "Outbox transport failed: ~a"
+                     (outbox-transport-error-message condition)))))
+
+(defclass outbox-entry ()
+  ((id :initarg :id :reader outbox-entry-id :type string)
+   (document-id :initarg :document-id :reader outbox-entry-document-id :type string)
+   (dtype :initarg :dtype :reader outbox-entry-dtype :type string)
+   (operation :initarg :operation :reader outbox-entry-operation :initform "" :type string)
+   (payload :initarg :payload :reader outbox-entry-payload :type string)
+   (state :initarg :state :accessor outbox-entry-state :initform :queued)
+   (attempts :initarg :attempts :accessor outbox-entry-attempts :initform 0 :type integer)
+   (created-at :initarg :created-at :reader outbox-entry-created-at :type integer)
+   (updated-at :initarg :updated-at :accessor outbox-entry-updated-at :type integer)
+   (next-attempt-at :initarg :next-attempt-at :accessor outbox-entry-next-attempt-at
+                    :initform nil)
+   (last-error :initarg :last-error :accessor outbox-entry-last-error
+               :initform "" :type string)
+   (last-status :initarg :last-status :accessor outbox-entry-last-status
+                :initform nil)
+   (ack-kind :initarg :ack-kind :accessor outbox-entry-ack-kind :initform nil)
+   (acknowledged-at :initarg :acknowledged-at :accessor outbox-entry-acknowledged-at
+                    :initform nil)))
+
+(conspack:defencoding outbox-entry
+  id document-id dtype operation payload state attempts created-at updated-at
+  next-attempt-at last-error last-status ack-kind acknowledged-at)
+
+(defun outbox-payload-id (document-id payload)
+  "Return a deterministic outbox ID for DOCUMENT-ID and serialized PAYLOAD.
+
+A new StarIntel document version/payload gets a new outbox entry while repeated
+enqueue calls for byte-identical payloads collapse to one durable record."
+  (starintel:digest-id +outbox-id-version+
+                       document-id
+                       (starintel:digest-id payload)))
+
+(defun persist-outbox-entry (database entry)
+  "Persist ENTRY in DATABASE's named outbox database and return ENTRY."
+  (unless (and database (tek9:db-is-open-p database))
+    (error "Outbox persistence requires an open operation database."))
+  (tek9:put* database entry
+             :id (outbox-entry-id entry)
+             :database-name +outbox-database-name+)
+  entry)
+
+(defun fetch-outbox-entry (database id)
+  "Fetch outbox entry ID from DATABASE, or NIL."
+  (tek9:fetch* database id :database-name +outbox-database-name+))
+
+(defun list-outbox-entries (database &key state predicate)
+  "Return durable outbox entries, optionally filtered by STATE and PREDICATE."
+  (unless (and database (tek9:db-is-open-p database))
+    (error "Outbox query requires an open operation database."))
+  (let (entries)
+    (tek9:map-database
+     database
+     :database-name +outbox-database-name+
+     :map-fn
+     (lambda (key document)
+       (declare (ignore key))
+       (let ((entry (tek9:doc-value document)))
+         (when (and (typep entry 'outbox-entry)
+                    (or (null state) (eq state (outbox-entry-state entry)))
+                    (or (null predicate) (funcall predicate entry)))
+           (push entry entries)))))
+    (sort entries
+          (lambda (left right)
+            (or (< (outbox-entry-created-at left)
+                   (outbox-entry-created-at right))
+                (and (= (outbox-entry-created-at left)
+                        (outbox-entry-created-at right))
+                     (string< (outbox-entry-id left)
+                              (outbox-entry-id right))))))))
+
+(defun make-outbox-entry-for-json (json &key operation (now (unix-now)))
+  "Construct an outbox entry for canonical StarIntel JSON object JSON."
+  (let* ((document-id (jsown:val-safe json "id"))
+         (dtype (jsown:val-safe json "dtype"))
+         (payload (jsown:to-json json)))
+    (unless (and (stringp document-id) (plusp (length document-id)))
+      (error "Cannot enqueue StarIntel document without a canonical id."))
+    (unless (and (stringp dtype) (plusp (length dtype)))
+      (error "Cannot enqueue StarIntel document without dtype."))
+    (make-instance 'outbox-entry
+                   :id (outbox-payload-id document-id payload)
+                   :document-id document-id
+                   :dtype dtype
+                   :operation (or operation "")
+                   :payload payload
+                   :created-at now
+                   :updated-at now)))
+
+(defun enqueue-starintel-json (database json &key operation (now (unix-now)))
+  "Persist JSON in DATABASE before transmission.
+
+Returns ENTRY and true only when this call created a new durable outbox record."
+  (let* ((candidate (make-outbox-entry-for-json json :operation operation :now now))
+         (existing (fetch-outbox-entry database (outbox-entry-id candidate))))
+    (if existing
+        (values existing nil)
+        (values (persist-outbox-entry database candidate) t))))
+
+(defun enqueue-asset-for-starintel (asset &key (database *db*) (now (unix-now)))
+  "Project ASSET to StarIntel JSON and durably enqueue it in DATABASE."
+  (let ((json (asset->starintel-json asset)))
+    (unless json
+      (error "Asset type ~a has no safe StarIntel projection." (asset-kind asset)))
+    (enqueue-starintel-json database json
+                            :operation (doc-operation asset)
+                            :now now)))
+
+(defun outbox-backoff-seconds (attempts
+                               &key
+                                 (base *outbox-backoff-base-seconds*)
+                                 (maximum *outbox-backoff-max-seconds*))
+  "Return bounded exponential retry delay for ATTEMPTS."
+  (min maximum
+       (* base (expt 2 (max 0 (1- attempts))))))
+
+(defun outbox-due-p (entry now)
+  "Return true when ENTRY should be attempted at NOW.
+
+SENDING entries are deliberately recoverable: if a process dies after marking
+an entry SENDING but before recording the HTTP result, the next drain retries the
+same deterministic logical document rather than leaving it stuck forever."
+  (case (outbox-entry-state entry)
+    ((:queued :sending) t)
+    (:retry (let ((next (outbox-entry-next-attempt-at entry)))
+              (or (null next) (<= next now))))
+    (otherwise nil)))
+
+(defun outbox-retryable-http-status-p (status)
+  "Return true when HTTP STATUS should be retried."
+  (or (= status 408)
+      (= status 425)
+      (= status 429)
+      (<= 500 status 599)))
+
+(defun outbox-permanent-http-status-p (status)
+  "Return true when HTTP STATUS indicates a malformed/unauthorized request.
+
+429 is excluded because rate limiting is transient."
+  (and (<= 400 status 499)
+       (not (outbox-retryable-http-status-p status))))
+
+(defun mark-outbox-sending (database entry now)
+  (incf (outbox-entry-attempts entry))
+  (setf (outbox-entry-state entry) :sending
+        (outbox-entry-updated-at entry) now
+        (outbox-entry-next-attempt-at entry) nil
+        (outbox-entry-last-error entry) ""
+        (outbox-entry-last-status entry) nil)
+  (persist-outbox-entry database entry))
+
+(defun mark-outbox-acknowledged (database entry status now)
+  "Record StarIntel HTTP ingest acceptance.
+
+ACK-KIND is :INGEST-ACCEPTED: the server validated and published the document to
+its ingest broker. This does not claim that CouchDB persistence has already
+completed."
+  (setf (outbox-entry-state entry) :acknowledged
+        (outbox-entry-updated-at entry) now
+        (outbox-entry-next-attempt-at entry) nil
+        (outbox-entry-last-error entry) ""
+        (outbox-entry-last-status entry) status
+        (outbox-entry-ack-kind entry) :ingest-accepted
+        (outbox-entry-acknowledged-at entry) now)
+  (persist-outbox-entry database entry))
+
+(defun mark-outbox-quarantined (database entry status now)
+  (setf (outbox-entry-state entry) :quarantined
+        (outbox-entry-updated-at entry) now
+        (outbox-entry-next-attempt-at entry) nil
+        (outbox-entry-last-status entry) status
+        (outbox-entry-last-error entry) (format nil "HTTP ~d rejected document" status))
+  (persist-outbox-entry database entry))
+
+(defun mark-outbox-retry-or-failed (database entry message now &optional status)
+  (let ((failed-p (>= (outbox-entry-attempts entry) *outbox-max-attempts*)))
+    (setf (outbox-entry-state entry) (if failed-p :failed :retry)
+          (outbox-entry-updated-at entry) now
+          (outbox-entry-last-status entry) status
+          (outbox-entry-last-error entry) message
+          (outbox-entry-next-attempt-at entry)
+          (unless failed-p
+            (+ now (outbox-backoff-seconds (outbox-entry-attempts entry)))))
+    (persist-outbox-entry database entry)))
+
+(defun process-outbox-entry (database entry transport &key (now (unix-now)))
+  "Attempt one ENTRY through TRANSPORT and persist its resulting state.
+
+TRANSPORT is a function of ENTRY returning STATUS and optional response body.
+Transport errors should signal OUTBOX-TRANSPORT-ERROR; any unexpected condition
+is also converted to a retry/failed state rather than escaping and dropping the
+entry."
+  (unless (outbox-due-p entry now)
+    (return-from process-outbox-entry entry))
+  (mark-outbox-sending database entry now)
+  (handler-case
+      (multiple-value-bind (status body)
+          (funcall transport entry)
+        (declare (ignore body))
+        (cond
+          ((and (integerp status) (<= 200 status 299))
+           (mark-outbox-acknowledged database entry status now))
+          ((and (integerp status) (outbox-permanent-http-status-p status))
+           (mark-outbox-quarantined database entry status now))
+          (t
+           (mark-outbox-retry-or-failed
+            database entry
+            (if (integerp status)
+                (format nil "HTTP ~d did not accept document" status)
+                "Transport returned no valid HTTP status")
+            now status))))
+    (outbox-transport-error (condition)
+      (mark-outbox-retry-or-failed
+       database entry
+       (outbox-transport-error-message condition)
+       now))
+    (error (condition)
+      (mark-outbox-retry-or-failed
+       database entry
+       (format nil "Transport error: ~a" condition)
+       now))))
+
+(defun drain-outbox (database transport &key (now (unix-now)) (limit 100))
+  "Process up to LIMIT due outbox entries synchronously in the caller.
+
+Interactive clients should normally use DRAIN-OUTBOX-ASYNC so network work runs
+inside the dedicated outbox actor instead of blocking their thread."
+  (let ((processed 0)
+        results)
+    (dolist (entry (list-outbox-entries database) (nreverse results))
+      (when (and (< processed limit) (outbox-due-p entry now))
+        (incf processed)
+        (push (process-outbox-entry database entry transport :now now) results)))))
+
+(defun make-starintel-http-transport (&key
+                                       (base-url *starintel-ingest-base-url*)
+                                       headers-function
+                                       (connect-timeout 5)
+                                       (read-timeout 10))
+  "Return an HTTP transport for the existing StarIntel single-document ingest API.
+
+HEADERS-FUNCTION is called immediately before each request so credentials do not
+need to be persisted in outbox records."
+  (let ((root (string-right-trim "/" base-url)))
+    (lambda (entry)
+      (let* ((url (format nil "~a/new/document/~a"
+                          root (outbox-entry-dtype entry)))
+             (headers (append
+                       '(("Content-Type" . "application/json")
+                         ("Accept" . "application/json"))
+                       (when headers-function
+                         (funcall headers-function)))))
+        (handler-case
+            (multiple-value-bind (body status)
+                (dex:post url
+                          :content (outbox-entry-payload entry)
+                          :headers headers
+                          :connect-timeout connect-timeout
+                          :read-timeout read-timeout)
+              (values status body))
+          (dex:http-request-failed (condition)
+            (values (dex:response-status condition)
+                    (dex:response-body condition)))
+          (error (condition)
+            (error 'outbox-transport-error
+                   :message (format nil "~a" condition))))))))

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -122,6 +122,46 @@
    :query-assets
    :publish-asset-event
    :publish-legacy-asset-hook
-   :subscribe-asset-events))
+   :subscribe-asset-events
+   ;; Persistent StarIntel outbox
+   :+outbox-database-name+
+   :outbox-entry
+   :outbox-entry-id
+   :outbox-entry-document-id
+   :outbox-entry-dtype
+   :outbox-entry-operation
+   :outbox-entry-payload
+   :outbox-entry-state
+   :outbox-entry-attempts
+   :outbox-entry-created-at
+   :outbox-entry-updated-at
+   :outbox-entry-next-attempt-at
+   :outbox-entry-last-error
+   :outbox-entry-last-status
+   :outbox-entry-ack-kind
+   :outbox-entry-acknowledged-at
+   :outbox-transport-error
+   :outbox-transport-error-message
+   :*outbox-max-attempts*
+   :*outbox-backoff-base-seconds*
+   :*outbox-backoff-max-seconds*
+   :*starintel-ingest-base-url*
+   :outbox-payload-id
+   :enqueue-starintel-json
+   :enqueue-asset-for-starintel
+   :fetch-outbox-entry
+   :list-outbox-entries
+   :outbox-backoff-seconds
+   :outbox-due-p
+   :process-outbox-entry
+   :drain-outbox
+   :make-starintel-http-transport
+   ;; Outbox actor
+   :*hackmode-actor-system*
+   :*outbox-actor*
+   :ensure-hackmode-actor-system
+   :stop-hackmode-actor-system
+   :start-outbox-actor
+   :drain-outbox-async))
 
 (in-package :hackmode)

--- a/source/hackmode-core/starintel-documents.lisp
+++ b/source/hackmode-core/starintel-documents.lisp
@@ -12,9 +12,23 @@
       (setf (jsown:val provenance "producer") (doc-tool asset)))
     provenance))
 
+(defun unix-seconds->starintel-timestring (seconds)
+  "Format Unix SECONDS as a stable UTC StarIntel timestamp string."
+  (local-time:format-timestring
+   nil
+   (local-time:unix-to-timestamp seconds)
+   :format local-time:+iso-8601-format+
+   :timezone local-time:+utc-zone+))
+
 (defun asset-starintel-common-initargs (asset)
-  "Return shared StarIntel document initargs for ASSET."
+  "Return shared StarIntel document initargs for ASSET.
+
+Carry Hackmode's persisted timestamps into the projection so serializing the
+same asset repeatedly does not create a different outbox payload merely because
+the projection happened at a later wall-clock time."
   (list :tags (copy-list (doc-tags asset))
+        :date-added (unix-seconds->starintel-timestring (doc-date-added asset))
+        :date-updated (unix-seconds->starintel-timestring (doc-date-updated asset))
         :provenance (asset-starintel-provenance asset)))
 
 (defmethod asset->starintel-document ((asset domain) &key (dataset *starintel-dataset*))

--- a/source/hackmode-core/tests/core-state.lisp
+++ b/source/hackmode-core/tests/core-state.lisp
@@ -176,6 +176,7 @@
     (unwind-protect
          (progn
            (tek9:open-database db)
+
            ;; Enqueue is durable and byte-identical repeated projection dedupes.
            (multiple-value-bind (entry created-p)
                (hackmode:enqueue-asset-for-starintel asset :database db :now 1000)
@@ -188,10 +189,12 @@
                              "duplicate enqueue id"))
              (tek9:close-database db)
              (tek9:open-database db)
-             (let ((reloaded (hackmode:fetch-outbox-entry
-                              db (hackmode:outbox-entry-id entry))))
+             (let ((reloaded
+                     (hackmode:fetch-outbox-entry
+                      db (hackmode:outbox-entry-id entry))))
                (assert reloaded () "Queued outbox entry did not survive reopen.")
                (assert (eq :queued (hackmode:outbox-entry-state reloaded)))
+
                ;; Offline transport moves to retry without affecting operation data.
                (hackmode:process-outbox-entry db reloaded transport :now 1010)
                (assert (eq :retry (hackmode:outbox-entry-state reloaded)))
@@ -202,16 +205,20 @@
                                :record "still-working.example"
                                :record-type "A")
                 :database db)
-               (assert (= 1 (length (hackmode:query-assets
-                                     :database db :type :domain))))
-               ;; Restoration retries the same logical record and acknowledges
-               ;; broker acceptance; it does not mint another outbox entry.
+               (assert (= 1
+                          (length
+                           (hackmode:query-assets :database db :type :domain))))
+
+               ;; Restoration retries the same record and acknowledges acceptance.
                (hackmode:process-outbox-entry db reloaded transport :now 1012)
                (assert (eq :acknowledged (hackmode:outbox-entry-state reloaded)))
-               (assert (eq :ingest-accepted (hackmode:outbox-entry-ack-kind reloaded)))
+               (assert (eq :ingest-accepted
+                           (hackmode:outbox-entry-ack-kind reloaded)))
                (assert (= 202 (hackmode:outbox-entry-last-status reloaded)))
                (assert (= 2 (hackmode:outbox-entry-attempts reloaded)))
-               (assert (= 1 (length (hackmode:list-outbox-entries db)))))))
+               (assert (= 1
+                          (length (hackmode:list-outbox-entries db))))))
+
            ;; Permanent 4xx is inspectable quarantine, never silently dropped.
            (let ((bad (make-instance 'hackmode:domain
                                      :record "bad.example"
@@ -222,13 +229,18 @@
                  (hackmode:enqueue-asset-for-starintel bad :database db :now 2000)
                (assert created-p)
                (hackmode:process-outbox-entry
-                db entry (lambda (ignored)
-                           (declare (ignore ignored))
-                           (values 400 "invalid"))
+                db
+                entry
+                (lambda (ignored)
+                  (declare (ignore ignored))
+                  (values 400 "invalid"))
                 :now 2001)
                (assert (eq :quarantined (hackmode:outbox-entry-state entry)))
-               (assert (= 1 (length (hackmode:list-outbox-entries
-                                     db :state :quarantined))))))
+               (assert (= 1
+                          (length
+                           (hackmode:list-outbox-entries
+                            db :state :quarantined))))))
+
            ;; Bounded retries eventually become FAILED and remain inspectable.
            (let ((hackmode:*outbox-max-attempts* 2)
                  (doomed (make-instance 'hackmode:domain
@@ -237,29 +249,39 @@
                                         :date-added 3000
                                         :date-updated 3000)))
              (multiple-value-bind (entry created-p)
-                 (hackmode:enqueue-asset-for-starintel doomed :database db :now 3000)
+                 (hackmode:enqueue-asset-for-starintel doomed
+                                                       :database db
+                                                       :now 3000)
                (assert created-p)
                (flet ((fail (ignored)
                         (declare (ignore ignored))
-                        (error 'hackmode:outbox-transport-error :message "offline")))
+                        (error 'hackmode:outbox-transport-error
+                               :message "offline")))
                  (hackmode:process-outbox-entry db entry #'fail :now 3001)
-                 (hackmode:process-outbox-entry db entry #'fail
-                                                :now (hackmode:outbox-entry-next-attempt-at entry)))
+                 (hackmode:process-outbox-entry
+                  db
+                  entry
+                  #'fail
+                  :now (hackmode:outbox-entry-next-attempt-at entry)))
                (assert (eq :failed (hackmode:outbox-entry-state entry)))))
-           ;; Network delivery can run on a dedicated actor and return immediately.
+
+           ;; Network delivery runs on a dedicated actor and returns immediately.
            (let ((async-asset (make-instance 'hackmode:domain
                                              :record "async.example"
                                              :record-type "A"
                                              :date-added 4000
                                              :date-updated 4000)))
              (multiple-value-bind (entry created-p)
-                 (hackmode:enqueue-asset-for-starintel async-asset :database db :now 4000)
+                 (hackmode:enqueue-asset-for-starintel async-asset
+                                                       :database db
+                                                       :now 4000)
                (assert created-p)
                (hackmode:start-outbox-actor
                 :database db
-                :transport (lambda (ignored)
-                             (declare (ignore ignored))
-                             (values 200 "accepted")))
+                :transport
+                (lambda (ignored)
+                  (declare (ignore ignored))
+                  (values 200 "accepted")))
                (hackmode:drain-outbox-async :now 4001 :limit 10)
                (assert
                 (wait-until
@@ -268,7 +290,8 @@
                        (hackmode:outbox-entry-state
                         (hackmode:fetch-outbox-entry
                          db (hackmode:outbox-entry-id entry))))))
-                () "Async outbox actor did not acknowledge entry.")))
+                ()
+                "Async outbox actor did not acknowledge entry."))))
       (ignore-errors (hackmode:stop-hackmode-actor-system))
       (when (tek9:db-is-open-p db)
         (tek9:close-database db))

--- a/source/hackmode-core/tests/core-state.lisp
+++ b/source/hackmode-core/tests/core-state.lisp
@@ -16,6 +16,12 @@
   (ignore-errors
     (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)))
 
+(defun wait-until (predicate &key (attempts 200) (delay 0.01))
+  (loop repeat attempts
+        when (funcall predicate) return t
+        do (sleep delay)
+        finally (return nil)))
+
 (defun run-instance-state-test ()
   (let ((left (make-instance 'hackmode:domain
                              :record "left.example"
@@ -60,10 +66,13 @@
                                :record-type "a"
                                :operation "op-alpha"
                                :tool "crt.sh"
+                               :date-added 100
+                               :date-updated 200
                                :tags '("dns" "ct")))
          (_normalized (hackmode:normalize-asset asset))
          (document (hackmode:asset->starintel-document asset))
-         (json (hackmode:asset->starintel-json asset)))
+         (json (hackmode:asset->starintel-json asset))
+         (json-again (hackmode:asset->starintel-json asset)))
     (declare (ignore _normalized))
     (assert (typep document 'starintel:domain))
     (assert-equal "example.com" (starintel:domain-record document)
@@ -73,6 +82,9 @@
     (assert-equal (starintel:doc-id document)
                   (hackmode:asset-deterministic-id asset)
                   "shared canonical domain id")
+    (assert-equal (jsown:to-json json)
+                  (jsown:to-json json-again)
+                  "stable repeated StarIntel projection")
     (assert-equal "domain" (jsown:val json "dtype") "wire dtype")
     (assert-equal "example.com"
                   (jsown:val (jsown:val json "data") "record")
@@ -142,10 +154,131 @@
         (tek9:close-database db))
       (remove-test-path root))))
 
+(defun run-outbox-lifecycle-test ()
+  (let* ((root (fresh-test-path "hackmode-outbox"))
+         (db (tek9:new-database "operation" :path root))
+         (asset (make-instance 'hackmode:domain
+                               :record "offline.example"
+                               :record-type "A"
+                               :operation "offline-op"
+                               :date-added 1000
+                               :date-updated 1000))
+         (calls 0)
+         (transport
+           (lambda (entry)
+             (declare (ignore entry))
+             (incf calls)
+             (if (= calls 1)
+                 (error 'hackmode:outbox-transport-error
+                        :message "server offline")
+                 (values 202 "accepted"))))
+         (hackmode:*outbox-max-attempts* 3))
+    (unwind-protect
+         (progn
+           (tek9:open-database db)
+           ;; Enqueue is durable and byte-identical repeated projection dedupes.
+           (multiple-value-bind (entry created-p)
+               (hackmode:enqueue-asset-for-starintel asset :database db :now 1000)
+             (assert created-p)
+             (multiple-value-bind (same duplicate-created-p)
+                 (hackmode:enqueue-asset-for-starintel asset :database db :now 1001)
+               (assert (not duplicate-created-p))
+               (assert-equal (hackmode:outbox-entry-id entry)
+                             (hackmode:outbox-entry-id same)
+                             "duplicate enqueue id"))
+             (tek9:close-database db)
+             (tek9:open-database db)
+             (let ((reloaded (hackmode:fetch-outbox-entry
+                              db (hackmode:outbox-entry-id entry))))
+               (assert reloaded () "Queued outbox entry did not survive reopen.")
+               (assert (eq :queued (hackmode:outbox-entry-state reloaded)))
+               ;; Offline transport moves to retry without affecting operation data.
+               (hackmode:process-outbox-entry db reloaded transport :now 1010)
+               (assert (eq :retry (hackmode:outbox-entry-state reloaded)))
+               (assert (= 1 (hackmode:outbox-entry-attempts reloaded)))
+               (assert (= 1012 (hackmode:outbox-entry-next-attempt-at reloaded)))
+               (hackmode:discover-asset
+                (make-instance 'hackmode:domain
+                               :record "still-working.example"
+                               :record-type "A")
+                :database db)
+               (assert (= 1 (length (hackmode:query-assets
+                                     :database db :type :domain))))
+               ;; Restoration retries the same logical record and acknowledges
+               ;; broker acceptance; it does not mint another outbox entry.
+               (hackmode:process-outbox-entry db reloaded transport :now 1012)
+               (assert (eq :acknowledged (hackmode:outbox-entry-state reloaded)))
+               (assert (eq :ingest-accepted (hackmode:outbox-entry-ack-kind reloaded)))
+               (assert (= 202 (hackmode:outbox-entry-last-status reloaded)))
+               (assert (= 2 (hackmode:outbox-entry-attempts reloaded)))
+               (assert (= 1 (length (hackmode:list-outbox-entries db)))))))
+           ;; Permanent 4xx is inspectable quarantine, never silently dropped.
+           (let ((bad (make-instance 'hackmode:domain
+                                     :record "bad.example"
+                                     :record-type "A"
+                                     :date-added 2000
+                                     :date-updated 2000)))
+             (multiple-value-bind (entry created-p)
+                 (hackmode:enqueue-asset-for-starintel bad :database db :now 2000)
+               (assert created-p)
+               (hackmode:process-outbox-entry
+                db entry (lambda (ignored)
+                           (declare (ignore ignored))
+                           (values 400 "invalid"))
+                :now 2001)
+               (assert (eq :quarantined (hackmode:outbox-entry-state entry)))
+               (assert (= 1 (length (hackmode:list-outbox-entries
+                                     db :state :quarantined))))))
+           ;; Bounded retries eventually become FAILED and remain inspectable.
+           (let ((hackmode:*outbox-max-attempts* 2)
+                 (doomed (make-instance 'hackmode:domain
+                                        :record "doomed.example"
+                                        :record-type "A"
+                                        :date-added 3000
+                                        :date-updated 3000)))
+             (multiple-value-bind (entry created-p)
+                 (hackmode:enqueue-asset-for-starintel doomed :database db :now 3000)
+               (assert created-p)
+               (flet ((fail (ignored)
+                        (declare (ignore ignored))
+                        (error 'hackmode:outbox-transport-error :message "offline")))
+                 (hackmode:process-outbox-entry db entry #'fail :now 3001)
+                 (hackmode:process-outbox-entry db entry #'fail
+                                                :now (hackmode:outbox-entry-next-attempt-at entry)))
+               (assert (eq :failed (hackmode:outbox-entry-state entry)))))
+           ;; Network delivery can run on a dedicated actor and return immediately.
+           (let ((async-asset (make-instance 'hackmode:domain
+                                             :record "async.example"
+                                             :record-type "A"
+                                             :date-added 4000
+                                             :date-updated 4000)))
+             (multiple-value-bind (entry created-p)
+                 (hackmode:enqueue-asset-for-starintel async-asset :database db :now 4000)
+               (assert created-p)
+               (hackmode:start-outbox-actor
+                :database db
+                :transport (lambda (ignored)
+                             (declare (ignore ignored))
+                             (values 200 "accepted")))
+               (hackmode:drain-outbox-async :now 4001 :limit 10)
+               (assert
+                (wait-until
+                 (lambda ()
+                   (eq :acknowledged
+                       (hackmode:outbox-entry-state
+                        (hackmode:fetch-outbox-entry
+                         db (hackmode:outbox-entry-id entry))))))
+                () "Async outbox actor did not acknowledge entry.")))
+      (ignore-errors (hackmode:stop-hackmode-actor-system))
+      (when (tek9:db-is-open-p db)
+        (tek9:close-database db))
+      (remove-test-path root))))
+
 (defun run-tests ()
   (run-instance-state-test)
   (run-operation-registry-test)
   (run-starintel-projection-test)
   (run-asset-lifecycle-test)
+  (run-outbox-lifecycle-test)
   (format t "Hackmode core tests passed.~%")
   t)


### PR DESCRIPTION
## Summary
Implements #12 as a durable operation-local outbox layered on the existing Tek9 store and StarIntel HTTP ingest boundary.

### Persistence and idempotency
- outbox records live in the operation Tek9 environment under named DB `outbox`
- enqueue persists before any network call
- deterministic outbox ID uses canonical StarIntel document ID + serialized payload digest
- repeated byte-identical document/version enqueue collapses to one record
- StarIntel projection now carries Hackmode's persisted timestamps, preventing repeated projection alone from changing the wire payload

### State machine
Durable states:
- `queued`
- `sending`
- `retry`
- `acknowledged`
- `failed`
- `quarantined`

`ack-kind :ingest-accepted` explicitly means the StarIntel HTTP boundary validated and published the document to its ingest broker. It does **not** claim CouchDB persistence has already completed.

### Retry / poison handling
- bounded deterministic exponential backoff
- retries transport failures, 408, 425, 429, and 5xx
- permanent 4xx becomes inspectable `quarantined`
- retry exhaustion becomes inspectable `failed`
- `sending` is recoverable after process death, so a crash between send-start and response does not strand the record

### Transport
`make-starintel-http-transport` reuses the existing server route:

`POST /new/document/:dtype`

No RabbitMQ credentials or second message transport are added to Hackmode. Credentials/headers, if needed, are supplied by a callback immediately before HTTP request and are never persisted in the outbox record.

### Async actor
Adds a Sento outbox actor with a dedicated dispatcher:
- `start-outbox-actor`
- `drain-outbox-async`

Interactive clients can queue a drain and return immediately instead of performing network I/O on the REPL/Emacs thread.

### Tests
Extends the real clean-runner `asdf:test-system :hackmode` suite for:
- stable repeated StarIntel projection
- enqueue dedupe
- queued record survives Tek9 close/reopen
- offline transport -> retry/backoff
- operation asset writes continue while sync is failing
- restored transport -> same record acknowledged
- 400 -> quarantined
- bounded retry exhaustion -> failed
- asynchronous Sento actor drain -> acknowledged

No live StarIntel server is required; transport behavior is deterministic/fake in tests.

Closes #12 when both `core` and `monorepo` workflows pass.