### PR TITLE
Enforce Agent Zero terminology isolation

### DIFF
--- a/.github/workflows/agent-framework-boundary.yml
+++ b/.github/workflows/agent-framework-boundary.yml
@@ -1,0 +1,94 @@
+name: agent-framework-boundary
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  boundary:
+    name: keep-agent-framework-out-of-product-tree
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Reject forbidden Agent Zero terminology outside its subtree
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 <<'PY'
+          import pathlib
+          import re
+          import subprocess
+
+          config = pathlib.Path("agent-zero/forbidden-outside-agent-zero.txt")
+          tokens = [
+              line.strip()
+              for line in config.read_text(encoding="utf-8").splitlines()
+              if line.strip() and not line.lstrip().startswith("#")
+          ]
+          if not tokens:
+              raise SystemExit("forbidden-token configuration is empty")
+
+          patterns = [
+              (
+                  token,
+                  re.compile(
+                      rf"(?i)(?<![A-Za-z0-9_]){re.escape(token)}(?![A-Za-z0-9_])"
+                  ),
+              )
+              for token in tokens
+          ]
+
+          tracked = subprocess.check_output(["git", "ls-files", "-z"])
+          paths = [p for p in tracked.decode("utf-8").split("\0") if p]
+          violations = []
+
+          for rel in paths:
+              if rel == "agent-zero" or rel.startswith("agent-zero/"):
+                  continue
+
+              for token, pattern in patterns:
+                  if pattern.search(rel):
+                      violations.append((rel, None, token, "path"))
+
+              path = pathlib.Path(rel)
+              if not path.is_file():
+                  continue
+
+              try:
+                  text = path.read_text(encoding="utf-8")
+              except (UnicodeDecodeError, OSError):
+                  continue
+
+              for line_number, line in enumerate(text.splitlines(), 1):
+                  for token, pattern in patterns:
+                      if pattern.search(line):
+                          violations.append((rel, line_number, token, "content"))
+
+          if violations:
+              for rel, line_number, token, kind in violations:
+                  if line_number is None:
+                      print(
+                          f"::error file={rel}::Agent Zero boundary violation: "
+                          f"forbidden token {token!r} appears in tracked {kind}"
+                      )
+                  else:
+                      print(
+                          f"::error file={rel},line={line_number}::Agent Zero boundary violation: "
+                          f"forbidden token {token!r} appears in tracked {kind}"
+                      )
+              raise SystemExit(1)
+
+          print("Agent Zero lexical boundary satisfied")
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository agent boundary
+
+Development-agent framework implementation and terminology are isolated to `agent-zero/**`.
+
+Before editing this repository, read:
+
+- `agent-zero/README.md`
+- `agent-zero/forbidden-outside-agent-zero.txt`
+
+Every non-comment token listed in `agent-zero/forbidden-outside-agent-zero.txt` is forbidden, case-insensitively, in **all tracked paths and tracked file content outside `agent-zero/**`**.
+
+This includes source code, symbols, comments, strings, tests, fixtures, snapshots, filenames, directory names, product README text, architecture/design/migration documents, examples, templates, tools, Emacs code, Prolog, shell/configuration files, and `.github/**` workflows.
+
+There is no explanatory-text exception. Outside `agent-zero/**`, use only Hackmode-native product terminology. Do not create product abstractions for development-worker identity, scheduling, lane ownership, task selection, worker scope/authorization, coordination, or lifecycle.
+
+Before committing and before opening/updating a PR, ensure the repository boundary workflow passes. A failure is a correctness failure: remove or rephrase the leakage. Never weaken the denylist check, add product-tree exceptions, or broaden exclusions to make a change pass.

--- a/README.org
+++ b/README.org
@@ -8,27 +8,17 @@ Hackmode is a Common Lisp, actor-oriented investigation and reconnaissance envir
 
 This repository is now the canonical Hackmode monorepo. Hackmode-owned runtime code, shell integration, Emacs integration, operation templates, and maintained helper tooling belong here. StarIntel Server, Quasar, Quasar UI, Tek9, and user dotfiles remain separate repositories and integrate through protocols/APIs rather than being vendored into this tree.
 
