### PR TITLE
Database: add operation-scoped operational KB mutations

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -34,3 +34,38 @@
                    (tool-result-link-edge call result)
                    :database-name graph-name))
   (values call result))
+
+(defun persist-operational-kb-entry (database entry)
+  "Persist one replay-safe operational KB assertion or retraction through Tek9."
+  (let ((graph-name (operational-kb-graph-name
+                     (operational-kb-entry-operation-id entry))))
+    (ecase (operational-kb-entry-kind entry)
+      (:assert
+       (tek9:put-nodes database
+                       (list (operational-kb-root-node
+                              (operational-kb-entry-operation-id entry))
+                             (operational-kb-entry->tek9-node entry))
+                       :database-name graph-name)
+       (tek9:put-edge database
+                      (operational-kb-membership-edge entry)
+                      :database-name graph-name))
+      (:retract
+       (unless (tek9:fetch-node database
+                                (operational-kb-entry-target-assertion-id entry)
+                                :database-name graph-name)
+         (error 'operational-kb-validation-error
+                :field :target-assertion-id
+                :value (operational-kb-entry-target-assertion-id entry)
+                :reason "target assertion does not exist"))
+       (tek9:put-node database
+                      (operational-kb-entry->tek9-node entry)
+                      :database-name graph-name)
+       (tek9:put-edge database
+                      (operational-kb-retraction-edge entry)
+                      :database-name graph-name)))
+    entry))
+
+(defun fetch-operational-kb-entry (database operation-id record-id)
+  "Fetch one operational KB graph node by stable RECORD-ID."
+  (tek9:fetch-node database record-id
+                   :database-name (operational-kb-graph-name operation-id)))

--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -8,4 +8,5 @@
   :depends-on (#:tek9)
   :components ((:file "package")
                (:file "execution-graph")
+               (:file "operational-kb")
                (:file "db")))

