### PR TITLE
Hackpert: establish explicit passive/active engine authority

### DIFF
--- a/source/hackmode-core/expert.lisp
+++ b/source/hackmode-core/expert.lisp
@@ -3,6 +3,13 @@
 (defparameter *expert-program* "swipl"
   "SWI-Prolog executable used by the optional Hackmode expert layer.")
 
+(defparameter +expert-engine-modes+ '(:passive :active)
+  "Closed authority-mode vocabulary for the Hackpert expert engine.")
+
+(defparameter +expert-effect-kinds+
+  '(:reasoning :provider-dispatch :canonical-mutation)
+  "First-slice effect classes admitted by the Hackpert authority gate.")
+
 (define-condition expert-unavailable (error)
   ((program :initarg :program :reader expert-unavailable-program))
   (:report (lambda (condition stream)
@@ -19,6 +26,60 @@
                        (and stderr
                             (plusp (length stderr))
                             stderr))))))
+
+(define-condition invalid-expert-engine-mode (error)
+  ((mode :initarg :mode :reader invalid-expert-engine-mode-value))
+  (:report (lambda (condition stream)
+             (format stream "Unsupported Hackpert engine mode ~s; expected one of ~s."
+                     (invalid-expert-engine-mode-value condition)
+                     +expert-engine-modes+))))
+
+(define-condition expert-effect-denied (error)
+  ((engine :initarg :engine :reader expert-effect-denied-engine)
+   (effect :initarg :effect :reader expert-effect-denied-effect))
+  (:report (lambda (condition stream)
+             (format stream "Hackpert ~s mode denies effect ~s."
+                     (expert-engine-mode (expert-effect-denied-engine condition))
+                     (expert-effect-denied-effect condition)))))
+
+(defstruct (expert-engine
+             (:constructor %make-expert-engine (mode)))
+  "Hackpert reasoning engine with explicit execution authority.
+
+MODE controls effect authority only. Reasoning strategy (direct, symbolic,
+expert rules, or later RLM escalation) is an orthogonal concern and must not
+silently widen this authority."
+  (mode :passive :type keyword))
+
+(defun make-expert-engine (&key (mode :passive))
+  "Create a Hackpert engine in explicit PASSIVE or ACTIVE authority mode.
+
+PASSIVE is the default so constructing an engine never accidentally grants
+provider-dispatch or canonical-mutation authority."
+  (unless (member mode +expert-engine-modes+)
+    (error 'invalid-expert-engine-mode :mode mode))
+  (%make-expert-engine mode))
+
+(defun expert-engine-effect-authorized-p (engine effect)
+  "Return true when ENGINE may request EFFECT under its authority mode.
+
+This is a pure gate. It does not execute providers or mutate state. Unknown
+effect classes fail closed. PASSIVE may reason only; ACTIVE may additionally
+request provider dispatch and canonical mutation through later typed action
+validation and Hackmode's canonical effect boundaries."
+  (check-type engine expert-engine)
+  (and (member effect +expert-effect-kinds+)
+       (or (eq effect :reasoning)
+           (eq (expert-engine-mode engine) :active))))
+
+(defun require-expert-engine-effect (engine effect)
+  "Return EFFECT when authorized, otherwise signal EXPERT-EFFECT-DENIED.
+
+Call this at effect admission boundaries before any provider dispatch or
+canonical mutation. It is deliberately not an executor itself."
+  (unless (expert-engine-effect-authorized-p engine effect)
+    (error 'expert-effect-denied :engine engine :effect effect))
+  effect)
 
 (defstruct expert-recommendation
   capability
@@ -233,3 +294,16 @@ advisory only; this function never executes a provider or writes operation state
           for trimmed = (string-trim '(#\Space #\Tab #\Return) line)
           unless (zerop (length trimmed))
             collect (parse-expert-recommendation trimmed))))
+
+(export '(+expert-engine-modes+
+          +expert-effect-kinds+
+          expert-engine
+          make-expert-engine
+          expert-engine-mode
+          invalid-expert-engine-mode
+          invalid-expert-engine-mode-value
+          expert-effect-denied
+          expert-effect-denied-engine
+          expert-effect-denied-effect
+          expert-engine-effect-authorized-p
+          require-expert-engine-effect))

--- a/source/hackmode-core/tests/expert.lisp
+++ b/source/hackmode-core/tests/expert.lisp
@@ -8,6 +8,56 @@
         (setf raised t)))
     (assert raised () "Expected HACKMODE:EXPERT-UNAVAILABLE.")))
 
+(defun assert-expert-effect-denied (thunk expected-effect)
+  (let ((condition nil))
+    (handler-case
+        (funcall thunk)
+      (hackmode:expert-effect-denied (raised)
+        (setf condition raised)))
+    (assert condition () "Expected HACKMODE:EXPERT-EFFECT-DENIED.")
+    (assert-equal expected-effect
+                  (hackmode:expert-effect-denied-effect condition)
+                  "denied expert effect")
+    condition))
+
+(defun run-expert-engine-mode-test ()
+  (let ((passive (hackmode:make-expert-engine))
+        (active (hackmode:make-expert-engine :mode :active)))
+    (assert-equal :passive (hackmode:expert-engine-mode passive)
+                  "Hackpert defaults to passive authority")
+    (assert-equal :active (hackmode:expert-engine-mode active)
+                  "active Hackpert authority is explicit")
+    (assert (hackmode:expert-engine-effect-authorized-p passive :reasoning))
+    (assert (not (hackmode:expert-engine-effect-authorized-p
+                  passive :provider-dispatch)))
+    (assert (not (hackmode:expert-engine-effect-authorized-p
+                  passive :canonical-mutation)))
+    (assert (hackmode:expert-engine-effect-authorized-p
+             active :provider-dispatch))
+    (assert (hackmode:expert-engine-effect-authorized-p
+             active :canonical-mutation))
+    (assert-expert-effect-denied
+     (lambda ()
+       (hackmode:require-expert-engine-effect passive :provider-dispatch))
+     :provider-dispatch)
+    (assert-expert-effect-denied
+     (lambda ()
+       (hackmode:require-expert-engine-effect passive :canonical-mutation))
+     :canonical-mutation)
+    (assert-equal :provider-dispatch
+                  (hackmode:require-expert-engine-effect
+                   active :provider-dispatch)
+                  "active authority admits provider dispatch")
+    (assert-equal :canonical-mutation
+                  (hackmode:require-expert-engine-effect
+                   active :canonical-mutation)
+                  "active authority admits canonical mutation")
+    (let ((raised nil))
+      (handler-case
+          (hackmode:make-expert-engine :mode :llm)
+        (error () (setf raised t)))
+      (assert raised () "Unsupported authority modes must fail closed."))))
+
 (defun run-expert-snapshot-test ()
   (let* ((operation (make-instance 'hackmode:operation
                                    :name "expert-op"
@@ -130,6 +180,7 @@
   t)
 
 (defun run-expert-tests ()
+  (run-expert-engine-mode-test)
   (run-expert-snapshot-test)
   (run-expert-unavailable-test)
   (run-live-expert-test)


### PR DESCRIPTION
Implements the first bounded slice of #27.

RED-first goal: make Hackpert authority an explicit engine property before adding the typed active action protocol. Passive must admit reasoning but deny provider dispatch and canonical mutation; active must admit those effect classes without executing anything by itself.

This PR intentionally does not add provider execution, graph/KB persistence, or database internals.