### PR TITLE
Hackpert: add typed active action protocol

### DIFF
--- a/source/hackmode-core/expert.lisp
+++ b/source/hackmode-core/expert.lisp
@@ -7,7 +7,7 @@
   "Closed authority-mode vocabulary for the Hackpert expert engine.")
 
 (defparameter +expert-effect-kinds+
-  '(:reasoning :provider-dispatch :canonical-mutation)
+  '(:reasoning :active-control :provider-dispatch :canonical-mutation)
   "First-slice effect classes admitted by the Hackpert authority gate.")
 
 (define-condition expert-unavailable (error)
@@ -65,8 +65,8 @@ provider-dispatch or canonical-mutation authority."
 
 This is a pure gate. It does not execute providers or mutate state. Unknown
 effect classes fail closed. PASSIVE may reason only; ACTIVE may additionally
-request provider dispatch and canonical mutation through later typed action
-validation and Hackmode's canonical effect boundaries."
+request active-run control, provider dispatch, and canonical mutation through
+typed action validation and Hackmode's canonical effect boundaries."
   (check-type engine expert-engine)
   (and (member effect +expert-effect-kinds+)
        (or (eq effect :reasoning)

--- a/source/hackmode-core/expert/actions.lisp
+++ b/source/hackmode-core/expert/actions.lisp
@@ -1,0 +1,267 @@
+(in-package :hackmode)
+
+(defparameter +expert-active-action-kinds+
+  '(:dispatch
+    :graph-delta
+    :discover
+    :operational-kb-delta
+    :plan-transition
+    :control)
+  "Closed first-version vocabulary for effect-bearing Hackpert actions.")
+
+(defparameter +expert-plan-transitions+ '(:advance :fail :succeed)
+  "Allowed state transitions for one Hackpert plan step.")
+
+(defparameter +expert-control-directives+ '(:stop :yield :wait)
+  "Allowed active-run control directives.")
+
+(define-condition invalid-expert-action (error)
+  ((reason :initarg :reason :reader invalid-expert-action-reason)
+   (action :initarg :action :reader invalid-expert-action-action))
+  (:report (lambda (condition stream)
+             (format stream "Invalid Hackpert active action: ~a"
+                     (invalid-expert-action-reason condition)))))
+
+(defstruct expert-dispatch-payload
+  capability
+  provider
+  input)
+
+(defstruct expert-graph-delta-payload
+  (nodes nil :type list)
+  (edges nil :type list))
+
+(defstruct expert-discover-payload
+  asset)
+
+(defstruct expert-kb-delta-payload
+  (assertions nil :type list)
+  (retractions nil :type list))
+
+(defstruct expert-plan-transition-payload
+  plan-id
+  step-id
+  transition)
+
+(defstruct expert-control-payload
+  directive
+  reason)
+
+(defstruct (expert-active-action
+             (:constructor %make-expert-active-action
+                 (&key id kind operation run-id expert-id expert-version
+                       evidence-ids payload)))
+  "Typed Hackpert request for one admitted active-run effect.
+
+The action is only a request. Constructing or validating it never dispatches a
+provider and never mutates canonical state. ACTION metadata is operation/run
+scoped so the eventual executor can reject stale or cross-run output."
+  id
+  kind
+  operation
+  run-id
+  expert-id
+  expert-version
+  (evidence-ids nil :type list)
+  payload)
+
+(defun expert-action-string-p (value)
+  (and (stringp value) (plusp (length value))))
+
+(defun invalid-expert-action (action control &rest arguments)
+  (error 'invalid-expert-action
+         :action action
+         :reason (apply #'format nil control arguments)))
+
+(defun validate-expert-action-metadata (action)
+  (dolist (slot (list (cons :id (expert-active-action-id action))
+                      (cons :operation (expert-active-action-operation action))
+                      (cons :run-id (expert-active-action-run-id action))
+                      (cons :expert-id (expert-active-action-expert-id action))
+                      (cons :expert-version
+                            (expert-active-action-expert-version action))))
+    (unless (expert-action-string-p (cdr slot))
+      (invalid-expert-action action "~a must be a non-empty string" (car slot))))
+  (unless (every #'expert-action-string-p
+                 (expert-active-action-evidence-ids action))
+    (invalid-expert-action action
+                           "evidence IDs must be non-empty strings"))
+  action)
+
+(defun validate-expert-dispatch-payload (action payload)
+  (unless (expert-action-string-p
+           (expert-dispatch-payload-capability payload))
+    (invalid-expert-action action "dispatch capability is required"))
+  (let ((provider (expert-dispatch-payload-provider payload)))
+    (unless (or (null provider) (expert-action-string-p provider))
+      (invalid-expert-action action
+                             "dispatch provider must be NIL or a non-empty string")))
+  (when (null (expert-dispatch-payload-input payload))
+    (invalid-expert-action action "dispatch input is required"))
+  payload)
+
+(defun validate-expert-graph-delta-payload (action payload)
+  (when (and (null (expert-graph-delta-payload-nodes payload))
+             (null (expert-graph-delta-payload-edges payload)))
+    (invalid-expert-action action "graph delta must contain nodes or edges"))
+  payload)
+
+(defun validate-expert-discover-payload (action payload)
+  (when (null (expert-discover-payload-asset payload))
+    (invalid-expert-action action "discover action requires an asset"))
+  payload)
+
+(defun validate-expert-kb-delta-payload (action payload)
+  (when (and (null (expert-kb-delta-payload-assertions payload))
+             (null (expert-kb-delta-payload-retractions payload)))
+    (invalid-expert-action action
+                           "operational KB delta must assert or retract data"))
+  payload)
+
+(defun validate-expert-plan-transition-payload (action payload)
+  (unless (expert-action-string-p
+           (expert-plan-transition-payload-plan-id payload))
+    (invalid-expert-action action "plan transition requires a plan ID"))
+  (unless (expert-action-string-p
+           (expert-plan-transition-payload-step-id payload))
+    (invalid-expert-action action "plan transition requires a step ID"))
+  (unless (member (expert-plan-transition-payload-transition payload)
+                  +expert-plan-transitions+)
+    (invalid-expert-action action
+                           "unsupported plan transition ~s"
+                           (expert-plan-transition-payload-transition payload)))
+  payload)
+
+(defun validate-expert-control-payload (action payload)
+  (unless (member (expert-control-payload-directive payload)
+                  +expert-control-directives+)
+    (invalid-expert-action action
+                           "unsupported control directive ~s"
+                           (expert-control-payload-directive payload)))
+  (let ((reason (expert-control-payload-reason payload)))
+    (unless (or (null reason) (stringp reason))
+      (invalid-expert-action action "control reason must be NIL or a string")))
+  payload)
+
+(defun validate-expert-action-payload (action)
+  (let ((kind (expert-active-action-kind action))
+        (payload (expert-active-action-payload action)))
+    (case kind
+      (:dispatch
+       (unless (typep payload 'expert-dispatch-payload)
+         (invalid-expert-action action "dispatch requires dispatch payload"))
+       (validate-expert-dispatch-payload action payload))
+      (:graph-delta
+       (unless (typep payload 'expert-graph-delta-payload)
+         (invalid-expert-action action "graph-delta requires graph payload"))
+       (validate-expert-graph-delta-payload action payload))
+      (:discover
+       (unless (typep payload 'expert-discover-payload)
+         (invalid-expert-action action "discover requires discover payload"))
+       (validate-expert-discover-payload action payload))
+      (:operational-kb-delta
+       (unless (typep payload 'expert-kb-delta-payload)
+         (invalid-expert-action action
+                                "operational-kb-delta requires KB payload"))
+       (validate-expert-kb-delta-payload action payload))
+      (:plan-transition
+       (unless (typep payload 'expert-plan-transition-payload)
+         (invalid-expert-action action
+                                "plan-transition requires plan payload"))
+       (validate-expert-plan-transition-payload action payload))
+      (:control
+       (unless (typep payload 'expert-control-payload)
+         (invalid-expert-action action "control requires control payload"))
+       (validate-expert-control-payload action payload))
+      (otherwise
+       (invalid-expert-action action "unsupported action kind ~s" kind)))))
+
+(defun make-expert-active-action (&rest initargs &key &allow-other-keys)
+  "Construct and validate one typed active action without executing it."
+  (let ((action (apply #'%make-expert-active-action initargs)))
+    (validate-expert-action-metadata action)
+    (validate-expert-action-payload action)
+    action))
+
+(defun expert-active-action-effect-kind (action)
+  "Return the Hackpert authority class required by ACTION."
+  (check-type action expert-active-action)
+  (case (expert-active-action-kind action)
+    (:dispatch :provider-dispatch)
+    ((:graph-delta :discover :operational-kb-delta :plan-transition)
+     :canonical-mutation)
+    (:control :active-control)
+    (otherwise
+     (invalid-expert-action action
+                            "unsupported action kind ~s"
+                            (expert-active-action-kind action)))))
+
+(defun validate-expert-active-action (engine action &key operation run-id)
+  "Admit ACTION for ENGINE and an expected operation/run identity.
+
+This is the final pure boundary before a later executor. It proves authority,
+shape, and provenance scope only. It intentionally performs zero effects."
+  (check-type engine expert-engine)
+  (check-type action expert-active-action)
+  (validate-expert-action-metadata action)
+  (validate-expert-action-payload action)
+  (when (and operation
+             (not (string= operation (expert-active-action-operation action))))
+    (invalid-expert-action action
+                           "operation ~s does not match expected ~s"
+                           (expert-active-action-operation action)
+                           operation))
+  (when (and run-id
+             (not (string= run-id (expert-active-action-run-id action))))
+    (invalid-expert-action action
+                           "run ~s does not match expected ~s"
+                           (expert-active-action-run-id action)
+                           run-id))
+  (require-expert-engine-effect
+   engine
+   (expert-active-action-effect-kind action))
+  action)
+
+(export '(+expert-active-action-kinds+
+          +expert-plan-transitions+
+          +expert-control-directives+
+          invalid-expert-action
+          invalid-expert-action-reason
+          invalid-expert-action-action
+          expert-dispatch-payload
+          make-expert-dispatch-payload
+          expert-dispatch-payload-capability
+          expert-dispatch-payload-provider
+          expert-dispatch-payload-input
+          expert-graph-delta-payload
+          make-expert-graph-delta-payload
+          expert-graph-delta-payload-nodes
+          expert-graph-delta-payload-edges
+          expert-discover-payload
+          make-expert-discover-payload
+          expert-discover-payload-asset
+          expert-kb-delta-payload
+          make-expert-kb-delta-payload
+          expert-kb-delta-payload-assertions
+          expert-kb-delta-payload-retractions
+          expert-plan-transition-payload
+          make-expert-plan-transition-payload
+          expert-plan-transition-payload-plan-id
+          expert-plan-transition-payload-step-id
+          expert-plan-transition-payload-transition
+          expert-control-payload
+          make-expert-control-payload
+          expert-control-payload-directive
+          expert-control-payload-reason
+          expert-active-action
+          make-expert-active-action
+          expert-active-action-id
+          expert-active-action-kind
+          expert-active-action-operation
+          expert-active-action-run-id
+          expert-active-action-expert-id
+          expert-active-action-expert-version
+          expert-active-action-evidence-ids
+          expert-active-action-payload
+          expert-active-action-effect-kind
+          validate-expert-active-action))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -31,6 +31,9 @@
                (:file "providers")
                (:file "provider-actor")
                (:file "expert")
+               (:module "expert"
+                :serial t
+                :components ((:file "actions")))
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -31,7 +31,8 @@
                (:file "providers")
                (:file "provider-actor")
                (:file "expert")
-               (:module "expert"
+               (:module "expert-actions"
+                :pathname "expert/"
                 :serial t
                 :components ((:file "actions")))
                (:file "functions")

--- a/source/hackmode-core/tests/expert.lisp
+++ b/source/hackmode-core/tests/expert.lisp
@@ -41,10 +41,14 @@
                   passive :provider-dispatch)))
     (assert (not (hackmode:expert-engine-effect-authorized-p
                   passive :canonical-mutation)))
+    (assert (not (hackmode:expert-engine-effect-authorized-p
+                  passive :active-control)))
     (assert (hackmode:expert-engine-effect-authorized-p
              active :provider-dispatch))
     (assert (hackmode:expert-engine-effect-authorized-p
              active :canonical-mutation))
+    (assert (hackmode:expert-engine-effect-authorized-p
+             active :active-control))
     (assert-expert-effect-denied
      (lambda ()
        (hackmode:require-expert-engine-effect passive :provider-dispatch))
@@ -130,7 +134,8 @@
                       :payload
                       (ecase kind
                         (:graph-delta
-                         (hackmode:make-expert-graph-delta-payload))
+                         (hackmode:make-expert-graph-delta-payload
+                          :nodes '("node-1")))
                         (:discover
                          (hackmode:make-expert-discover-payload :asset "asset-1"))
                         (:operational-kb-delta
@@ -154,16 +159,16 @@
              (hackmode:make-expert-control-payload
               :directive :yield
               :reason "need evidence"))))
-      (assert-equal :reasoning
+      (assert-equal :active-control
                     (hackmode:expert-active-action-effect-kind control)
-                    "control actions do not claim mutation authority")
+                    "control actions require active-run authority")
       (assert-expert-effect-denied
        (lambda ()
          (hackmode:validate-expert-active-action
           passive control
           :operation "op-a"
           :run-id "run-1"))
-       :canonical-mutation))))
+       :active-control))))
 
 (defun run-expert-snapshot-test ()
   (let* ((operation (make-instance 'hackmode:operation

--- a/source/hackmode-core/tests/expert.lisp
+++ b/source/hackmode-core/tests/expert.lisp
@@ -20,6 +20,15 @@
                   "denied expert effect")
     condition))
 
+(defun assert-invalid-expert-action (thunk)
+  (let ((condition nil))
+    (handler-case
+        (funcall thunk)
+      (hackmode:invalid-expert-action (raised)
+        (setf condition raised)))
+    (assert condition () "Expected HACKMODE:INVALID-EXPERT-ACTION.")
+    condition))
+
 (defun run-expert-engine-mode-test ()
   (let ((passive (hackmode:make-expert-engine))
         (active (hackmode:make-expert-engine :mode :active)))
@@ -57,6 +66,104 @@
           (hackmode:make-expert-engine :mode :llm)
         (error () (setf raised t)))
       (assert raised () "Unsupported authority modes must fail closed."))))
+
+(defun run-expert-active-action-test ()
+  (let* ((passive (hackmode:make-expert-engine))
+         (active (hackmode:make-expert-engine :mode :active))
+         (payload
+           (hackmode:make-expert-dispatch-payload
+            :capability "dns-resolve"
+            :provider "fixture"
+            :input "example.com"))
+         (action
+           (hackmode:make-expert-active-action
+            :id "action-1"
+            :kind :dispatch
+            :operation "op-a"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "1"
+            :evidence-ids '("call-1")
+            :payload payload)))
+    (assert-equal :provider-dispatch
+                  (hackmode:expert-active-action-effect-kind action)
+                  "dispatch actions map to provider authority")
+    (assert-equal action
+                  (hackmode:validate-expert-active-action
+                   active action
+                   :operation "op-a"
+                   :run-id "run-1")
+                  "active action validates in its operation/run")
+    (assert-expert-effect-denied
+     (lambda ()
+       (hackmode:validate-expert-active-action
+        passive action
+        :operation "op-a"
+        :run-id "run-1"))
+     :provider-dispatch)
+    (assert-invalid-expert-action
+     (lambda ()
+       (hackmode:validate-expert-active-action
+        active action
+        :operation "op-b"
+        :run-id "run-1")))
+    (assert-invalid-expert-action
+     (lambda ()
+       (hackmode:make-expert-active-action
+        :id "action-2"
+        :kind :graph-delta
+        :operation "op-a"
+        :run-id "run-1"
+        :expert-id "recon"
+        :expert-version "1"
+        :payload payload)))
+    (dolist (kind '(:graph-delta :discover :operational-kb-delta :plan-transition))
+      (assert-equal :canonical-mutation
+                    (hackmode:expert-active-action-effect-kind
+                     (hackmode:make-expert-active-action
+                      :id (format nil "action-~a" kind)
+                      :kind kind
+                      :operation "op-a"
+                      :run-id "run-1"
+                      :expert-id "recon"
+                      :expert-version "1"
+                      :payload
+                      (ecase kind
+                        (:graph-delta
+                         (hackmode:make-expert-graph-delta-payload))
+                        (:discover
+                         (hackmode:make-expert-discover-payload :asset "asset-1"))
+                        (:operational-kb-delta
+                         (hackmode:make-expert-kb-delta-payload
+                          :assertions '((hypothesis "h1"))))
+                        (:plan-transition
+                         (hackmode:make-expert-plan-transition-payload
+                          :plan-id "plan-1"
+                          :step-id "step-1"
+                          :transition :advance)))))
+                    "state-changing active actions map to canonical mutation"))
+    (let ((control
+            (hackmode:make-expert-active-action
+             :id "action-control"
+             :kind :control
+             :operation "op-a"
+             :run-id "run-1"
+             :expert-id "recon"
+             :expert-version "1"
+             :payload
+             (hackmode:make-expert-control-payload
+              :directive :yield
+              :reason "need evidence"))))
+      (assert-equal :reasoning
+                    (hackmode:expert-active-action-effect-kind control)
+                    "control actions do not claim mutation authority")
+      (assert-expert-effect-denied
+       (lambda ()
+         (hackmode:validate-expert-active-action
+          passive control
+          :operation "op-a"
+          :run-id "run-1"))
+       :canonical-mutation))))
 
 (defun run-expert-snapshot-test ()
   (let* ((operation (make-instance 'hackmode:operation
@@ -181,6 +288,7 @@
 
 (defun run-expert-tests ()
   (run-expert-engine-mode-test)
+  (run-expert-active-action-test)
   (run-expert-snapshot-test)
   (run-expert-unavailable-test)
   (run-live-expert-test)


### PR DESCRIPTION
Issue #27 bounded Auto-RAGE Hackpert slice. Supersedes draft #43 at the identical exact head because the connector could not transition that PR out of draft.

Defines the typed operation/run-scoped active action envelope and payload vocabulary only. It does not add a second executor, direct Tek9 writes, database internals, or product RAGE runtime.

Invariants:
- passive rejects every active action, including run control;
- active dispatch maps to provider-dispatch authority;
- graph/discovery/operational-KB/plan deltas map to canonical-mutation authority;
- operation/run provenance mismatches fail closed;
- action kind and typed payload must agree;
- validation performs zero effects.

RED commit: 53b62aff3f1faa3e3ad8839d1dc7312e849851a2
Current exact head: 6f6956af5b6b9623ba2c9c8a2a0902efbde68c90
Prior exact-head core and monorepo runs for this same head passed before reopening.