### PR TITLE
Database: establish typed execution graph foundation

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
+          submodules: recursive
 
       - name: Checkout pinned Tek9
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
-          submodules: recursive
 
       - name: Checkout pinned Tek9
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -100,11 +99,15 @@ jobs:
             --eval '(asdf:load-asd (truename "deps/sento-ci/sento.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-core/hackmode-tests.asd"))' \
+            --eval '(asdf:load-asd (truename "source/hackmode-database/hackmode-database.asd"))' \
+            --eval '(asdf:load-asd (truename "source/hackmode-database/hackmode-database-tests.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-providers/dns/hackmode-provider-dns.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-providers/dns/hackmode-provider-dns-tests.asd"))' \
             --eval '(ql:quickload :hackmode-tests)' \
+            --eval '(ql:quickload :hackmode-database-tests)' \
             --eval '(ql:quickload :hackmode-provider-dns-tests)' \
             --eval '(asdf:test-system :hackmode)' \
+            --eval '(asdf:test-system :hackmode-database)' \
             --eval '(asdf:test-system :hackmode-provider-dns)' \
             2>&1 | tee "$RUNNER_TEMP/hackmode-core.log"
 

--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -1,15 +1,36 @@
 (in-package :hackmode-database)
 
-(defvar *db* nil "The hackmode database object")
+(defvar *db* nil "The active Hackmode/Tek9 database object.")
 
+(defun put-doc (document &key (database-name "std") (database *db*))
+  "Persist DOCUMENT through the canonical Tek9 document boundary."
+  (unless database
+    (error "No Hackmode database is open."))
+  (tek9:put* database document :database-name database-name))
 
-(defun make-document (data &key (id (make-ke))))
+(defun put-docs (documents &key (database-name "std") (database *db*))
+  "Persist DOCUMENTS through one Tek9 bulk write."
+  (unless database
+    (error "No Hackmode database is open."))
+  (tek9:put-bulk* database documents :database-name database-name))
 
-;; default to the one from tek9
-;; This is effectivly just a wrapper around "put"
-(defun put-doc (database document &key (database-name "std"))
-  (tek9:put* database document :key (sxhash)))
+(defun persist-execution-record (database record)
+  "Persist one typed execution RECORD into its operation-scoped Tek9 graph."
+  (tek9:put-node database
+                 (execution-record->tek9-node record)
+                 :database-name (execution-graph-name
+                                 (execution-record-operation-id record)))
+  record)
 
-
-(defun put-docs (database documents &key (database-name "std"))
-  (loop for))
+(defun persist-tool-execution (database call result)
+  "Persist CALL, RESULT, and their typed relation through Tek9's graph API."
+  (validate-tool-result-link call result)
+  (let ((graph-name (execution-graph-name (execution-record-operation-id call))))
+    (tek9:put-nodes database
+                    (list (execution-record->tek9-node call)
+                          (execution-record->tek9-node result))
+                    :database-name graph-name)
+    (tek9:put-edge database
+                   (tool-result-link-edge call result)
+                   :database-name graph-name))
+  (values call result))

