### PR TITLE
Move RAGE worker scope into Hackmode with StarIntel BBP-only policy

### DIFF
--- a/docs/architecture/rage-workers.org
+++ b/docs/architecture/rage-workers.org
@@ -1,0 +1,110 @@
+#+title: Hackmode RAGE Workers
+
+* Status
+
+This document records the worker-ownership migration tracked by GitHub issues
+#30 and #31.
+
+The old autonomous StarIntel product worker roles are retired:
+
+- =lost-rob0t/starintel-auto-research#170=
+- =starintel-labs/RAGE#3=
+
+Their historical artifacts remain records, but they are no longer executable
+worker contracts.
+
+* Ownership
+
+Hackmode owns RAGE workers used for cyber operations.
+
+A worker is operation-driven rather than GitHub-issue-driven.  It receives an
+explicit operation, target scope, objective, mode, run identity, and candidate
+cyber work.  Later slices attach the same identity to Hackpert reasoning,
+provider dispatch, execution graph nodes, operational KB state, and LISH.
+
+The old RAGE Task Steward pattern that scans arbitrary repositories for the
+highest-priority engineering issue is not the scheduler for this worker class.
+
+* StarIntel boundary
+
+StarIntel may be touched only in the authorized cyber / BBP sense.  Examples:
+
+- recon and attack-surface enumeration;
+- passive IPX/application-traffic analysis;
+- source-assisted security review;
+- vulnerability research and validation;
+- CVE correlation;
+- authentication, authorization, and session testing;
+- bounded fuzzing/protocol/API testing;
+- exploitability, foothold, and privilege-escalation reasoning;
+- finding/report generation;
+- projection of accepted security evidence/findings into StarIntel.
+
+The worker must not use StarIntel repositories as a general engineering
+backlog.  Feature implementation, architecture/design work, refactors,
+infrastructure work, UI work, and ordinary bug fixing are outside this worker
+class even when an issue is approved or high priority.
+
+If cyber work discovers a defect that needs remediation, the worker records a
+finding and hands it to the normal StarIntel development workflow.  Security
+analysis does not silently turn into product implementation authority.
+
+* First typed scope contract
+
+Core exposes a small pure policy substrate:
+
+- =rage-worker= -- worker/run identity plus Hackpert mode and operation/objective;
+- =rage-work-item= -- candidate work, explicit scope, target/source, and operation authorization;
+- =rage-scope-decision= -- allow/deny plus a stable reason;
+- =authorize-rage-work-item= -- pure authorization decision;
+- =rage-worker-can-accept-p= -- worker-facing scope check.
+
+The first mode vocabulary is =:passive= and =:active=.  Prolog-RLM/LLM is a
+later reasoning/escalation extension inside the open worker loop rather than an
+implicit new authority mode.
+
+The first cyber task vocabulary includes recon, passive analysis,
+source-security review, vulnerability research/validation, CVE correlation,
+auth/session testing, fuzzing, protocol/API testing, SQLi/XSS/OOB testing,
+exploitability/foothold/privilege-escalation reasoning, findings/reports, and
+security projection/handoff.
+
+For =:starintel= scoped work, anything outside that closed cyber vocabulary is
+rejected with =:starintel-cyber-only=.  For other scopes, non-cyber work is
+rejected with =:non-cyber-work=.  An item outside the containing operation's
+explicit authorization is rejected first with =:operation-not-authorized=.
+
+* Worker concurrency
+
+Worker ID and run ID are distinct first-class values.  Multiple RAGE workers
+may therefore share an operation graph/KB later without sharing run-local plan
+state or tool execution identity.
+
+Future persistence must key mutations/tool calls by operation + worker/run
+identity and use canonical Hackmode conflict/effect boundaries rather than
+per-worker shadow databases.
+
+* Open loop
+
+The worker loop is intentionally extensible:
+
+#+begin_example
+scope + objective
+  -> graph/KB/assets
+  -> select cyber work
+  -> Hackpert reasoning
+  -> typed provider/action execution when active
+  -> observe result
+  -> graph + operational-KB mutation
+  -> evaluate objective / stop / escalation
+  -> repeat or emit finding/report
+#+end_example
+
+Objectives are data rather than hard-coded end states.  Expected future
+examples include foothold required, final privilege/UID requirements,
+retrieve/correlate CVEs, prove/reject a vulnerability hypothesis, or satisfy an
+expert-system graph predicate.
+
+Future ZeroForge and Prolog-RLM integrations plug into this same loop.  They do
+not introduce a second StarIntel task scheduler or bypass the Hackmode
+provider/state boundary.

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -1,10 +1,12 @@
 (asdf:defsystem :hackmode-tests
-  :description "Regression tests for Hackmode core state, asset lifecycle, and expert reasoning"
+  :description "Regression tests for Hackmode core state, asset lifecycle, expert reasoning, and RAGE worker scope"
   :depends-on (#:hackmode)
   :serial t
   :components ((:file "tests/core-state")
-               (:file "tests/expert"))
+               (:file "tests/expert")
+               (:file "tests/rage-worker"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
-             (uiop:symbol-call :hackmode-tests :run-expert-tests)))
+             (uiop:symbol-call :hackmode-tests :run-expert-tests)
+             (uiop:symbol-call :hackmode-tests :run-rage-worker-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -31,6 +31,7 @@
                (:file "providers")
                (:file "provider-actor")
                (:file "expert")
+               (:file "rage-worker")
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/rage-worker.lisp
+++ b/source/hackmode-core/rage-worker.lisp
@@ -1,0 +1,140 @@
+(in-package :hackmode)
+
+(defparameter +rage-worker-modes+ '(:passive :active)
+  "Hackpert execution modes supported by the RAGE worker substrate.")
+
+(defparameter +rage-cyber-task-kinds+
+  '(:recon
+    :passive-analysis
+    :source-security-review
+    :vulnerability-research
+    :vulnerability-validation
+    :cve-correlation
+    :authentication-testing
+    :authorization-testing
+    :session-testing
+    :fuzzing
+    :protocol-testing
+    :api-security-testing
+    :sqli-testing
+    :xss-testing
+    :oob-testing
+    :exploitability-analysis
+    :foothold
+    :privilege-escalation
+    :finding
+    :security-report
+    :security-projection
+    :security-handoff)
+  "Closed first-slice vocabulary of work this worker class may accept.")
+
+(defstruct (rage-work-item
+             (:constructor make-rage-work-item
+                 (&key kind
+                       (scope :external)
+                       (description "")
+                       operation-authorized-p
+                       source
+                       target)))
+  "A candidate unit of cyber work presented to a Hackmode RAGE worker.
+
+SCOPE is an explicit authority label supplied by the caller.  In particular,
+:STARINTEL means the item touches StarIntel as a target, security corpus, or
+security integration surface; it does not mean the worker may perform ordinary
+StarIntel product engineering."
+  (kind :recon :type keyword)
+  (scope :external :type keyword)
+  (description "" :type string)
+  (operation-authorized-p nil :type boolean)
+  source
+  target)
+
+(defstruct (rage-scope-decision
+             (:constructor %make-rage-scope-decision))
+  "Pure authorization decision for a RAGE work item."
+  (allowed-p nil :type boolean)
+  (reason :denied :type keyword)
+  work-item)
+
+(defstruct (rage-worker
+             (:constructor %make-rage-worker))
+  "Identity and run-local state for one Hackmode RAGE worker."
+  (id "" :type string)
+  (run-id "" :type string)
+  operation
+  (mode :passive :type keyword)
+  objective
+  (state :idle :type keyword))
+
+(defun non-empty-string-p (value)
+  (and (stringp value) (plusp (length value))))
+
+(defun make-rage-worker (&key id run-id operation (mode :passive) objective)
+  "Create one isolated RAGE worker identity.
+
+The first worker substrate deliberately accepts only Hackpert's PASSIVE and
+ACTIVE modes.  Future RLM/LLM escalation is an extension inside the worker loop,
+not a third authority-bearing worker mode unless that contract is explicitly
+added later."
+  (unless (non-empty-string-p id)
+    (error "RAGE worker ID must be a non-empty string."))
+  (unless (non-empty-string-p run-id)
+    (error "RAGE worker run ID must be a non-empty string."))
+  (unless (member mode +rage-worker-modes+)
+    (error "Unsupported RAGE worker mode ~s; expected one of ~s."
+           mode +rage-worker-modes+))
+  (%make-rage-worker :id id
+                     :run-id run-id
+                     :operation operation
+                     :mode mode
+                     :objective objective
+                     :state :idle))
+
+(defun rage-cyber-task-kind-p (kind)
+  "Return true when KIND belongs to the closed RAGE cyber work vocabulary."
+  (not (null (member kind +rage-cyber-task-kinds+))))
+
+(defun starintel-rage-scope-p (work-item)
+  "Return true when WORK-ITEM explicitly targets the StarIntel security scope."
+  (eq :starintel (rage-work-item-scope work-item)))
+
+(defun authorize-rage-work-item (work-item)
+  "Return a RAGE-SCOPE-DECISION for WORK-ITEM without causing side effects.
+
+All RAGE workers are cyber workers.  StarIntel receives an additional explicit
+guardrail: a StarIntel-scoped item that is not in the cyber vocabulary is
+rejected with :STARINTEL-CYBER-ONLY, making it impossible for the migrated
+worker to silently fall back into StarIntel product issue implementation."
+  (check-type work-item rage-work-item)
+  (cond
+    ((not (rage-work-item-operation-authorized-p work-item))
+     (%make-rage-scope-decision
+      :allowed-p nil
+      :reason :operation-not-authorized
+      :work-item work-item))
+    ((and (starintel-rage-scope-p work-item)
+          (not (rage-cyber-task-kind-p (rage-work-item-kind work-item))))
+     (%make-rage-scope-decision
+      :allowed-p nil
+      :reason :starintel-cyber-only
+      :work-item work-item))
+    ((not (rage-cyber-task-kind-p (rage-work-item-kind work-item)))
+     (%make-rage-scope-decision
+      :allowed-p nil
+      :reason :non-cyber-work
+      :work-item work-item))
+    (t
+     (%make-rage-scope-decision
+      :allowed-p t
+      :reason :authorized
+      :work-item work-item))))
+
+(defun rage-worker-can-accept-p (worker work-item)
+  "Return two values: whether WORKER may accept WORK-ITEM and its decision.
+
+This first slice does not dispatch providers or mutate canonical state.  It
+only establishes the worker identity/scope gate that later active orchestration
+must call before execution."
+  (check-type worker rage-worker)
+  (let ((decision (authorize-rage-work-item work-item)))
+    (values (rage-scope-decision-allowed-p decision) decision)))

--- a/source/hackmode-core/rage-worker.lisp
+++ b/source/hackmode-core/rage-worker.lisp
@@ -138,3 +138,30 @@ must call before execution."
   (check-type worker rage-worker)
   (let ((decision (authorize-rage-work-item work-item)))
     (values (rage-scope-decision-allowed-p decision) decision)))