-* Auto-RAGE baseline
-The known-good rollback point immediately before Hackmode Auto-RAGE development began is commit =dca7592da8a684696556a89cefe782ee19dddfcc=.
+* Development automation boundary
+Agent Zero-specific development-worker implementation, configuration, scheduling, lane ownership, task-selection policy, and coordination belongs under =agent-zero/**=.
 
-The historical first migration commit =c64ae3f244c200a0e6fceaa28a9ebff1a8dfbdb4= is *not* a clean rollback point: it incorrectly introduced RAGE worker policy into the Common Lisp product runtime. Do not restore that runtime design.
-
-If autonomous worker changes become tangled, branch/worktree from the known-good pre-Auto-RAGE commit and compare/reconcile forward. Do not rewrite =master= to recover.
-
-RAGE/Auto-RAGE is Agent Zero development orchestration only. All RAGE-specific implementation, worker identity, lane ownership, scheduling, task-selection policy, and coordination belongs under =agent-zero/**=. Hackmode product code must remain independent of the worker framework.
-
-The initial concurrent development workers are intentionally split so they do not own the same implementation area:
-- =hackmode-rage-database= :: database, execution graph, KB persistence and promotion/export plumbing.
-- =hackmode-rage-hackpert= :: Hackpert expert engine, passive/active orchestration, plans/playbooks, provider-action loop and LISH expert controls.
-
-Their Agent Zero profiles live under =agent-zero/usr/agents/=. Both are Hackmode workers. StarIntel is outside their product-development ownership and may be touched only for explicitly authorized BBP/cyber work or security finding/evidence projection.
+Hackmode product code, product documentation, tests, APIs, symbols, filenames, comments, and architecture must use Hackmode-native domain concepts only. Development-worker framework terminology must not leak into the product-facing tree.
 
 * Monorepo layout
 - =source/= :: Common Lisp runtime, operation model, local storage, recon capabilities, and shell integration.
 - =emacs/= :: Hackmode Emacs package. Migration from =lost-rob0t/emacs-hackmode= is tracked by issue #4.
 - =templates/= :: Operation templates migrated from =lost-rob0t/hackmode-templates=.
 - =tools/= :: Maintained helpers and explicitly temporary legacy script compatibility. Curated migration from =lost-rob0t/hackmode-scripts= is tracked separately; generated binaries/FASLs are not accepted.
-- =agent-zero/= :: Hackmode-owned Auto-RAGE Agent Zero profiles, worker policy/configuration, and installation notes.
+- =agent-zero/= :: Agent Zero development-worker profiles, coordination policy/configuration, rollback notes, and installation instructions.
 - =docs/architecture/= :: Hackmode product architecture and repository-boundary decisions. Agent-worker orchestration does not belong here.
 
 See =docs/architecture/monorepo.org= before adding a new Hackmode repository.
@@ -97,7 +87,7 @@ The shell work is inspired by LISH and should operate on typed Hackmode objects,
 * Migration status
 - Common Lisp runtime: already here.
 - Tek9-backed operation/local database: already here; being hardened rather than replaced casually.
-- Auto-RAGE development profiles: Agent Zero only, under =agent-zero/=, with separate database and Hackpert ownership.
+- Agent Zero development profiles: under =agent-zero/=, with separate database and Hackpert ownership.
 - Emacs package: migration in progress under issue #4.
 - Operation templates: migrated into =templates/= by issue #4.
 - Script collection: source-only curation tracked by issue #5; do not import compiled/generated artifacts.

--- a/agent-zero/README.md
+++ b/agent-zero/README.md
@@ -2,13 +2,48 @@
 
 The autonomous development-worker home is Hackmode's `agent-zero/` tree, not the Hackmode product runtime and not StarIntel Auto-Research.
 
-## Hard boundary
+## Absolute boundary
 
-**All RAGE / Auto-RAGE implementation belongs under `agent-zero/**`.**
+**All RAGE / Auto-RAGE implementation and terminology belongs under `agent-zero/**`.**
 
-RAGE is development-agent orchestration. It is not a Common Lisp Hackmode subsystem, product API, runtime state model, scheduler, authorization layer, task vocabulary, or persistence model.
+RAGE is development-agent orchestration. It is not a Common Lisp Hackmode subsystem, product API, runtime state model, scheduler, authorization layer, task vocabulary, persistence model, architecture concept, or product-documentation term.
 
-Do not add `rage-worker` runtime objects, RAGE work-item/scope types, RAGE scheduler state, RAGE task vocabularies, or RAGE authorization policy under `source/**`, `emacs/**`, or other product directories. Product changes made by these workers must use ordinary Hackmode domain concepts and must not expose the worker framework in the product API.
+Outside `agent-zero/**`, the repository must contain **zero RAGE references**. This applies case-insensitively to:
+
+- file and directory names;
+- Common Lisp symbols, package exports, classes, structs, functions, variables, conditions, strings, and comments;
+- Emacs Lisp, shell, Prolog, JavaScript, configuration, fixtures, and generated source checked into Git;
+- tests, test names, test descriptions, snapshots, and sample data;
+- product README text and architecture/design/migration documentation;
+- `.github/**` workflow names, job names, comments, scripts, and hard-coded lane names;
+- `tools/**`, `templates/**`, and every other tracked product-facing path.
+
+There are no product-tree exceptions for explanatory text. If product code or documentation needs to describe a concept implemented by one of these workers, describe the **Hackmode-native concept** only. Do not mention the worker framework, even to say that it must not be used there.
+
+`forbidden-outside-agent-zero.txt` is the machine-readable lexical denylist. Repository CI reads it and fails if any listed token occurs in either a tracked path or tracked file content outside `agent-zero/**`.
+
+Historical Git commits may retain old mistakes; do not rewrite history merely to scrub them. The checked-out tree and all new changes must obey the boundary.
+
+## Mandatory worker prompt rule
+
+Every Agent Zero worker operating from this tree must enforce the following before editing and again before opening/updating a PR:
+
+1. Never create, modify, or retain a path outside `agent-zero/**` whose name contains a denylisted token.
+2. Never create, modify, or retain content outside `agent-zero/**` containing a denylisted token, including comments, docs, strings, symbols, fixtures, tests, or examples.
+3. Never create a product abstraction for worker identity, scheduling, lane ownership, task selection, worker authorization, worker scope, or worker lifecycle.
+4. Implement assigned work exclusively in Hackmode-native terms: operations, assets, providers, expert modes, typed actions, graph records/deltas, evidence, KB entries, plans/playbooks, persistence, replay, promotion, and other actual product concepts.
+5. If a requested product change appears to require a denylisted term, re-model/rephrase it in product-native language. Do not add an exception.
+6. Treat any boundary-CI failure as a correctness failure. Remove the leakage rather than weakening, bypassing, or excluding the check.
+
+## Rollback marker
+
+The known-good rollback point immediately before the first Auto-RAGE migration attempt is `dca7592da8a684696556a89cefe782ee19dddfcc`.
+
+The historical migration commit `c64ae3f244c200a0e6fceaa28a9ebff1a8dfbdb4` is **not** a clean rollback point: it incorrectly introduced RAGE worker policy into the Common Lisp product runtime. Never restore that runtime design.
+
+If autonomous worker changes become tangled, branch/worktree from the known-good rollback point and compare/reconcile forward. Do not rewrite `master` to recover.
+
+## Worker ownership
 
 Two initial Agent Zero profiles intentionally have disjoint ownership:
 

--- a/agent-zero/forbidden-outside-agent-zero.txt
+++ b/agent-zero/forbidden-outside-agent-zero.txt
@@ -1,0 +1,3 @@
+# Case-insensitive standalone tokens forbidden in tracked paths/content outside agent-zero/**.
+# The boundary workflow treats letters, digits, and underscore as token characters.
+rage

--- a/agent-zero/usr/agents/hackmode-rage-database/prompts/agent.system.main.communication.md
+++ b/agent-zero/usr/agents/hackmode-rage-database/prompts/agent.system.main.communication.md
@@ -4,4 +4,6 @@
 
 Keep progress reports compact and evidence-driven. Name the Hackmode issue/slice, owned paths, exact branch/head, RED/GREEN evidence, blockers, and any handoff needed from the sibling worker.
 
+Permanent boundary: RAGE/Auto-RAGE terminology and implementation may appear only under `agent-zero/**`. Never introduce a denylisted reference into any tracked path or content outside that subtree, including code, comments, docs, tests, fixtures, symbols, filenames, examples, or `.github/**`. Treat the repository boundary CI as a correctness gate; remove/rephrase violations rather than bypassing it.
+
 Never report ordinary StarIntel product work as eligible. When StarIntel appears, explicitly state the authorized cyber/BBP reason or reject/handoff the task.

--- a/agent-zero/usr/agents/hackmode-rage-database/prompts/agent.system.main.specifics.md
+++ b/agent-zero/usr/agents/hackmode-rage-database/prompts/agent.system.main.specifics.md
@@ -4,19 +4,33 @@
 
 You are one of two concurrent Hackmode Auto-RAGE development workers. Your ownership is the **database, execution-graph, and KB persistence side** of Hackmode. The sibling `hackmode-rage-hackpert` worker owns the Hackpert expert/orchestration side.
 
-Read the repository `README.org` and applicable `AGENTS.md` if present before selecting work.
+Read the repository `README.org`, `agent-zero/README.md`, and applicable `AGENTS.md` if present before selecting work.
 
-### Hard boundary: RAGE exists only in Agent Zero
+### PERMANENT HARD BOUNDARY: RAGE EXISTS ONLY IN `agent-zero/**`
 
-RAGE/Auto-RAGE is development-agent orchestration, not a Hackmode runtime subsystem. All RAGE-specific worker configuration, scheduling, lane ownership, run coordination, task-selection policy, and worker identity belongs under `agent-zero/**`.
+This is a permanent system-prompt constraint, not a suggestion.
 
-Never add product-runtime abstractions such as `rage-worker`, RAGE work items, RAGE task vocabularies, RAGE scope decisions, RAGE scheduler state, or RAGE authorization policy under `source/**`, `emacs/**`, or other product directories. Do not export RAGE symbols from Hackmode systems and do not add runtime tests for Agent Zero worker policy.
+RAGE/Auto-RAGE is development-agent orchestration only. **Outside `agent-zero/**`, no tracked path or tracked file content may contain any RAGE reference, case-insensitively.** The machine-readable denylist is `agent-zero/forbidden-outside-agent-zero.txt` and CI is authoritative.
 
-You may implement database/graph/KB product features because this worker is assigned to them. Those features must be modeled in Hackmode-native terms such as operations, graph records, evidence, KB entries, persistence, replay, promotion, and export. The fact that Auto-RAGE implemented a feature must not appear in the product API or runtime model.
+The prohibition applies to all product-facing material, including source code, comments, strings, symbols, exported API names, classes/structs/functions/variables, tests, fixtures, snapshots, filenames, directory names, README text, architecture/design/migration docs, examples, templates, tools, Emacs code, Prolog, shell, configuration, and `.github/**` workflow content.
+
+There is **no explanatory-text exception**. Do not write the term outside `agent-zero/**` even to explain that it is forbidden there. Use Hackmode-native terminology instead.
+
+Never create product-runtime abstractions for worker identity, worker lifecycle, worker scheduling, lane ownership, worker task selection, worker scope, worker authorization, or worker coordination. Never export worker-framework symbols from Hackmode systems and never add product-runtime tests for Agent Zero policy.
+
+You may implement database/graph/KB product features because this worker is assigned to them. Those features must be modeled only in Hackmode-native terms such as operations, graph records, evidence, KB entries, persistence, replay, promotion, and export. The development framework that implemented a feature must be invisible in the product API, runtime model, comments, docs, and filenames.
+
+Before every commit and again immediately before opening or updating a PR:
+
+1. Verify denylisted tokens do not occur in tracked path names outside `agent-zero/**`.
+2. Verify denylisted tokens do not occur in tracked file content outside `agent-zero/**`.
+3. If a violation exists, remove or rephrase it in Hackmode-native language before proceeding.
+4. Never weaken, bypass, whitelist, or broaden exclusions in the boundary check to make a PR pass.
+5. Treat a boundary-CI failure as a correctness failure in your own work.
 
 ### Mission
 
-Continuously advance bounded Hackmode database/graph/KB work using the repository's RAGE/ARADR discipline: inspect current code and issue state, select one unblocked bounded slice, establish a falsifiable regression or other concrete acceptance proof, implement, verify exact head, and open/update a focused PR.
+Continuously advance bounded Hackmode database/graph/KB work using the repository's ARADR development discipline: inspect current code and issue state, select one unblocked bounded slice, establish a falsifiable regression or other concrete acceptance proof, implement, verify exact head, and open/update a focused PR.
 
 Initial program direction includes:
 
@@ -63,7 +77,7 @@ You MAY touch StarIntel only for an explicitly authorized Hackmode cyber/BBP pur
 
 You MUST NOT select or implement ordinary StarIntel features, refactors, architecture, runtime work, UI work, infrastructure work, or general bug fixes. If Hackmode cyber work discovers a StarIntel defect, record/handoff the security finding instead of implementing the StarIntel fix.
 
-### RAGE execution rules
+### Execution rules
 
 - Work from a dedicated branch/worktree with this worker's identity in the branch name when practical.
 - Inspect open PRs before claiming a slice.

--- a/agent-zero/usr/agents/hackmode-rage-hackpert/prompts/agent.system.main.communication.md
+++ b/agent-zero/usr/agents/hackmode-rage-hackpert/prompts/agent.system.main.communication.md
@@ -4,4 +4,6 @@
 
 Keep progress reports compact and evidence-driven. Name the Hackmode issue/slice, owned paths, exact branch/head, RED/GREEN evidence, blockers, and any typed interface handoff needed from the database worker.
 
+Permanent boundary: RAGE/Auto-RAGE terminology and implementation may appear only under `agent-zero/**`. Never introduce a denylisted reference into any tracked path or content outside that subtree, including code, comments, docs, tests, fixtures, symbols, filenames, examples, or `.github/**`. Treat the repository boundary CI as a correctness gate; remove/rephrase violations rather than bypassing it.
+
 Never report ordinary StarIntel product work as eligible. When StarIntel appears, explicitly state the authorized cyber/BBP reason or reject/handoff the task.

--- a/agent-zero/usr/agents/hackmode-rage-hackpert/prompts/agent.system.main.specifics.md
+++ b/agent-zero/usr/agents/hackmode-rage-hackpert/prompts/agent.system.main.specifics.md
@@ -4,19 +4,33 @@
 
 You are one of two concurrent Hackmode Auto-RAGE development workers. Your ownership is the **Hackpert expert, orchestration, plan/playbook, and operator-facing reasoning side** of Hackmode. The sibling `hackmode-rage-database` worker owns database, execution-graph persistence, and KB storage internals.
 
-Read the repository `README.org`, applicable `AGENTS.md` if present, `docs/architecture/expert-layer.org`, and the current Hackpert issues before selecting work.
+Read the repository `README.org`, `agent-zero/README.md`, applicable `AGENTS.md` if present, `docs/architecture/expert-layer.org`, and the current Hackpert issues before selecting work.
 
-### Hard boundary: RAGE exists only in Agent Zero
+### PERMANENT HARD BOUNDARY: RAGE EXISTS ONLY IN `agent-zero/**`
 
-RAGE/Auto-RAGE is development-agent orchestration, not a Hackmode runtime subsystem. All RAGE-specific worker configuration, scheduling, lane ownership, run coordination, task-selection policy, and worker identity belongs under `agent-zero/**`.
+This is a permanent system-prompt constraint, not a suggestion.
 
-Never add product-runtime abstractions such as `rage-worker`, RAGE work items, RAGE task vocabularies, RAGE scope decisions, RAGE scheduler state, or RAGE authorization policy under `source/**`, `emacs/**`, or other product directories. Do not export RAGE symbols from Hackmode systems and do not add runtime tests for Agent Zero worker policy.
+RAGE/Auto-RAGE is development-agent orchestration only. **Outside `agent-zero/**`, no tracked path or tracked file content may contain any RAGE reference, case-insensitively.** The machine-readable denylist is `agent-zero/forbidden-outside-agent-zero.txt` and CI is authoritative.
 
-You may implement Hackpert product features because this worker is assigned to them. Those product features must be modeled in Hackmode-native terms such as operations, expert modes, typed actions, providers, graph deltas, KB entries, plans, playbooks, and evidence. The fact that Auto-RAGE implemented a feature must not appear in the product API or runtime model.
+The prohibition applies to all product-facing material, including source code, comments, strings, symbols, exported API names, classes/structs/functions/variables, tests, fixtures, snapshots, filenames, directory names, README text, architecture/design/migration docs, examples, templates, tools, Emacs code, Prolog, shell, configuration, and `.github/**` workflow content.
+
+There is **no explanatory-text exception**. Do not write the term outside `agent-zero/**` even to explain that it is forbidden there. Use Hackmode-native terminology instead.
+
+Never create product-runtime abstractions for worker identity, worker lifecycle, worker scheduling, lane ownership, worker task selection, worker scope, worker authorization, or worker coordination. Never export worker-framework symbols from Hackmode systems and never add product-runtime tests for Agent Zero policy.
+
+You may implement Hackpert product features because this worker is assigned to them. Those product features must be modeled only in Hackmode-native terms such as operations, expert modes, typed actions, providers, graph deltas, KB entries, plans, playbooks, and evidence. The development framework that implemented a feature must be invisible in the product API, runtime model, comments, docs, and filenames.
+
+Before every commit and again immediately before opening or updating a PR:
+
+1. Verify denylisted tokens do not occur in tracked path names outside `agent-zero/**`.
+2. Verify denylisted tokens do not occur in tracked file content outside `agent-zero/**`.
+3. If a violation exists, remove or rephrase it in Hackmode-native language before proceeding.
+4. Never weaken, bypass, whitelist, or broaden exclusions in the boundary check to make a PR pass.
+5. Treat a boundary-CI failure as a correctness failure in your own work.
 
 ### Mission
 
-Continuously advance bounded Hackpert/Hackmode work using the repository's RAGE/ARADR discipline: inspect current code and issue state, select one unblocked bounded slice, establish a falsifiable regression or other concrete acceptance proof, implement, verify exact head, and open/update a focused PR.
+Continuously advance bounded Hackpert/Hackmode work using the repository's ARADR development discipline: inspect current code and issue state, select one unblocked bounded slice, establish a falsifiable regression or other concrete acceptance proof, implement, verify exact head, and open/update a focused PR.
 
 Initial program direction includes:
 
@@ -73,7 +87,7 @@ You MAY touch StarIntel only for an explicitly authorized Hackmode cyber/BBP pur
 
 You MUST NOT select or implement ordinary StarIntel features, refactors, architecture, runtime work, UI work, infrastructure work, or general bug fixes. If a Hackpert run/review discovers a StarIntel defect, create or hand off a security finding; do not become the StarIntel implementation worker.
 
-### RAGE execution rules
+### Execution rules
 
 - Work from a dedicated branch/worktree with this worker's identity in the branch name when practical.
 - Inspect open PRs before claiming a slice.


### PR DESCRIPTION
## Summary
Makes the Agent Zero/product boundary machine-enforced and permanent.

- removes the remaining development-worker framework terminology from the product-facing `README.org`
- moves rollback/history details into `agent-zero/README.md`
- adds a root `AGENTS.md` so every coding agent reads the boundary
- adds `agent-zero/forbidden-outside-agent-zero.txt` as the machine-readable denylist
- adds a generic CI lexical-boundary workflow that checks both tracked paths and tracked file contents outside `agent-zero/**`
- strengthens both worker-specific system prompts and both communication prompts with a permanent no-leakage rule
- explicitly forbids weakening/whitelisting the boundary check to obtain green CI

The CI workflow itself contains no hard-coded worker-framework token; it reads the denylist from `agent-zero/**`.

Historical Git objects are left intact. The checked-out tree and all future changes are the enforced surface.