### PR TITLE
Adapt Hackpert into Hackmode as an optional Prolog expert layer

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -71,6 +71,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             sbcl \
+            swi-prolog-nox \
             liblmdb-dev \
             libffi-dev \
             libssl-dev \

--- a/docs/architecture/expert-layer.org
+++ b/docs/architecture/expert-layer.org
@@ -1,0 +1,88 @@
+#+title: Hackmode Prolog Expert Layer
+
+* Status
+Issue: [[https://github.com/lost-rob0t/hackmode/issues/24][#24]]
+
+This subsystem adapts the useful reasoning ideas from the old =hackpert= prototype into the canonical Hackmode runtime.
+
+The old repository is design input, not runtime authority:
+[[https://github.com/lost-rob0t/hackpert][lost-rob0t/hackpert]]
+
+* Authority boundary
+Hackmode Common Lisp remains authoritative for:
+- operation selection and metadata;
+- typed assets and Tek9 persistence;
+- capability/provider registration;
+- provider actor execution and job lifecycle;
+- StarIntel projection and durable outbox synchronization.
+
+Prolog is advisory. It may classify, constrain, rank, and recommend based on a generated snapshot. It does not own a second operation/target database and does not execute recon tools directly.
+
+The flow is:
+
+#+begin_example
+Hackmode operation + assets + providers
+                |
+                v
+      deterministic fact snapshot
+                |
+                v
+          SWI-Prolog rules
+                |
+                v
+      typed Common Lisp result
+                |
+                v
+ explicit caller decision / provider dispatch
+#+end_example
+
+* Snapshot protocol
+The first slice projects only derived facts:
+
+#+begin_src prolog
+operation("example-op").
+asset("document-id", "domain", "example.com|A").
+provider("dns-resolve", "massdns", "domain", 20).
+#+end_src
+
+Query inputs are also facts:
+
+#+begin_src prolog
+query_target("example.com").
+query_asset("document-id").
+#+end_src
+
+Caller-controlled strings are escaped as Prolog string literals. Public Common Lisp APIs execute fixed goals; caller text is never concatenated into a goal.
+
+Snapshots are temporary and disposable. They are not persisted as canonical Hackmode state.
+
+* Public API
+- =expert-available-p= :: check whether the configured SWI-Prolog executable is usable.
+- =expert-snapshot= :: inspect the deterministic derived fact projection.
+- =expert-classify-target= :: classify a target as URL, domain, IPv4, IPv6, or unknown.
+- =expert-recommend-capabilities= :: rank registered providers compatible with a canonical asset type.
+
+Recommendations return =expert-recommendation= structures and never invoke provider handlers.
+
+* Failure model
+SWI-Prolog is optional. Normal Hackmode startup and operation use do not require it.
+
+When a caller explicitly requests expert reasoning and Prolog is unavailable, =expert-unavailable= is signaled. A failed Prolog query signals =expert-query-failed=. Neither path mutates operation state.
+
+* Hackpert migration mapping
+| Hackpert | Hackmode |
+|-
+| environment-backed current operation | canonical Common Lisp =current-operation= projection |
+| mutable =target/3= database | canonical typed asset projection |
+| =suggest_tool/*= | provider/capability recommendation |
+| =run_tool/*= | not ported; use Hackmode provider dispatch |
+| expert REPL | not ported; LISH/Emacs/other clients call Hackmode APIs |
+| state files under operation directories | not ported; snapshots are temporary |
+| scope facts | deferred until Hackmode has canonical operation-scope state |
+
+* Next slices
+- project canonical scan scope once that protocol exists;
+- add phase/workflow reasoning over provider metadata;
+- reason over normalized service/software evidence for exploit/CVE suggestions;
+- expose expert queries through the typed Hackmode shell and Emacs client;
+- allow curated user expert rules through Hackmode configuration without granting them canonical-state authority.

--- a/docs/architecture/expert-layer.org
+++ b/docs/architecture/expert-layer.org
@@ -8,36 +8,164 @@ This subsystem adapts the useful reasoning ideas from the old =hackpert= prototy
 The old repository is design input, not runtime authority:
 [[https://github.com/lost-rob0t/hackpert][lost-rob0t/hackpert]]
 
+* Core model
+Hackpert is an expert plane over Hackmode, not a second shell or database.
+
+Its important input is not just a target. The expert plane consumes canonical operation state plus typed tool-call observations: what capability was requested, its typed inputs, provider/tool identity, status, outputs, findings, and failure evidence.
+
+Its important output is a graph.
+
+#+begin_example
+canonical Hackmode state + typed tool call/result
+                    |
+                    v
+          deterministic expert snapshot
+                    |
+                    v
+              SWI-Prolog rules
+                    |
+                    v
+             typed graph delta
+       nodes + edges + evidence + advice
+                    |
+                    v
+          Common Lisp acceptance layer
+                    |
+          +---------+----------+
+          |                    |
+          v                    v
+  operation/Tek9 state     provider dispatch
+#+end_example
+
+The expert system itself never mutates the database. Common Lisp owns validation, policy, persistence, promotion, dispatch, and all other effects.
+
 * Authority boundary
 Hackmode Common Lisp remains authoritative for:
 - operation selection and metadata;
 - typed assets and Tek9 persistence;
+- expert graph persistence;
+- knowledge-base lifecycle and promotion;
 - capability/provider registration;
 - provider actor execution and job lifecycle;
 - StarIntel projection and durable outbox synchronization.
 
-Prolog is advisory. It may classify, constrain, rank, and recommend based on a generated snapshot. It does not own a second operation/target database and does not execute recon tools directly.
+Prolog may classify, constrain, rank, correlate, plan, and recommend based on generated snapshots. It may return typed graph deltas and promotion candidates. It does not own a second operation/target database and it does not execute recon or attack tools directly.
 
-The flow is:
+No Prolog rule gets a direct Tek9 mutation primitive. No rule may shell out to a capability. Effects always return to the Common Lisp boundary.
 
-#+begin_example
-Hackmode operation + assets + providers
-                |
-                v
-      deterministic fact snapshot
-                |
-                v
-          SWI-Prolog rules
-                |
-                v
-      typed Common Lisp result
-                |
-                v
- explicit caller decision / provider dispatch
-#+end_example
+* Graph contract
+The durable reasoning product is a graph rather than a bag of mutable Prolog facts.
+
+Initial node families should cover at least:
+- operation;
+- asset/target;
+- tool/capability/provider;
+- tool call;
+- observation/result;
+- finding;
+- attack/recon step;
+- playbook/plan step;
+- KB entry/source;
+- success/failure evidence.
+
+Initial edge families should cover at least:
+- tool-call -> input asset;
+- tool-call -> capability/provider;
+- tool-call -> result;
+- result -> discovered asset/finding;
+- step -> prerequisite;
+- step -> next candidate;
+- observation -> supports/refutes hypothesis;
+- attempt -> succeeded/failed-on target condition;
+- KB entry -> derived-from evidence;
+- plan/playbook -> contains step.
+
+Graph records must preserve provenance. A result derived from a tool call must retain enough identity to trace it back to the exact operation, capability/provider, input, execution/job, raw output reference, and expert/rule version.
+
+The Common Lisp wrapper validates graph deltas before persistence. Invalid, over-broad, or malformed expert output is rejected without corrupting canonical state.
+
+* Knowledge bases
+Hackmode uses multiple KB scopes instead of one mutable global Prolog state file.
+
+** Operational KB
+Operation-local working knowledge.
+
+Use it for:
+- current hypotheses and attack/recon paths;
+- failed paths and negative evidence;
+- per-target observations;
+- temporary word/fuzz candidates;
+- active plan/playbook state;
+- recent tool-call graph context.
+
+This KB may change quickly and is scoped to the current operation.
+
+** Long-term KB
+Reusable knowledge learned from completed or repeated work.
+
+Use it for:
+- validated working attack/recon patterns;
+- useful payload/fuzz/wordlist knowledge;
+- stable technique constraints;
+- reusable plan/playbook fragments;
+- repeated failure conditions worth remembering;
+- provider/tool behavior learned from evidence.
+
+Promotion from operational to long-term is a Common Lisp effect and must retain the source graph/evidence and promotion reason. Prolog may propose a promotion; it cannot perform it.
+
+** Global KB / looting
+Long-term entries may optionally be exported into a global reusable KB. This is the explicit "looting" step.
+
+Global export is never implicit. It requires an explicit Common Lisp API/policy decision so one operation cannot silently poison every future operation.
+
+The global KB is therefore an export/import surface, not hidden process-global Prolog mutation.
+
+* KB ingestion
+Wordlists, fuzz lists, payload corpora, and similar sources may be imported as expert KB material.
+
+Imports must be data, not executable Prolog source. Preserve:
+- source identity/path/reference;
+- content digest/version;
+- import timestamp;
+- source type;
+- tags/technique family;
+- operation/global scope;
+- provenance/license metadata when relevant.
+
+Imported material may become nodes/entries referenced by rules and plans. Caller-controlled strings are serialized as data and never concatenated into callable Prolog goals.
+
+* Learning from execution
+The expert layer should learn from the execution graph without granting it database authority.
+
+Examples:
+- a working attack/recon path can become a long-term-KB promotion candidate;
+- a failed path stays useful as negative evidence so orchestration does not blindly retry it;
+- repeated failures under the same target/software/context can become a reusable constraint candidate;
+- successful tool sequences can become playbook fragments;
+- new payloads/words discovered during an operation can be promoted or looted explicitly.
+
+"Learns" therefore means: expert reasoning proposes graph/KB changes, Common Lisp validates and persists them.
+
+* Expert families
+The intended Hackpert direction includes specialized experts sharing the same graph + KB substrate rather than separate mini-databases:
+- recon expert;
+- web fuzzing expert;
+- SQL injection expert;
+- out-of-band testing expert;
+- XSS expert;
+- blind-XSS expert.
+
+Each expert should consume typed canonical evidence and return graph deltas, ranked next steps, constraints, or plan changes. Actual execution remains behind Hackmode provider actors and explicit operation scope/authorization.
+
+* Attack plans and playbooks
+Plans and playbooks are first-class graph structures.
+
+A playbook describes reusable technique structure: prerequisites, candidate capabilities, expected evidence, failure branches, success branches, and stop conditions. An attack plan is the operation-specific instantiated graph for current targets and evidence.
+
+The orchestration expert may update the proposed plan graph as evidence arrives. It must retain failed branches rather than erase them, because failed attack paths are useful knowledge.
 
 * Snapshot protocol
-The first slice projects only derived facts:
+The first merged slice projects canonical state as derived facts:
 
 #+begin_src prolog
 operation("example-op").
@@ -52,11 +180,13 @@ query_target("example.com").
 query_asset("document-id").
 #+end_src
 
+The next graph/KB slice should add versioned facts for tool calls/results, graph nodes/edges, operational KB entries, long-term KB entries, and explicit global-export candidates.
+
 Caller-controlled strings are escaped as Prolog string literals. Public Common Lisp APIs execute fixed goals; caller text is never concatenated into a goal.
 
-Snapshots are temporary and disposable. They are not persisted as canonical Hackmode state.
+Snapshots are temporary and disposable. They are projections of canonical state, not canonical state themselves.
 
-* Public API
+* Public API in this first slice
 - =expert-available-p= :: check whether the configured SWI-Prolog executable is usable.
 - =expert-snapshot= :: inspect the deterministic derived fact projection.
 - =expert-classify-target= :: classify a target as URL, domain, IPv4, IPv6, or unknown.
@@ -64,10 +194,14 @@ Snapshots are temporary and disposable. They are not persisted as canonical Hack
 
 Recommendations return =expert-recommendation= structures and never invoke provider handlers.
 
+The graph/KB mutation API belongs on the Common Lisp side and is intentionally not faked into this first slice before its typed persistence contract exists.
+
 * Failure model
 SWI-Prolog is optional. Normal Hackmode startup and operation use do not require it.
 
 When a caller explicitly requests expert reasoning and Prolog is unavailable, =expert-unavailable= is signaled. A failed Prolog query signals =expert-query-failed=. Neither path mutates operation state.
+
+Malformed expert graph output must fail closed at the persistence boundary: preserve the raw expert result for diagnostics when appropriate, reject the graph delta, and keep the operation runtime healthy.
 
 * Hackpert migration mapping
 | Hackpert | Hackmode |
@@ -76,13 +210,26 @@ When a caller explicitly requests expert reasoning and Prolog is unavailable, =e
 | mutable =target/3= database | canonical typed asset projection |
 | =suggest_tool/*= | provider/capability recommendation |
 | =run_tool/*= | not ported; use Hackmode provider dispatch |
+| tool-call/output history | typed execution graph projected into Prolog |
 | expert REPL | not ported; LISH/Emacs/other clients call Hackmode APIs |
-| state files under operation directories | not ported; snapshots are temporary |
-| scope facts | deferred until Hackmode has canonical operation-scope state |
+| mutable expert state file | operational/long-term/global KBs owned by Common Lisp/Tek9 |
+| scope facts | pure reasoning over canonical operation scope once that protocol exists |
+| learned working paths | graph-backed long-term promotion candidates |
+| failed attack paths | retained graph evidence and orchestration constraints |
+| word/fuzz lists | provenance-carrying KB imports |
+
+* Prolog-RLM
+Prolog-RLM integration is a possible later control-plane layer once its runtime/API is stable enough for Hackmode.
+
+It must reuse this graph/KB/effect boundary. Prolog-RLM does not get to bypass Hackmode provider authority or canonical persistence merely because it can recursively reason.
 
 * Next slices
-- project canonical scan scope once that protocol exists;
-- add phase/workflow reasoning over provider metadata;
-- reason over normalized service/software evidence for exploit/CVE suggestions;
-- expose expert queries through the typed Hackmode shell and Emacs client;
-- allow curated user expert rules through Hackmode configuration without granting them canonical-state authority.
+1. Define and persist the typed execution graph for tool calls/results through Common Lisp and Tek9.
+2. Define operational and long-term KB storage plus explicit global-KB export/looting.
+3. Project graph + scoped KB state into fixed-goal Prolog queries and accept typed graph deltas back.
+4. Add attack-plan/playbook graph primitives with success/failure branches.
+5. Add the recon expert over the shared substrate.
+6. Add specialized web fuzzing, SQLi, OOB, XSS, and blind-XSS experts incrementally with deterministic fixtures and explicit operation scope.
+7. Import wordlists/fuzz lists as provenance-carrying KB data and add explicit promotion workflows for validated useful entries.
+8. Expose expert graph/plan/KB inspection through the typed Hackmode shell and Emacs client.
+9. Evaluate Prolog-RLM integration only after the direct Prolog expert boundary is stable and tested.

--- a/docs/architecture/ipx.org
+++ b/docs/architecture/ipx.org
@@ -1,0 +1,230 @@
+#+title: Hackmode IPX Passive Traffic Stack
+
+* Status
+Issue: [[https://github.com/lost-rob0t/hackmode/issues/26][#26]]
+Expert substrate: [[https://github.com/lost-rob0t/hackmode/issues/24][#24]]
+Foundation PR: [[https://github.com/lost-rob0t/hackmode/pull/25][#25]]
+
+* Purpose
+IPX is Hackmode's passive traffic-intelligence path.
+
+A proxy/capture boundary records traffic to a durable append-only file/spool. Hackpert consumes bounded typed projections of that evidence, derives graph/KB candidates passively, and returns typed graph deltas. Common Lisp validates every delta and owns canonical persistence and StarIntel ingest.
+
+Observing traffic never implicitly executes a provider, replays a request, scans a target, or launches an attack expert.
+
+#+begin_example
+client / browser / tool
+        |
+        v
+   IPX capture proxy
+        |
+        v
+append-only capture file/spool
+ raw evidence + offsets + digests
+        |
+        v
+capture parser/tailer actor
+        |
+        v
+typed application exchanges
+        |
+        +----------------------------+
+        |                            |
+        v                            v
+ operational graph/KB       deterministic Hackpert snapshot
+                                     |
+                                     v
+                               SWI-Prolog rules
+                                     |
+                                     v
+                              typed graph delta
+                                     |
+                                     v
+                           Common Lisp acceptance
+                                     |
+                         +-----------+-----------+
+                         |                       |
+                         v                       v
+                    Tek9/KB state        StarIntel projection
+                                                |
+                                                v
+                                         durable outbox
+                                                |
+                                                v
+                                         starintel-server
+#+end_example
+
+* Authority boundary
+- The capture file/spool is source evidence. Analysis never rewrites it.
+- Common Lisp owns capture lifecycle, parser supervision, canonical graph/KB writes, redaction policy, promotion/export, StarIntel projection, and every other effect.
+- Hackpert/Prolog may classify, correlate, fingerprint, infer, rank, and emit graph deltas.
+- Prolog receives bounded typed projections or evidence references, not arbitrary raw-file or database authority.
+- Passive analysis never grants authority for an active action.
+- Later active actions must cross the normal Hackmode operation-scope, capability/provider, and authorization boundary explicitly.
+
+* HTTP(S) first
+The first IPX protocol is HTTP request/response traffic captured through the proxy.
+
+A typed exchange should retain at least:
+- operation and capture-session identity;
+- source capture-file identity plus record/byte offset;
+- request/response correlation identity;
+- timestamp and duration;
+- method, scheme, host, port, path, and query;
+- response status;
+- bounded/redacted headers;
+- request/response body digest plus raw-evidence reference;
+- content type, content length, and encoding;
+- connection/TLS metadata when the capture boundary can provide it safely;
+- capture/parser format version.
+
+Large or sensitive bodies should normally stay in the raw evidence store and be represented by a digest/reference in canonical graph state.
+
+WebSocket, SSE, raw TCP, DNS, or other application traces can be added later through versioned adapters without changing this ownership model.
+
+* Passive Hackpert analysis
+Hackpert should derive graph/KB candidates from traffic without mutating state directly.
+
+Useful passive deductions include:
+- domains, hosts, URLs, endpoints, parameters, and observed value/type shapes;
+- request -> response -> redirect relationships;
+- API route/resource relationships;
+- login/logout/session boundaries;
+- technology/server/framework fingerprints with supporting evidence;
+- errors, debug responses, and unusual response behavior;
+- repeated or variant requests and response-shape changes;
+- observed forms, inputs, content types, and upload surfaces;
+- endpoint/parameter candidates for later explicitly authorized expert workflows;
+- traffic-derived findings with confidence and exact evidence links.
+
+Credentials, cookies, bearer tokens, API keys, session identifiers, and similar values are secret-bearing evidence. They may be represented by redacted metadata/digests when useful, but they are not reusable plaintext KB knowledge.
+
+* Graph model
+IPX extends the expert graph from =expert-layer.org= rather than creating a parallel traffic database.
+
+Useful node families include:
+- capture session;
+- capture source/file;
+- connection;
+- HTTP request;
+- HTTP response;
+- endpoint;
+- parameter;
+- observed value/type;
+- header/cookie metadata;
+- technology fingerprint;
+- traffic-derived finding;
+- raw evidence reference.
+
+Useful edge families include:
+- capture-session -> contains exchange;
+- request -> targets endpoint;
+- request -> has parameter;
+- request -> produced response;
+- response -> redirects-to endpoint;
+- response -> supports fingerprint;
+- exchange -> observed asset;
+- finding -> derived-from exchange/evidence;
+- parameter -> observed-at endpoint;
+- session/auth boundary -> evidenced-by exchanges.
+
+Every derived node/edge must retain provenance back to exact source capture records and the expert/rule version that produced it.
+
+* KB lifecycle
+Traffic-derived knowledge uses the same scopes as Hackpert.
+
+** Operational KB
+Per-operation live traffic intelligence:
+- endpoint and parameter graph;
+- fingerprints;
+- observed flows;
+- session/auth relationships;
+- traffic-derived hypotheses/findings;
+- recent passive-analysis context.
+
+** Long-term KB
+Explicitly promoted reusable knowledge:
+- validated fingerprint patterns;
+- parser/normalization patterns;
+- stable technique constraints;
+- reusable workflow/playbook fragments discovered from evidence.
+
+** Global KB / looting
+Explicit export only.
+
+Never loot credentials, cookies, bearer tokens, API keys, session identifiers, private body content, or other secret-bearing raw evidence into a global KB.
+
+* Secret and privacy handling
+Raw capture data may contain credentials or private application data and therefore has a stricter boundary than derived graph facts.
+
+Requirements:
+- configurable header/body capture and size limits;
+- canonical redaction of =Authorization=, cookies, common API-key fields, and configured secret fields before expert/StarIntel projection;
+- digests/evidence references survive redaction so facts remain traceable to authorized raw evidence;
+- secrets do not enter Prolog source, normal logs, StarIntel documents, long-term KB, or global KB by default;
+- raw-capture retention/deletion policy is explicit and operation-scoped;
+- malformed or untrusted captured content is always treated as data, never executable Prolog or Lisp input.
+
+* File/spool contract
+The initial capture spool should be boring and recoverable:
+- append-only while capturing;
+- deterministic versioned framing;
+- durable parser checkpoint/offset;
+- idempotent replay;
+- explicit file rotation identity;
+- corrupt/truncated records quarantined and inspectable;
+- capture continues when Hackpert or StarIntel is unavailable;
+- replay never duplicates logical graph records.
+
+Raw evidence identity should be stable enough that a graph fact can cite a capture file/session and record/offset range without depending on mutable filenames alone.
+
+* StarIntel ingest
+Hackpert never posts directly to StarIntel.
+
+The path is:
+
+#+begin_example
+capture evidence
+ -> typed exchange
+ -> passive Hackpert graph delta
+ -> Common Lisp validation
+ -> canonical Hackmode graph/assets/findings/relations
+ -> StarIntel projection
+ -> durable outbox
+ -> starintel-server
+#+end_example
+
+Reuse canonical StarIntel identities and provenance. Transport publication alone is not proof of ingest acceptance; existing Hackmode durable outbox/ack semantics remain authoritative for synchronization state.
+
+* Failure behavior
+- Proxy capture failure is explicit and does not corrupt existing operation state.
+- Parser failure leaves the raw evidence intact and records/quarantines the bad region.
+- Hackpert unavailable means capture + parsing may continue; passive expert analysis is deferred.
+- Hackpert malformed output is rejected at the Common Lisp acceptance boundary.
+- StarIntel unavailable means capture + local analysis continue and accepted projections remain queued locally.
+- Reprocessing the same evidence remains idempotent.
+
+* Implementation order
+1. Versioned append-only IPX capture format and capture-session identity.
+2. Proxy adapter producing deterministic HTTP request/response records.
+3. Tail/replay parser actor with durable checkpoints and quarantine.
+4. Typed exchange/evidence nodes and edges in the Hackmode execution graph.
+5. Redaction and body-reference policy.
+6. Passive Hackpert snapshot facts for exchanges.
+7. Typed passive-analysis graph-delta contract.
+8. Common Lisp graph-delta acceptance and operational-KB/Tek9 persistence.
+9. StarIntel projection/outbox for accepted traffic-derived assets/findings/relations.
+10. LISH/Emacs controls for capture status, replay, passive analysis, graph inspection, and ingest state.
+
+* Acceptance proof
+1. Start a capture session for an operation.
+2. Send deterministic fixture HTTP traffic through the proxy.
+3. The capture file records framed request/response evidence with stable correlation and provenance offsets.
+4. Restart the parser and resume from its checkpoint without duplicate graph state.
+5. Hackpert derives endpoint/parameter/fingerprint graph facts passively.
+6. Passive analysis executes zero providers and zero active requests.
+7. Common Lisp validates and persists accepted graph deltas.
+8. Secret headers/fields are absent from Prolog projections, normal logs, StarIntel documents, long-term KB, and global KB by default.
+9. StarIntel can be offline while capture and local analysis continue.
+10. Reconnect drains accepted projections through the durable outbox exactly/idempotently.
+11. Replaying the same capture does not duplicate logical assets, findings, or relations.

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
             pkg-config
             sbcl
             sbclPackages.mcclim
+            swiProlog
             glib
             openssl
             # Hacking tools used

--- a/source/hackmode-core/expert.lisp
+++ b/source/hackmode-core/expert.lisp
@@ -1,0 +1,234 @@
+(in-package :hackmode)
+
+(defparameter *expert-program* "swipl"
+  "SWI-Prolog executable used by the optional Hackmode expert layer.")
+
+(define-condition expert-unavailable (error)
+  ((program :initarg :program :reader expert-unavailable-program))
+  (:report (lambda (condition stream)
+             (format stream "Hackmode expert layer is unavailable: ~a was not found or could not run."
+                     (expert-unavailable-program condition)))))
+
+(define-condition expert-query-failed (error)
+  ((status :initarg :status :reader expert-query-failed-status)
+   (stderr :initarg :stderr :reader expert-query-failed-stderr))
+  (:report (lambda (condition stream)
+             (format stream "Hackmode expert query failed with status ~a~@[: ~a~]"
+                     (expert-query-failed-status condition)
+                     (let ((stderr (expert-query-failed-stderr condition)))
+                       (and stderr
+                            (plusp (length stderr))
+                            stderr))))))
+
+(defstruct expert-recommendation
+  capability
+  provider
+  priority)
+
+(defun expert-available-p (&optional (program *expert-program*))
+  "Return true when PROGRAM can execute as SWI-Prolog.
+
+Hackmode does not require Prolog for normal operation; this probe is intentionally
+isolated from startup and canonical state initialization."
+  (handler-case
+      (progn
+        (uiop:run-program (list program "--version")
+                          :output nil
+                          :error-output nil)
+        t)
+    (error () nil)))
+
+(defun expert-rules-path ()
+  (asdf:system-relative-pathname :hackmode "expert/hackmode_expert.pl"))
+
+(defun prolog-write-string (stream value)
+  "Write VALUE as an escaped SWI-Prolog string literal."
+  (write-char #\" stream)
+  (loop for character across (or value "")
+        for code = (char-code character)
+        do (case character
+             (#\\ (write-string "\\\\" stream))
+             (#\" (write-string "\\\"" stream))
+             (#\Newline (write-string "\\n" stream))
+             (#\Return (write-string "\\r" stream))
+             (#\Tab (write-string "\\t" stream))
+             (otherwise
+              (if (or (< code 32) (= code 127))
+                  (format stream "\\x~x\\" code)
+                  (write-char character stream)))))
+  (write-char #\" stream))
+
+(defun prolog-write-value (stream value)
+  (etypecase value
+    (integer (princ value stream))
+    (string (prolog-write-string stream value))))
+
+(defun write-expert-fact (stream predicate &rest values)
+  (format stream "~a(" predicate)
+  (loop for value in values
+        for first = t then nil
+        do (unless first (write-char #\, stream))
+           (prolog-write-value stream value))
+  (write-string ")." stream)
+  (terpri stream))
+
+(defun expert-current-assets ()
+  (if (and *db* (tek9:db-is-open-p *db*))
+      (query-assets :database *db*)
+      nil))
+
+(defun expert-type-name (value)
+  (let* ((raw (cond
+                ((null value) "any")
+                ((symbolp value) (symbol-name value))
+                (t (princ-to-string value))))
+         (name (string-downcase raw))
+         (colon (position #\: name :from-end t)))
+    (when colon
+      (setf name (subseq name (1+ colon))))
+    (cond
+      ((member name '("meta" "t") :test #'string=) "any")
+      ((string= name "cert") "certificate")
+      (t name))))
+
+(defun expert-asset-value (asset)
+  (or (ignore-errors (asset-canonical-value asset))
+      (doc-id asset)
+      ""))
+
+(defun expert-snapshot (&key
+                          (operation (current-operation))
+                          (assets (expert-current-assets))
+                          (providers (list-capability-providers))
+                          query-target
+                          query-asset)
+  "Return a deterministic Prolog fact snapshot of canonical Hackmode state.
+
+The snapshot is derived data only. It never becomes operation authority and is
+safe to discard after a query. QUERY-TARGET and QUERY-ASSET are internal query
+inputs serialized as data facts so caller-controlled text never becomes a Prolog
+goal."
+  (with-output-to-string (stream)
+    (when operation
+      (write-expert-fact stream "operation" (operation-name operation)))
+    (dolist (asset
+             (sort (copy-list assets) #'string<
+                   :key (lambda (item) (or (doc-id item) ""))))
+      (write-expert-fact stream
+                         "asset"
+                         (or (doc-id asset) "")
+                         (asset-kind asset)
+                         (expert-asset-value asset)))
+    (dolist (provider
+             (sort (copy-list providers)
+                   (lambda (left right)
+                     (let ((lp (capability-provider-priority left))
+                           (rp (capability-provider-priority right)))
+                       (or (< lp rp)
+                           (and (= lp rp)
+                                (string<
+                                 (format nil "~a/~a"
+                                         (capability-provider-capability left)
+                                         (capability-provider-name left))
+                                 (format nil "~a/~a"
+                                         (capability-provider-capability right)
+                                         (capability-provider-name right))))))))))
+      (write-expert-fact stream
+                         "provider"
+                         (capability-provider-capability provider)
+                         (capability-provider-name provider)
+                         (expert-type-name
+                          (capability-provider-input-type provider))
+                         (capability-provider-priority provider)))
+    (when query-target
+      (write-expert-fact stream "query_target" query-target))
+    (when query-asset
+      (write-expert-fact stream "query_asset" query-asset))))
+
+(defun expert-temp-path ()
+  (merge-pathnames
+   (format nil "hackmode-expert-~d-~d.pl"
+           (get-universal-time)
+           (random 1000000000))
+   (uiop:temporary-directory)))
+
+(defun run-expert-goal (goal snapshot)
+  (unless (expert-available-p)
+    (error 'expert-unavailable :program *expert-program*))
+  (let ((path (expert-temp-path)))
+    (unwind-protect
+         (progn
+           (with-open-file (stream path
+                                   :direction :output
+                                   :if-exists :supersede
+                                   :if-does-not-exist :create)
+             (write-string snapshot stream))
+           (multiple-value-bind (stdout stderr status)
+               (uiop:run-program
+                (list *expert-program*
+                      "-q"
+                      "-f" (namestring (expert-rules-path))
+                      "-s" (namestring path)
+                      "-g" goal
+                      "-t" "halt")
+                :output :string
+                :error-output :string
+                :ignore-error-status t)
+             (unless (or (null status) (zerop status))
+               (error 'expert-query-failed :status status :stderr stderr))
+             (or stdout "")))
+      (when (probe-file path)
+        (delete-file path)))))
+
+(defun expert-classify-target (target &key
+                                      (operation (current-operation))
+                                      (assets (expert-current-assets))
+                                      (providers (list-capability-providers)))
+  "Classify TARGET using the Prolog expert rules and return a keyword.
+
+TARGET is serialized only as a data fact; it cannot alter the executed Prolog
+goal."
+  (let* ((snapshot (expert-snapshot :operation operation
+                                    :assets assets
+                                    :providers providers
+                                    :query-target target))
+         (output (string-trim '(#\Space #\Tab #\Newline #\Return)
+                              (run-expert-goal "emit_classification" snapshot))))
+    (cond
+      ((string= output "url") :url)
+      ((string= output "domain") :domain)
+      ((string= output "ipv4") :ipv4)
+      ((string= output "ipv6") :ipv6)
+      (t :unknown))))
+
+(defun parse-expert-recommendation (line)
+  (let ((parts (uiop:split-string line :separator '(#\Tab))))
+    (unless (= 3 (length parts))
+      (error 'expert-query-failed
+             :status :invalid-output
+             :stderr (format nil "Invalid expert recommendation row: ~s" line)))
+    (make-expert-recommendation
+     :priority (parse-integer (first parts))
+     :capability (second parts)
+     :provider (third parts))))
+
+(defun expert-recommend-capabilities (asset-or-id &key
+                                                    (operation (current-operation))
+                                                    (assets (expert-current-assets))
+                                                    (providers (list-capability-providers)))
+  "Return deterministic Prolog recommendations for a canonical asset.
+
+ASSET-OR-ID may be a Hackmode asset or its document ID. Recommendations are
+advisory only; this function never executes a provider or writes operation state."
+  (let* ((asset-id (etypecase asset-or-id
+                     (meta (doc-id asset-or-id))
+                     (string asset-or-id)))
+         (snapshot (expert-snapshot :operation operation
+                                    :assets assets
+                                    :providers providers
+                                    :query-asset asset-id))
+         (output (run-expert-goal "emit_recommendations" snapshot)))
+    (loop for line in (uiop:split-string output :separator '(#\Newline))
+          for trimmed = (string-trim '(#\Space #\Tab #\Return) line)
+          unless (zerop (length trimmed))
+            collect (parse-expert-recommendation trimmed))))

--- a/source/hackmode-core/expert.lisp
+++ b/source/hackmode-core/expert.lisp
@@ -96,6 +96,19 @@ isolated from startup and canonical state initialization."
       (doc-id asset)
       ""))
 
+(defun expert-provider< (left right)
+  (let ((left-priority (capability-provider-priority left))
+        (right-priority (capability-provider-priority right)))
+    (or (< left-priority right-priority)
+        (and (= left-priority right-priority)
+             (string<
+              (format nil "~a/~a"
+                      (capability-provider-capability left)
+                      (capability-provider-name left))
+              (format nil "~a/~a"
+                      (capability-provider-capability right)
+                      (capability-provider-name right)))))))
+
 (defun expert-snapshot (&key
                           (operation (current-operation))
                           (assets (expert-current-assets))
@@ -120,19 +133,7 @@ goal."
                          (asset-kind asset)
                          (expert-asset-value asset)))
     (dolist (provider
-             (sort (copy-list providers)
-                   (lambda (left right)
-                     (let ((lp (capability-provider-priority left))
-                           (rp (capability-provider-priority right)))
-                       (or (< lp rp)
-                           (and (= lp rp)
-                                (string<
-                                 (format nil "~a/~a"
-                                         (capability-provider-capability left)
-                                         (capability-provider-name left))
-                                 (format nil "~a/~a"
-                                         (capability-provider-capability right)
-                                         (capability-provider-name right))))))))))
+             (sort (copy-list providers) #'expert-provider<))
       (write-expert-fact stream
                          "provider"
                          (capability-provider-capability provider)

--- a/source/hackmode-core/expert/hackmode_expert.pl
+++ b/source/hackmode-core/expert/hackmode_expert.pl
@@ -1,0 +1,58 @@
+:- use_module(library(pcre)).
+
+:- dynamic operation/1.
+:- dynamic asset/3.
+:- dynamic provider/4.
+:- dynamic query_target/1.
+:- dynamic query_asset/1.
+
+classify_target(Input, url) :-
+    re_match('(?i)^https?://[^[:space:]]+$', Input), !.
+
+classify_target(Input, ipv4) :-
+    re_match('^(?:(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})\\.){3}(?:25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})$', Input), !.
+
+classify_target(Input, ipv6) :-
+    split_string(Input, ":", "", Parts),
+    length(Parts, Count),
+    Count >= 3,
+    Count =< 9,
+    member("", Parts),
+    forall(member(Part, Parts), ipv6_part(Part)), !.
+
+classify_target(Input, ipv6) :-
+    split_string(Input, ":", "", Parts),
+    length(Parts, 8),
+    forall(member(Part, Parts), ipv6_part(Part)), !.
+
+classify_target(Input, domain) :-
+    re_match('(?i)^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,63}$', Input), !.
+
+classify_target(_, unknown).
+
+ipv6_part("").
+ipv6_part(Part) :-
+    re_match('^[0-9A-Fa-f]{1,4}$', Part).
+
+compatible_kind("any", _).
+compatible_kind(Kind, Kind).
+
+recommend(AssetId, Capability, ProviderName, Priority) :-
+    asset(AssetId, Kind, _),
+    provider(Capability, ProviderName, InputKind, Priority),
+    compatible_kind(InputKind, Kind).
+
+emit_classification :-
+    query_target(Input),
+    classify_target(Input, Type),
+    format('~a~n', [Type]).
+
+emit_recommendations :-
+    query_asset(AssetId),
+    findall(Priority-Capability-ProviderName,
+            recommend(AssetId, Capability, ProviderName, Priority),
+            Rows),
+    sort(Rows, Sorted),
+    forall(member(Priority-Capability-ProviderName, Sorted),
+           format('~d\t~a\t~a~n',
+                  [Priority, Capability, ProviderName])).

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -1,8 +1,10 @@
 (asdf:defsystem :hackmode-tests
-  :description "Regression tests for Hackmode core state and asset lifecycle"
+  :description "Regression tests for Hackmode core state, asset lifecycle, and expert reasoning"
   :depends-on (#:hackmode)
   :serial t
-  :components ((:file "tests/core-state"))
+  :components ((:file "tests/core-state")
+               (:file "tests/expert"))
   :perform (test-op (op system)
              (declare (ignore op system))
-             (uiop:symbol-call :hackmode-tests :run-tests)))
+             (uiop:symbol-call :hackmode-tests :run-tests)
+             (uiop:symbol-call :hackmode-tests :run-expert-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -30,6 +30,7 @@
                (:file "outbox-actor")
                (:file "providers")
                (:file "provider-actor")
+               (:file "expert")
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -194,6 +194,21 @@
    :drain-outbox-async
    ;; Provider actor
    :start-provider-supervisor
-   :dispatch-capability))
+   :dispatch-capability
+   ;; Optional Prolog expert layer
+   :*expert-program*
+   :expert-unavailable
+   :expert-unavailable-program
+   :expert-query-failed
+   :expert-query-failed-status
+   :expert-query-failed-stderr
+   :expert-recommendation
+   :expert-recommendation-capability
+   :expert-recommendation-provider
+   :expert-recommendation-priority
+   :expert-available-p
+   :expert-snapshot
+   :expert-classify-target
+   :expert-recommend-capabilities))
 
 (in-package :hackmode)

--- a/source/hackmode-core/tests/expert.lisp
+++ b/source/hackmode-core/tests/expert.lisp
@@ -1,0 +1,137 @@
+(in-package :hackmode-tests)
+
+(defun assert-expert-unavailable (thunk)
+  (let ((raised nil))
+    (handler-case
+        (funcall thunk)
+      (hackmode:expert-unavailable ()
+        (setf raised t)))
+    (assert raised () "Expected HACKMODE:EXPERT-UNAVAILABLE.")))
+
+(defun run-expert-snapshot-test ()
+  (let* ((operation (make-instance 'hackmode:operation
+                                   :name "expert-op"
+                                   :dir "/tmp/expert-op/"))
+         (asset (make-instance 'hackmode:domain
+                               :id "asset-domain-1"
+                               :record "Example.COM."
+                               :record-type "A"
+                               :operation "expert-op"))
+         (before-id (hackmode:doc-id asset)))
+    (hackmode:normalize-asset asset)
+    (hackmode:clear-capability-providers)
+    (unwind-protect
+         (progn
+           (hackmode:register-capability-provider
+            :dns-resolve :fixture
+            (lambda (input)
+              (declare (ignore input))
+              (error "Expert recommendation must not execute providers."))
+            :input-type 'hackmode:domain
+            :output-types '(hackmode:host)
+            :priority 20)
+           (let ((snapshot
+                   (hackmode:expert-snapshot
+                    :operation operation
+                    :assets (list asset)
+                    :providers (hackmode:list-capability-providers)
+                    :query-target "evil.example\"). halt. %")))
+             (assert (search "operation(\"expert-op\")." snapshot))
+             (assert (search "asset(\"asset-domain-1\",\"domain\",\"example.com|A\")."
+                             snapshot))
+             (assert (search "provider(\"dns-resolve\",\"fixture\",\"domain\",20)."
+                             snapshot))
+             (assert (search "\\\"" snapshot) ()
+                     "Embedded quotes must be escaped in Prolog data facts.")))
+           (assert-equal before-id (hackmode:doc-id asset)
+                         "expert snapshot does not mutate asset identity"))
+      (hackmode:clear-capability-providers))))
+
+(defun run-expert-unavailable-test ()
+  (let ((hackmode:*expert-program* "hackmode-swipl-definitely-missing"))
+    (assert (not (hackmode:expert-available-p)))
+    (assert-expert-unavailable
+     (lambda ()
+       (hackmode:expert-classify-target
+        "example.com"
+        :operation nil
+        :assets nil
+        :providers nil)))))
+
+(defun run-live-expert-test ()
+  (unless (hackmode:expert-available-p)
+    (format t "Skipping live Hackmode expert tests: swipl unavailable.~%")
+    (return-from run-live-expert-test t))
+  (assert-equal :domain
+                (hackmode:expert-classify-target
+                 "example.com" :operation nil :assets nil :providers nil)
+                "domain classification")
+  (assert-equal :url
+                (hackmode:expert-classify-target
+                 "https://example.com/a?b=1"
+                 :operation nil :assets nil :providers nil)
+                "URL classification")
+  (assert-equal :ipv4
+                (hackmode:expert-classify-target
+                 "192.0.2.10" :operation nil :assets nil :providers nil)
+                "IPv4 classification")
+  (assert-equal :ipv6
+                (hackmode:expert-classify-target
+                 "::1" :operation nil :assets nil :providers nil)
+                "IPv6 classification")
+  (assert-equal :unknown
+                (hackmode:expert-classify-target
+                 "evil.example\"). halt. %"
+                 :operation nil :assets nil :providers nil)
+                "quoted input remains inert data")
+  (let ((asset (make-instance 'hackmode:domain
+                              :id "asset-domain-2"
+                              :record "example.net"
+                              :record-type "A")))
+    (hackmode:normalize-asset asset)
+    (hackmode:clear-capability-providers)
+    (unwind-protect
+         (progn
+           (flet ((must-not-run (input)
+                    (declare (ignore input))
+                    (error "Expert recommendation executed a provider.")))
+             (hackmode:register-capability-provider
+              :dns-resolve :slow #'must-not-run
+              :input-type 'hackmode:domain :priority 50)
+             (hackmode:register-capability-provider
+              :dns-resolve :fast #'must-not-run
+              :input-type 'hackmode:domain :priority 10)
+             (hackmode:register-capability-provider
+              :crawl :crawler #'must-not-run
+              :input-type 'hackmode:url :priority 1)
+             (hackmode:register-capability-provider
+              :inspect :generic #'must-not-run
+              :input-type t :priority 100))
+           (let* ((recommendations
+                    (hackmode:expert-recommend-capabilities
+                     asset
+                     :operation nil
+                     :assets (list asset)
+                     :providers (hackmode:list-capability-providers)))
+                  (rows
+                    (mapcar
+                     (lambda (recommendation)
+                       (list (hackmode:expert-recommendation-priority recommendation)
+                             (hackmode:expert-recommendation-capability recommendation)
+                             (hackmode:expert-recommendation-provider recommendation)))
+                     recommendations)))
+             (assert-equal
+              '((10 "dns-resolve" "fast")
+                (50 "dns-resolve" "slow")
+                (100 "inspect" "generic"))
+              rows
+              "deterministic compatible provider recommendations")))
+      (hackmode:clear-capability-providers)))
+  t)
+
+(defun run-expert-tests ()
+  (run-expert-snapshot-test)
+  (run-expert-unavailable-test)
+  (run-live-expert-test)
+  (format t "Hackmode expert tests passed.~%")
+  t)

--- a/source/hackmode-core/tests/expert.lisp
+++ b/source/hackmode-core/tests/expert.lisp
@@ -42,7 +42,7 @@
              (assert (search "provider(\"dns-resolve\",\"fixture\",\"domain\",20)."
                              snapshot))
              (assert (search "\\\"" snapshot) ()
-                     "Embedded quotes must be escaped in Prolog data facts.")))
+                     "Embedded quotes must be escaped in Prolog data facts."))
            (assert-equal before-id (hackmode:doc-id asset)
                          "expert snapshot does not mutate asset identity"))
       (hackmode:clear-capability-providers))))


### PR DESCRIPTION
## Summary
Adapts the useful Hackpert reasoning ideas into the canonical Hackmode runtime without importing its legacy operation/target state model or direct tool runner.

Closes #24 when the foundational expert bridge is accepted; the expanded graph/KB/expert-engine program is explicitly tracked in #24 as follow-on implementation slices rather than being hidden in comments.

The passive traffic-intelligence path is now tracked separately as **IPX** in #26, with its architecture contract added to this PR in `docs/architecture/ipx.org`.

## What changed
- optional SWI-Prolog expert bridge in Hackmode core
- deterministic projection of current operation, typed assets, and capability providers into disposable Prolog facts
- fixed-goal query boundary with escaped data facts
- target classification for URL/domain/IPv4/IPv6/unknown
- deterministic provider/capability recommendations by typed input compatibility and priority
- typed Common Lisp recommendation results and explicit unavailable/query-failed conditions
- no provider execution or Tek9 mutation from expert recommendation
- regression coverage for escaping/injection safety, missing SWI behavior, live classification, recommendation ordering, and read-only behavior
- SWI-Prolog added to CI and Nix dev shell
- expanded Hackpert architecture incorporating graph-shaped outputs, scoped KBs, learning/promotion, plans/playbooks, and expert-family direction
- added IPX passive traffic architecture: capture proxy -> append-only evidence spool -> typed exchange parser -> passive Hackpert graph delta -> Common Lisp acceptance -> Tek9/KB + StarIntel durable outbox

## Architecture correction from #24
Hackpert is an expert plane that consumes canonical state plus **typed tool calls/results** and ultimately returns a **typed graph delta**.

```text
Hackmode state + tool call/result
            -> deterministic snapshot
            -> Prolog reasoning
            -> graph delta
            -> Common Lisp validation/effect boundary
            -> Tek9/KB and/or provider dispatch
```

Prolog never mutates canonical state. The Common Lisp wrapper owns every effect.

The graph direction covers tool calls, inputs, outputs, findings, discovered assets, success/failure evidence, attack/recon steps, plans/playbooks, KB provenance, and—through IPX—passively observed application traffic.

## KB direction
The architecture defines three scopes:
- **operational KB** — per-operation working knowledge, failed paths, current observations, temporary fuzz/word candidates, active plans, recent execution/traffic graph context
- **long-term KB** — reusable validated working paths, useful payload/fuzz/word knowledge, stable constraints, repeated failure conditions, reusable playbook/fingerprint fragments
- **global KB / looting** — optional explicit export of selected long-term knowledge for reuse across operations

Prolog may propose promotion/export candidates. Common Lisp validates and persists them. Global looting is explicit, never implicit.

## IPX passive traffic stack (#26)
IPX adds a passive evidence path without weakening the Hackpert authority boundary:

```text
client/browser/tool
    -> IPX capture proxy
    -> append-only capture file/spool
    -> parser/tailer actor
    -> typed HTTP/application exchanges
    -> passive Hackpert analysis
    -> typed graph delta
    -> Common Lisp validation
    -> Tek9 operational graph/KB
    -> StarIntel projection + durable outbox
```

Key invariants:
- capture evidence is append-only/immutable from the analyzer's perspective
- Hackpert never rewrites capture files or directly ingests StarIntel documents
- passive analysis never implicitly performs scanning, replay, exploitation, or provider execution
- raw traffic may contain secrets, so derived Prolog/StarIntel/long-term/global projections redact credentials/cookies/tokens by default and retain evidence references/digests instead
- Hackpert or StarIntel may be offline while capture continues
- replaying the same capture is idempotent
- HTTP(S) is the first protocol; WebSocket/SSE/raw TCP/DNS can be later adapters

See `docs/architecture/ipx.org` and #26 for the full contract and acceptance proof.

## Learning / expert goals captured from #24
- import wordlists/fuzz lists as provenance-carrying KB data
- promote validated working attacks/recon paths into long-term KB candidates
- retain failed attack paths as negative graph evidence for orchestration
- make attack plans and playbooks first-class graph structures
- build shared-substrate experts for recon, web fuzzing, SQLi, OOB testing, XSS, and blind XSS
- evaluate Prolog-RLM later, only after this direct graph/KB/effect boundary is stable

## Deliberately not ported
- `HACKMODE_OP` / `HACKMODE_PATH` authority
- `targets.txt` / scope text files / mutable expert state files
- Hackpert REPL
- Prolog `run_tool`
- direct process execution from expert rules
- direct Prolog mutation of Tek9, KB state, capture evidence, or StarIntel

Execution stays behind Hackmode's existing provider/job path.

## Scope of this PR
This PR remains the **foundation slice**: optional Prolog bridge, safe snapshots, classification, recommendations, tests, and the now-correct architecture contracts.

The next implementation slices tracked in #24/#26 are:
1. typed tool-call/result execution graph persisted by Common Lisp/Tek9
2. operational + long-term KB storage
3. explicit global-KB export/looting API
4. graph/KB facts into Prolog + typed graph deltas back
5. attack-plan/playbook primitives
6. IPX append-only traffic capture + parser/replay substrate
7. passive Hackpert traffic analysis + StarIntel projection/outbox
8. recon expert, then specialized fuzzing/SQLi/OOB/XSS/blind-XSS experts
9. provenance-aware wordlist/fuzz-list import and success/failure promotion workflows
10. LISH/Emacs graph/plan/KB/IPX inspection
11. possible Prolog-RLM integration later