+
+(export '(+rage-worker-modes+
+          +rage-cyber-task-kinds+
+          rage-work-item
+          make-rage-work-item
+          rage-work-item-kind
+          rage-work-item-scope
+          rage-work-item-description
+          rage-work-item-operation-authorized-p
+          rage-work-item-source
+          rage-work-item-target
+          rage-scope-decision
+          rage-scope-decision-allowed-p
+          rage-scope-decision-reason
+          rage-scope-decision-work-item
+          rage-worker
+          make-rage-worker
+          rage-worker-id
+          rage-worker-run-id
+          rage-worker-operation
+          rage-worker-mode
+          rage-worker-objective
+          rage-worker-state
+          rage-cyber-task-kind-p
+          starintel-rage-scope-p
+          authorize-rage-work-item
+          rage-worker-can-accept-p))

--- a/source/hackmode-core/rage-worker.lisp
+++ b/source/hackmode-core/rage-worker.lisp
@@ -30,7 +30,7 @@
 
 (defstruct (rage-work-item
              (:constructor make-rage-work-item
-                 (&key kind
+                 (&key (kind :recon)
                        (scope :external)
                        (description "")
                        operation-authorized-p
@@ -66,7 +66,7 @@ StarIntel product engineering."
   objective
   (state :idle :type keyword))
 
-(defun non-empty-string-p (value)
+(defun %rage-non-empty-string-p (value)
   (and (stringp value) (plusp (length value))))
 
 (defun make-rage-worker (&key id run-id operation (mode :passive) objective)
@@ -76,9 +76,9 @@ The first worker substrate deliberately accepts only Hackpert's PASSIVE and
 ACTIVE modes.  Future RLM/LLM escalation is an extension inside the worker loop,
 not a third authority-bearing worker mode unless that contract is explicitly
 added later."
-  (unless (non-empty-string-p id)
+  (unless (%rage-non-empty-string-p id)
     (error "RAGE worker ID must be a non-empty string."))
-  (unless (non-empty-string-p run-id)
+  (unless (%rage-non-empty-string-p run-id)
     (error "RAGE worker run ID must be a non-empty string."))
   (unless (member mode +rage-worker-modes+)
     (error "Unsupported RAGE worker mode ~s; expected one of ~s."

--- a/source/hackmode-core/tests/rage-worker.lisp
+++ b/source/hackmode-core/tests/rage-worker.lisp
@@ -1,0 +1,95 @@
+(in-package :hackmode-tests)
+
+(defun run-rage-worker-scope-test ()
+  (let ((passive (hackmode:make-rage-worker
+                  :id "rage-recon"
+                  :run-id "run-001"
+                  :operation "bbp-starintel"
+                  :mode :passive
+                  :objective '(:finding-required t)))
+        (active (hackmode:make-rage-worker
+                 :id "rage-active"
+                 :run-id "run-002"
+                 :operation "bbp-starintel"
+                 :mode :active
+                 :objective '(:foothold-required t))))
+    (assert-equal :passive (hackmode:rage-worker-mode passive)
+                  "passive worker mode")
+    (assert-equal :active (hackmode:rage-worker-mode active)
+                  "active worker mode")
+    (assert (not (string= (hackmode:rage-worker-run-id passive)
+                          (hackmode:rage-worker-run-id active)))
+            ()
+            "Separate workers must retain separate run identities."))
+
+  ;; Migrated workers must not fall back into ordinary StarIntel engineering.
+  (let* ((item (hackmode:make-rage-work-item
+                :kind :implementation
+                :scope :starintel
+                :description "Implement an approved StarIntel feature issue"
+                :operation-authorized-p t
+                :source "lost-rob0t/starintel-server#999"))
+         (decision (hackmode:authorize-rage-work-item item)))
+    (assert (not (hackmode:rage-scope-decision-allowed-p decision)))
+    (assert-equal :starintel-cyber-only
+                  (hackmode:rage-scope-decision-reason decision)
+                  "StarIntel engineering rejection"))
+
+  ;; StarIntel is valid as an explicitly authorized BBP/security target.
+  (dolist (kind '(:recon
+                  :source-security-review
+                  :cve-correlation
+                  :fuzzing
+                  :security-projection))
+    (let* ((item (hackmode:make-rage-work-item
+                  :kind kind
+                  :scope :starintel
+                  :description "Authorized StarIntel BBP work"
+                  :operation-authorized-p t
+                  :target "starintel.actor"))
+           (decision (hackmode:authorize-rage-work-item item)))
+      (assert (hackmode:rage-scope-decision-allowed-p decision)
+              ()
+              "Expected StarIntel cyber work ~s to be accepted." kind)
+      (assert-equal :authorized
+                    (hackmode:rage-scope-decision-reason decision)
+                    "StarIntel cyber authorization")))
+
+  ;; Cyber vocabulary never overrides the containing operation's authorization.
+  (let* ((item (hackmode:make-rage-work-item
+                :kind :recon
+                :scope :starintel
+                :operation-authorized-p nil))
+         (decision (hackmode:authorize-rage-work-item item)))
+    (assert (not (hackmode:rage-scope-decision-allowed-p decision)))
+    (assert-equal :operation-not-authorized
+                  (hackmode:rage-scope-decision-reason decision)
+                  "operation scope rejection"))
+
+  ;; This migrated worker class is cyber-only even for non-StarIntel sources.
+  (let* ((item (hackmode:make-rage-work-item
+                :kind :architecture
+                :scope :external
+                :operation-authorized-p t))
+         (decision (hackmode:authorize-rage-work-item item)))
+    (assert (not (hackmode:rage-scope-decision-allowed-p decision)))
+    (assert-equal :non-cyber-work
+                  (hackmode:rage-scope-decision-reason decision)
+                  "generic engineering rejection"))
+
+  ;; RLM/LLM escalation is not a new worker authority mode in this foundation.
+  (let ((signaled nil))
+    (handler-case
+        (hackmode:make-rage-worker
+         :id "rage-llm"
+         :run-id "run-003"
+         :operation "bbp"
+         :mode :llm)
+      (error ()
+        (setf signaled t)))
+    (assert signaled ()
+            "Unsupported RAGE worker modes must fail closed.")))
+
+(defun run-rage-worker-tests ()
+  (run-rage-worker-scope-test)
+  t)


### PR DESCRIPTION
## What changed

Implements the first executable migration slice from #30 / #31.

- adds a Hackmode-native `rage-worker` identity/run contract;
- adds typed `rage-work-item` and `rage-scope-decision` values;
- defines a closed first-slice cyber task vocabulary;
- enforces operation authorization before worker acceptance;
- gives `:starintel` an explicit BBP/cyber-only scope gate;
- rejects ordinary StarIntel implementation/product work rather than scanning StarIntel engineering issue queues;
- keeps only `:passive` and `:active` as authority-bearing worker modes in this foundation;
- documents that future Prolog-RLM/ZeroForge plug into the same open objective/action/evidence loop;
- adds regression coverage to the core ASDF gate.

## Migration proof

The tests require:

1. `:starintel` + `:implementation` -> denied as `:starintel-cyber-only`;
2. authorized StarIntel recon/source-security-review/CVE/fuzzing/security-projection -> accepted;
3. operation not authorized -> denied even for recon;
4. non-cyber work outside StarIntel -> denied by this cyber worker class;
5. passive/active worker identities remain distinct and unsupported authority modes fail closed.

The retired StarIntel worker contracts are now closed at `starintel-auto-research#170` and `starintel-labs/RAGE#3` with migration notices pointing to #30.

This PR does **not** yet implement provider orchestration, execution graph persistence, operational KB mutation, or LISH controls; those remain in #27/#30.

Closes #31