--- a/source/hackmode-database/execution-graph.lisp
+++ b/source/hackmode-database/execution-graph.lisp
@@ -1,0 +1,123 @@
+(in-package :hackmode-database)
+
+(define-condition execution-graph-validation-error (error)
+  ((field :initarg :field :reader execution-graph-error-field)
+   (value :initarg :value :reader execution-graph-error-value)
+   (reason :initarg :reason :reader execution-graph-error-reason))
+  (:report (lambda (condition stream)
+             (format stream "Invalid execution graph field ~S: ~A (~S)"
+                     (execution-graph-error-field condition)
+                     (execution-graph-error-reason condition)
+                     (execution-graph-error-value condition)))))
+
+(defstruct (execution-record (:constructor %make-execution-record))
+  kind
+  operation-id
+  run-id
+  call-id
+  record-id
+  capability-id
+  status
+  payload
+  provenance)
+
+(defun %non-empty-string-p (value)
+  (and (stringp value) (plusp (length value))))
+
+(defun %require-string (field value)
+  (unless (%non-empty-string-p value)
+    (error 'execution-graph-validation-error
+           :field field :value value :reason "expected non-empty string"))
+  value)
+
+(defun %require-provenance (value)
+  (unless value
+    (error 'execution-graph-validation-error
+           :field :provenance :value value :reason "provenance is required"))
+  value)
+
+(defun %key-part (value)
+  (let ((string (princ-to-string value)))
+    (format nil "~D:~A" (length string) string)))
+
+(defun %record-id (&rest parts)
+  (with-output-to-string (stream)
+    (dolist (part parts)
+      (write-string (%key-part part) stream))))
+
+(defun make-tool-call-record (&key operation-id run-id call-id capability-id input provenance)
+  (%require-string :operation-id operation-id)
+  (%require-string :run-id run-id)
+  (%require-string :call-id call-id)
+  (%require-string :capability-id capability-id)
+  (%require-provenance provenance)
+  (%make-execution-record
+   :kind :tool-call
+   :operation-id operation-id
+   :run-id run-id
+   :call-id call-id
+   :record-id (%record-id "tool-call" operation-id run-id call-id)
+   :capability-id capability-id
+   :payload input
+   :provenance provenance))
+
+(defun make-tool-result-record
+    (&key operation-id run-id call-id result-id status output provenance)
+  (%require-string :operation-id operation-id)
+  (%require-string :run-id run-id)
+  (%require-string :call-id call-id)
+  (%require-string :result-id result-id)
+  (%require-provenance provenance)
+  (unless (member status '(:succeeded :failed :cancelled :timed-out) :test #'eq)
+    (error 'execution-graph-validation-error
+           :field :status :value status :reason "unsupported tool result status"))
+  (%make-execution-record
+   :kind :tool-result
+   :operation-id operation-id
+   :run-id run-id
+   :call-id call-id
+   :record-id (%record-id "tool-result" operation-id run-id call-id result-id)
+   :status status
+   :payload output
+   :provenance provenance))
+
+(defun validate-tool-result-link (call result)
+  (unless (eq :tool-call (execution-record-kind call))
+    (error 'execution-graph-validation-error
+           :field :call :value call :reason "expected tool-call record"))
+  (unless (eq :tool-result (execution-record-kind result))
+    (error 'execution-graph-validation-error
+           :field :result :value result :reason "expected tool-result record"))
+  (dolist (reader '(execution-record-operation-id execution-record-run-id execution-record-call-id))
+    (unless (string= (funcall reader call) (funcall reader result))
+      (error 'execution-graph-validation-error
+             :field reader
+             :value (list (funcall reader call) (funcall reader result))
+             :reason "call/result identity mismatch")))
+  t)
+
+(defun execution-graph-name (operation-id)
+  (%require-string :operation-id operation-id)
+  (format nil "hackmode/execution/~A" (%key-part operation-id)))
+
+(defun execution-record->tek9-node (record)
+  (make-instance 'tek9:node
+                 :id (execution-record-record-id record)
+                 :props (list :kind (execution-record-kind record)
+                              :operation-id (execution-record-operation-id record)
+                              :run-id (execution-record-run-id record)
+                              :call-id (execution-record-call-id record)
+                              :capability-id (execution-record-capability-id record)
+                              :status (execution-record-status record)
+                              :payload (execution-record-payload record)
+                              :provenance (execution-record-provenance record))))
+
+(defun tool-result-link-edge (call result)
+  (validate-tool-result-link call result)
+  (make-instance 'tek9:edge
+                 :id (%record-id "tool-result-link"
+                                 (execution-record-record-id call)
+                                 (execution-record-record-id result))
+                 :source (execution-record-record-id call)
+                 :predicate :produced
+                 :target (execution-record-record-id result)))

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -1,0 +1,8 @@
+(asdf:defsystem :hackmode-database-tests
+  :description "Regression tests for Hackmode database graph/KB persistence"
+  :depends-on (#:hackmode-database)
+  :serial t
+  :components ((:file "tests/execution-graph"))
+  :perform (test-op (op system)
+             (declare (ignore op system))
+             (uiop:symbol-call :hackmode-database-tests :run-tests)))

--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -1,12 +1,11 @@
 (asdf:defsystem :hackmode-database
-  :description "Database for hackmode"
+  :description "Hackmode-owned Tek9 execution graph and KB persistence boundary"
   :author "nsaspy"
   :license "MIT"
   :version "0.1.0"
   :serial t
-
-  :depends-on (#:tek9 #:cl-conspack)
+  :in-order-to ((test-op (test-op "hackmode-database-tests")))
+  :depends-on (#:tek9)
   :components ((:file "package")
-               (:file "objects")
-               (:file "encoding")
+               (:file "execution-graph")
                (:file "db")))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -1,4 +1,26 @@
-(uiop:define-package   :hackmode-database
+(uiop:define-package :hackmode-database
   (:nicknames :hack-db)
-  (:use :tek9  :cl)
-  (:documentation "the database for starintel"))
+  (:use :cl)
+  (:export
+   #:*db*
+   #:execution-graph-validation-error
+   #:execution-record
+   #:execution-record-kind
+   #:execution-record-operation-id
+   #:execution-record-run-id
+   #:execution-record-call-id
+   #:execution-record-record-id
+   #:execution-record-capability-id
+   #:execution-record-status
+   #:execution-record-payload
+   #:execution-record-provenance
+   #:make-tool-call-record
+   #:make-tool-result-record
+   #:validate-tool-result-link
+   #:execution-graph-name
+   #:execution-record->tek9-node
+   #:tool-result-link-edge
+   #:persist-execution-record
+   #:persist-tool-execution
+   #:put-doc
+   #:put-docs))

--- a/source/hackmode-database/tests/execution-graph.lisp
+++ b/source/hackmode-database/tests/execution-graph.lisp
@@ -1,0 +1,50 @@
+(uiop:define-package :hackmode-database-tests
+  (:use :cl :hackmode-database)
+  (:export #:run-tests))
+
+(in-package :hackmode-database-tests)
+
+(defun ensure (condition format-control &rest format-args)
+  (unless condition
+    (error (apply #'format nil format-control format-args))))
+
+(defun run-tests ()
+  (let* ((call (make-tool-call-record
+                :operation-id "op-1"
+                :run-id "run-1"
+                :call-id "call-1"
+                :capability-id "dns.resolve"
+                :input '(:domain "example.com")
+                :provenance '(:worker "database-test")))
+         (result (make-tool-result-record
+                  :operation-id "op-1"
+                  :run-id "run-1"
+                  :call-id "call-1"
+                  :result-id "result-1"
+                  :status :succeeded
+                  :output '(:addresses ("192.0.2.1"))
+                  :provenance '(:provider "fixture"))))
+    (ensure (string= "op-1" (execution-record-operation-id call))
+            "tool call lost operation identity")
+    (ensure (string= "call-1" (execution-record-call-id call))
+            "tool call lost call identity")
+    (ensure (eq :tool-call (execution-record-kind call))
+            "tool call has wrong kind")
+    (ensure (eq :tool-result (execution-record-kind result))
+            "tool result has wrong kind")
+    (ensure (string= (execution-record-call-id call)
+                     (execution-record-call-id result))
+            "result is not linked to its call")
+    (handler-case
+        (progn
+          (make-tool-result-record
+           :operation-id "op-2"
+           :run-id "run-1"
+           :call-id "call-1"
+           :result-id "result-2"
+           :status :succeeded
+           :output nil
+           :provenance nil)
+          (error "cross-operation result unexpectedly accepted"))
+      (execution-graph-validation-error () t)))
+  t)

--- a/source/hackmode-database/tests/execution-graph.lisp
+++ b/source/hackmode-database/tests/execution-graph.lisp
@@ -26,25 +26,43 @@
                   :provenance '(:provider "fixture"))))
     (ensure (string= "op-1" (execution-record-operation-id call))
             "tool call lost operation identity")
-    (ensure (string= "call-1" (execution-record-call-id call))
-            "tool call lost call identity")
     (ensure (eq :tool-call (execution-record-kind call))
             "tool call has wrong kind")
     (ensure (eq :tool-result (execution-record-kind result))
             "tool result has wrong kind")
-    (ensure (string= (execution-record-call-id call)
-                     (execution-record-call-id result))
-            "result is not linked to its call")
+    (ensure (validate-tool-result-link call result)
+            "valid call/result link rejected")
+    (ensure (string= (execution-record-record-id call)
+                     (tek9:node-id (execution-record->tek9-node call)))
+            "Tek9 node identity drifted")
+    (let ((edge (tool-result-link-edge call result)))
+      (ensure (string= (execution-record-record-id call) (tek9:edge-source edge))
+              "result edge source drifted")
+      (ensure (string= (execution-record-record-id result) (tek9:edge-target edge))
+              "result edge target drifted"))
     (handler-case
         (progn
-          (make-tool-result-record
-           :operation-id "op-2"
-           :run-id "run-1"
-           :call-id "call-1"
-           :result-id "result-2"
-           :status :succeeded
-           :output nil
-           :provenance nil)
+          (validate-tool-result-link
+           call
+           (make-tool-result-record
+            :operation-id "op-2"
+            :run-id "run-1"
+            :call-id "call-1"
+            :result-id "result-2"
+            :status :succeeded
+            :output nil
+            :provenance '(:provider "fixture")))
           (error "cross-operation result unexpectedly accepted"))
+      (execution-graph-validation-error () t))
+    (handler-case
+        (progn
+          (make-tool-call-record
+           :operation-id ""
+           :run-id "run-1"
+           :call-id "call-2"
+           :capability-id "dns.resolve"
+           :input nil
+           :provenance '(:worker "database-test"))
+          (error "empty operation identity unexpectedly accepted"))
       (execution-graph-validation-error () t)))
   t)


### PR DESCRIPTION
## Slice
Issue #24 database-owned prerequisite: make `hackmode-database` a real tested system and establish typed operation-scoped tool-call/result execution records before Hackpert active orchestration consumes them.

## RED
Commit `e1190b25dbf720a72cbf02a727f2441ce3215a48` wires `hackmode-database` into the repository-native core gate and adds executable acceptance tests for typed tool-call/result records. Current `master` is expected to fail because `hackmode-database.asd` references missing source files and the required graph API does not exist.

## Ownership
Database/graph/KB only. No Hackpert expert implementation or StarIntel product work.

## Acceptance
- database ASDF system loads under pinned Tek9 CI
- typed tool-call and tool-result records carry operation/run/call identity and provenance
- result links to its call
- invalid/missing operation-scoped identity fails closed
- database tests run in the ordinary core gate