--- a/source/hackmode-database/operational-kb.lisp
+++ b/source/hackmode-database/operational-kb.lisp
@@ -1,0 +1,160 @@
+(in-package :hackmode-database)
+
+(define-condition operational-kb-validation-error (error)
+  ((field :initarg :field :reader operational-kb-error-field)
+   (value :initarg :value :reader operational-kb-error-value)
+   (reason :initarg :reason :reader operational-kb-error-reason))
+  (:report (lambda (condition stream)
+             (format stream "Invalid operational KB field ~S: ~A (~S)"
+                     (operational-kb-error-field condition)
+                     (operational-kb-error-reason condition)
+                     (operational-kb-error-value condition)))))
+
+(defstruct (operational-kb-entry (:constructor %make-operational-kb-entry))
+  kind
+  operation-id
+  run-id
+  expert-id
+  expert-version
+  record-id
+  key
+  value
+  target-assertion-id
+  evidence-ids
+  provenance)
+
+(defun %kb-require-string (field value)
+  (unless (%non-empty-string-p value)
+    (error 'operational-kb-validation-error
+           :field field :value value :reason "expected non-empty string"))
+  value)
+
+(defun %kb-require-provenance (value)
+  (unless value
+    (error 'operational-kb-validation-error
+           :field :provenance :value value :reason "provenance is required"))
+  value)
+
+(defun %kb-require-evidence (value)
+  (unless (and (listp value) value (every #'%non-empty-string-p value))
+    (error 'operational-kb-validation-error
+           :field :evidence-ids :value value
+           :reason "at least one non-empty evidence ID is required"))
+  value)
+
+(defun operational-kb-graph-name (operation-id)
+  (%kb-require-string :operation-id operation-id)
+  (format nil "hackmode/kb/operational/~A" (%key-part operation-id)))
+
+(defun operational-kb-root-id (operation-id)
+  (%record-id "operational-kb-root" operation-id))
+
+(defun %operational-kb-assertion-prefix (operation-id)
+  (%record-id "operational-kb-assertion" operation-id))
+
+(defun make-operational-kb-assertion
+    (&key assertion-id operation-id run-id expert-id expert-version
+          key value evidence-ids provenance)
+  (%kb-require-string :assertion-id assertion-id)
+  (%kb-require-string :operation-id operation-id)
+  (%kb-require-string :run-id run-id)
+  (%kb-require-string :expert-id expert-id)
+  (%kb-require-string :expert-version expert-version)
+  (%kb-require-evidence evidence-ids)
+  (%kb-require-provenance provenance)
+  (when (null key)
+    (error 'operational-kb-validation-error
+           :field :key :value key :reason "assertion key is required"))
+  (%make-operational-kb-entry
+   :kind :assert
+   :operation-id operation-id
+   :run-id run-id
+   :expert-id expert-id
+   :expert-version expert-version
+   :record-id (%record-id "operational-kb-assertion"
+                          operation-id assertion-id)
+   :key key
+   :value value
+   :evidence-ids (copy-list evidence-ids)
+   :provenance provenance))
+
+(defun make-operational-kb-retraction
+    (&key retraction-id operation-id run-id expert-id expert-version
+          target-assertion-id evidence-ids provenance)
+  (%kb-require-string :retraction-id retraction-id)
+  (%kb-require-string :operation-id operation-id)
+  (%kb-require-string :run-id run-id)
+  (%kb-require-string :expert-id expert-id)
+  (%kb-require-string :expert-version expert-version)
+  (%kb-require-string :target-assertion-id target-assertion-id)
+  (%kb-require-evidence evidence-ids)
+  (%kb-require-provenance provenance)
+  (let ((prefix (%operational-kb-assertion-prefix operation-id)))
+    (unless (and (<= (length prefix) (length target-assertion-id))
+                 (string= prefix target-assertion-id :end2 (length prefix)))
+      (error 'operational-kb-validation-error
+             :field :target-assertion-id
+             :value target-assertion-id
+             :reason "target assertion is outside the operation scope")))
+  (%make-operational-kb-entry
+   :kind :retract
+   :operation-id operation-id
+   :run-id run-id
+   :expert-id expert-id
+   :expert-version expert-version
+   :record-id (%record-id "operational-kb-retraction"
+                          operation-id retraction-id)
+   :target-assertion-id target-assertion-id
+   :evidence-ids (copy-list evidence-ids)
+   :provenance provenance))
+
+(defun operational-kb-entry->tek9-node (entry)
+  (make-instance 'tek9:node
+                 :id (operational-kb-entry-record-id entry)
+                 :props (list :kind (operational-kb-entry-kind entry)
+                              :operation-id (operational-kb-entry-operation-id entry)
+                              :run-id (operational-kb-entry-run-id entry)
+                              :expert-id (operational-kb-entry-expert-id entry)
+                              :expert-version (operational-kb-entry-expert-version entry)
+                              :key (operational-kb-entry-key entry)
+                              :value (operational-kb-entry-value entry)
+                              :target-assertion-id
+                              (operational-kb-entry-target-assertion-id entry)
+                              :evidence-ids
+                              (operational-kb-entry-evidence-ids entry)
+                              :provenance
+                              (operational-kb-entry-provenance entry))))
+
+(defun operational-kb-root-node (operation-id)
+  (make-instance 'tek9:node
+                 :id (operational-kb-root-id operation-id)
+                 :props (list :kind :operational-kb-root
+                              :operation-id operation-id)))
+
+(defun operational-kb-membership-edge (assertion)
+  (unless (eq :assert (operational-kb-entry-kind assertion))
+    (error 'operational-kb-validation-error
+           :field :kind :value (operational-kb-entry-kind assertion)
+           :reason "membership edge requires assertion"))
+  (make-instance 'tek9:edge
+                 :id (%record-id "operational-kb-membership"
+                                 (operational-kb-entry-operation-id assertion)
+                                 (operational-kb-entry-record-id assertion))
+                 :source (operational-kb-root-id
+                          (operational-kb-entry-operation-id assertion))
+                 :predicate :contains
+                 :target (operational-kb-entry-record-id assertion)))
+
+(defun operational-kb-retraction-edge (retraction)
+  (unless (eq :retract (operational-kb-entry-kind retraction))
+    (error 'operational-kb-validation-error
+           :field :kind :value (operational-kb-entry-kind retraction)
+           :reason "retraction edge requires retraction"))
+  (make-instance 'tek9:edge
+                 :id (%record-id "operational-kb-retracted-by"
+                                 (operational-kb-entry-operation-id retraction)
+                                 (operational-kb-entry-target-assertion-id retraction)
+                                 (operational-kb-entry-record-id retraction))
+                 :source (operational-kb-entry-target-assertion-id retraction)
+                 :predicate :retracted-by
+                 :target (operational-kb-entry-record-id retraction)))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -22,5 +22,27 @@
    #:tool-result-link-edge
    #:persist-execution-record
    #:persist-tool-execution
+   #:operational-kb-validation-error
+   #:operational-kb-entry
+   #:operational-kb-entry-kind
+   #:operational-kb-entry-operation-id
+   #:operational-kb-entry-run-id
+   #:operational-kb-entry-expert-id
+   #:operational-kb-entry-expert-version
+   #:operational-kb-entry-record-id
+   #:operational-kb-entry-key
+   #:operational-kb-entry-value
+   #:operational-kb-entry-target-assertion-id
+   #:operational-kb-entry-evidence-ids
+   #:operational-kb-entry-provenance
+   #:make-operational-kb-assertion
+   #:make-operational-kb-retraction
+   #:operational-kb-graph-name
+   #:operational-kb-root-id
+   #:operational-kb-entry->tek9-node
+   #:operational-kb-membership-edge
+   #:operational-kb-retraction-edge
+   #:persist-operational-kb-entry
+   #:fetch-operational-kb-entry
    #:put-doc
    #:put-docs))

--- a/source/hackmode-database/tests/execution-graph.lisp
+++ b/source/hackmode-database/tests/execution-graph.lisp
@@ -8,7 +8,7 @@
   (unless condition
     (error (apply #'format nil format-control format-args))))
 
-(defun run-tests ()
+(defun run-execution-graph-tests ()
   (let* ((call (make-tool-call-record
                 :operation-id "op-1"
                 :run-id "run-1"
@@ -64,5 +64,78 @@
            :input nil
            :provenance '(:worker "database-test"))
           (error "empty operation identity unexpectedly accepted"))
-      (execution-graph-validation-error () t)))
+      (execution-graph-validation-error () t))))
+
+(defun run-operational-kb-tests ()
+  (let* ((assertion
+           (make-operational-kb-assertion
+            :assertion-id "a-1"
+            :operation-id "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "1"
+            :key '(:hypothesis "wildcard-dns")
+            :value '(:confidence 80)
+            :evidence-ids '("call-1" "result-1")
+            :provenance '(:worker "database-test")))
+         (same
+           (make-operational-kb-assertion
+            :assertion-id "a-1"
+            :operation-id "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "1"
+            :key '(:hypothesis "wildcard-dns")
+            :value '(:confidence 80)
+            :evidence-ids '("call-1" "result-1")
+            :provenance '(:worker "database-test")))
+         (retraction
+           (make-operational-kb-retraction
+            :retraction-id "r-1"
+            :operation-id "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "1"
+            :target-assertion-id (operational-kb-entry-record-id assertion)
+            :evidence-ids '("result-2")
+            :provenance '(:worker "database-test"))))
+    (ensure (eq :assert (operational-kb-entry-kind assertion))
+            "operational KB assertion has wrong kind")
+    (ensure (equal (operational-kb-entry-record-id assertion)
+                   (operational-kb-entry-record-id same))
+            "replaying the same assertion did not preserve identity")
+    (ensure (string= "op-1" (operational-kb-entry-operation-id assertion))
+            "operational KB assertion lost operation identity")
+    (ensure (equal '("call-1" "result-1")
+                   (operational-kb-entry-evidence-ids assertion))
+            "operational KB assertion lost evidence provenance")
+    (ensure (eq :retract (operational-kb-entry-kind retraction))
+            "operational KB retraction has wrong kind")
+    (ensure (string= (operational-kb-entry-record-id assertion)
+                     (operational-kb-entry-target-assertion-id retraction))
+            "retraction did not target exact assertion identity")
+    (let ((edge (operational-kb-retraction-edge retraction)))
+      (ensure (string= (operational-kb-entry-record-id assertion)
+                       (tek9:edge-source edge))
+              "retraction edge source drifted")
+      (ensure (string= (operational-kb-entry-record-id retraction)
+                       (tek9:edge-target edge))
+              "retraction edge target drifted"))
+    (handler-case
+        (progn
+          (make-operational-kb-retraction
+           :retraction-id "r-cross"
+           :operation-id "op-2"
+           :run-id "run-2"
+           :expert-id "recon"
+           :expert-version "1"
+           :target-assertion-id (operational-kb-entry-record-id assertion)
+           :evidence-ids '("result-x")
+           :provenance '(:worker "database-test"))
+          (error "cross-operation retraction unexpectedly accepted"))
+      (operational-kb-validation-error () t))))
+
+(defun run-tests ()
+  (run-execution-graph-tests)
+  (run-operational-kb-tests)
   t)


### PR DESCRIPTION
Bounded database-owned slice for #24/#27 after execution graph (#42) and typed Hackpert actions (#44).

Adds an append-only operational KB contract over canonical Tek9 graph storage:
- typed assertions/retractions with operation/run/expert/version provenance;
- required evidence IDs;
- deterministic replay-safe record IDs;
- operation-scoped graph identity;
- explicit assertion membership and retraction edges;
- no mutable shadow KB, direct Prolog write path, or Hackpert orchestration changes.

Concurrency decision: operational facts are immutable assertion nodes; retractions target exact assertion IDs. Concurrent workers therefore append independent evidence-bearing mutations instead of racing on a single mutable key/value row.

RED commit: 24ec6d61797280513564c11c7f7865481ba7f6a7
Current head: 32c65a383f4775c1d230913ed23b4f0239880e16