### PR TITLE
Database: add evidence-backed long-term KB promotion

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -69,3 +69,23 @@
   "Fetch one operational KB graph node by stable RECORD-ID."
   (tek9:fetch-node database record-id
                    :database-name (operational-kb-graph-name operation-id)))
+
+(defun persist-long-term-kb-promotion (database promotion)
+  "Persist one immutable evidence-backed promotion through canonical Tek9 graph APIs."
+  (let ((graph-name (long-term-kb-graph-name)))
+    (tek9:put-nodes database
+                    (list (long-term-kb-root-node)
+                          (long-term-kb-promotion->tek9-node promotion))
+                    :database-name graph-name)
+    (tek9:put-edge database
+                   (long-term-kb-membership-edge promotion)
+                   :database-name graph-name)
+    (tek9:put-edge database
+                   (long-term-kb-source-edge promotion)
+                   :database-name graph-name))
+  promotion)
+
+(defun fetch-long-term-kb-promotion (database record-id)
+  "Fetch one long-term KB promotion by its stable record identity."
+  (tek9:fetch-node database record-id
+                   :database-name (long-term-kb-graph-name)))

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -2,7 +2,9 @@
   :description "Regression tests for Hackmode database graph/KB persistence"
   :depends-on (#:hackmode-database)
   :serial t
-  :components ((:file "tests/execution-graph"))
+  :components ((:file "tests/execution-graph")
+               (:file "tests/long-term-kb"))
   :perform (test-op (op system)
              (declare (ignore op system))
-             (uiop:symbol-call :hackmode-database-tests :run-tests)))
+             (uiop:symbol-call :hackmode-database-tests :run-tests)
+             (uiop:symbol-call :hackmode-database-tests :run-long-term-kb-tests)))

--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -9,4 +9,5 @@
   :components ((:file "package")
                (:file "execution-graph")
                (:file "operational-kb")
+               (:file "long-term-kb")
                (:file "db")))

--- a/source/hackmode-database/long-term-kb.lisp
+++ b/source/hackmode-database/long-term-kb.lisp
@@ -1,0 +1,142 @@
+(in-package :hackmode-database)
+
+(define-condition long-term-kb-validation-error (error)
+  ((field :initarg :field :reader long-term-kb-error-field)
+   (value :initarg :value :reader long-term-kb-error-value)
+   (reason :initarg :reason :reader long-term-kb-error-reason))
+  (:report (lambda (condition stream)
+             (format stream "Invalid long-term KB field ~S: ~A (~S)"
+                     (long-term-kb-error-field condition)
+                     (long-term-kb-error-reason condition)
+                     (long-term-kb-error-value condition)))))
+
+(defstruct (long-term-kb-promotion
+             (:constructor %make-long-term-kb-promotion))
+  record-id
+  source-operation-id
+  source-assertion-id
+  source-run-id
+  source-expert-id
+  source-expert-version
+  source-evidence-ids
+  key
+  value
+  promoted-by
+  promoter-version
+  evidence-ids
+  provenance)
+
+(defun %long-term-require-string (field value)
+  (unless (%non-empty-string-p value)
+    (error 'long-term-kb-validation-error
+           :field field :value value :reason "expected non-empty string"))
+  value)
+
+(defun %long-term-require-evidence (field value)
+  (unless (and (listp value) value (every #'%non-empty-string-p value))
+    (error 'long-term-kb-validation-error
+           :field field :value value
+           :reason "at least one non-empty evidence ID is required"))
+  value)
+
+(defun long-term-kb-graph-name ()
+  "Return the canonical reusable-knowledge graph name."
+  "hackmode/kb/long-term")
+
+(defun long-term-kb-root-id ()
+  (%record-id "long-term-kb-root"))
+
+(defun make-long-term-kb-promotion
+    (&key promotion-id source-assertion promoted-by promoter-version
+          evidence-ids provenance)
+  "Create one immutable evidence-backed promotion from operational knowledge.
+
+Promotion copies the source assertion's semantic value and provenance identity.
+It never mutates or deletes the operational assertion and does not imply global
+export. Multiple operations may independently promote corroborating knowledge."
+  (%long-term-require-string :promotion-id promotion-id)
+  (%long-term-require-string :promoted-by promoted-by)
+  (%long-term-require-string :promoter-version promoter-version)
+  (%long-term-require-evidence :evidence-ids evidence-ids)
+  (unless provenance
+    (error 'long-term-kb-validation-error
+           :field :provenance :value provenance :reason "provenance is required"))
+  (unless (typep source-assertion 'operational-kb-entry)
+    (error 'long-term-kb-validation-error
+           :field :source-assertion :value source-assertion
+           :reason "expected operational KB entry"))
+  (unless (eq :assert (operational-kb-entry-kind source-assertion))
+    (error 'long-term-kb-validation-error
+           :field :source-assertion :value source-assertion
+           :reason "only operational assertions may be promoted"))
+  (%long-term-require-evidence
+   :source-evidence-ids
+   (operational-kb-entry-evidence-ids source-assertion))
+  (%make-long-term-kb-promotion
+   :record-id (%record-id "long-term-kb-promotion"
+                          (operational-kb-entry-operation-id source-assertion)
+                          (operational-kb-entry-record-id source-assertion)
+                          promotion-id)
+   :source-operation-id (operational-kb-entry-operation-id source-assertion)
+   :source-assertion-id (operational-kb-entry-record-id source-assertion)
+   :source-run-id (operational-kb-entry-run-id source-assertion)
+   :source-expert-id (operational-kb-entry-expert-id source-assertion)
+   :source-expert-version (operational-kb-entry-expert-version source-assertion)
+   :source-evidence-ids (copy-list
+                         (operational-kb-entry-evidence-ids source-assertion))
+   :key (operational-kb-entry-key source-assertion)
+   :value (operational-kb-entry-value source-assertion)
+   :promoted-by promoted-by
+   :promoter-version promoter-version
+   :evidence-ids (copy-list evidence-ids)
+   :provenance provenance))
+
+(defun long-term-kb-promotion->tek9-node (promotion)
+  (make-instance 'tek9:node
+                 :id (long-term-kb-promotion-record-id promotion)
+                 :props
+                 (list :kind :long-term-kb-promotion
+                       :source-operation-id
+                       (long-term-kb-promotion-source-operation-id promotion)
+                       :source-assertion-id
+                       (long-term-kb-promotion-source-assertion-id promotion)
+                       :source-run-id
+                       (long-term-kb-promotion-source-run-id promotion)
+                       :source-expert-id
+                       (long-term-kb-promotion-source-expert-id promotion)
+                       :source-expert-version
+                       (long-term-kb-promotion-source-expert-version promotion)
+                       :source-evidence-ids
+                       (long-term-kb-promotion-source-evidence-ids promotion)
+                       :key (long-term-kb-promotion-key promotion)
+                       :value (long-term-kb-promotion-value promotion)
+                       :promoted-by (long-term-kb-promotion-promoted-by promotion)
+                       :promoter-version
+                       (long-term-kb-promotion-promoter-version promotion)
+                       :evidence-ids
+                       (long-term-kb-promotion-evidence-ids promotion)
+                       :provenance
+                       (long-term-kb-promotion-provenance promotion))))
+
+(defun long-term-kb-root-node ()
+  (make-instance 'tek9:node
+                 :id (long-term-kb-root-id)
+                 :props (list :kind :long-term-kb-root)))
+
+(defun long-term-kb-membership-edge (promotion)
+  (make-instance 'tek9:edge
+                 :id (%record-id "long-term-kb-membership"
+                                 (long-term-kb-promotion-record-id promotion))
+                 :source (long-term-kb-root-id)
+                 :predicate :contains
+                 :target (long-term-kb-promotion-record-id promotion)))
+
+(defun long-term-kb-source-edge (promotion)
+  "Return the provenance edge back to the exact operational assertion ID."
+  (make-instance 'tek9:edge
+                 :id (%record-id "long-term-kb-promoted-from"
+                                 (long-term-kb-promotion-record-id promotion)
+                                 (long-term-kb-promotion-source-assertion-id promotion))
+                 :source (long-term-kb-promotion-record-id promotion)
+                 :predicate :promoted-from
+                 :target (long-term-kb-promotion-source-assertion-id promotion)))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -44,5 +44,28 @@
    #:operational-kb-retraction-edge
    #:persist-operational-kb-entry
    #:fetch-operational-kb-entry
+   #:long-term-kb-validation-error
+   #:long-term-kb-promotion
+   #:long-term-kb-promotion-record-id
+   #:long-term-kb-promotion-source-operation-id
+   #:long-term-kb-promotion-source-assertion-id
+   #:long-term-kb-promotion-source-run-id
+   #:long-term-kb-promotion-source-expert-id
+   #:long-term-kb-promotion-source-expert-version
+   #:long-term-kb-promotion-source-evidence-ids
+   #:long-term-kb-promotion-key
+   #:long-term-kb-promotion-value
+   #:long-term-kb-promotion-promoted-by
+   #:long-term-kb-promotion-promoter-version
+   #:long-term-kb-promotion-evidence-ids
+   #:long-term-kb-promotion-provenance
+   #:make-long-term-kb-promotion
+   #:long-term-kb-graph-name
+   #:long-term-kb-root-id
+   #:long-term-kb-promotion->tek9-node
+   #:long-term-kb-membership-edge
+   #:long-term-kb-source-edge
+   #:persist-long-term-kb-promotion
+   #:fetch-long-term-kb-promotion
    #:put-doc
    #:put-docs))

--- a/source/hackmode-database/tests/long-term-kb.lisp
+++ b/source/hackmode-database/tests/long-term-kb.lisp
@@ -1,0 +1,83 @@
+(in-package :hackmode-database-tests)
+
+(defun run-long-term-kb-tests ()
+  (let* ((source
+           (make-operational-kb-assertion
+            :assertion-id "a-promote"
+            :operation-id "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "1"
+            :key '(:service-pattern "nginx")
+            :value '(:stable t)
+            :evidence-ids '("call-1" "result-1")
+            :provenance '(:source "fixture")))
+         (promotion
+           (make-long-term-kb-promotion
+            :promotion-id "p-1"
+            :source-assertion source
+            :promoted-by "operator-policy"
+            :promoter-version "1"
+            :evidence-ids '("review-1")
+            :provenance '(:reason "validated reusable pattern")))
+         (same
+           (make-long-term-kb-promotion
+            :promotion-id "p-1"
+            :source-assertion source
+            :promoted-by "operator-policy"
+            :promoter-version "1"
+            :evidence-ids '("review-1")
+            :provenance '(:reason "validated reusable pattern"))))
+    (ensure (string= (long-term-kb-promotion-record-id promotion)
+                     (long-term-kb-promotion-record-id same))
+            "replaying a promotion changed its identity")
+    (ensure (string= "op-1"
+                     (long-term-kb-promotion-source-operation-id promotion))
+            "promotion lost source operation identity")
+    (ensure (string= (operational-kb-entry-record-id source)
+                     (long-term-kb-promotion-source-assertion-id promotion))
+            "promotion lost exact source assertion identity")
+    (ensure (equal '("call-1" "result-1")
+                   (long-term-kb-promotion-source-evidence-ids promotion))
+            "promotion lost source evidence")
+    (ensure (equal '("review-1")
+                   (long-term-kb-promotion-evidence-ids promotion))
+            "promotion lost promotion evidence")
+    (ensure (equal (operational-kb-entry-key source)
+                   (long-term-kb-promotion-key promotion))
+            "promotion key drifted from source assertion")
+    (ensure (equal (operational-kb-entry-value source)
+                   (long-term-kb-promotion-value promotion))
+            "promotion value drifted from source assertion")
+    (let ((node (long-term-kb-promotion->tek9-node promotion))
+          (edge (long-term-kb-source-edge promotion)))
+      (ensure (string= (long-term-kb-promotion-record-id promotion)
+                       (tek9:node-id node))
+              "long-term promotion Tek9 identity drifted")
+      (ensure (string= (long-term-kb-promotion-record-id promotion)
+                       (tek9:edge-source edge))
+              "promotion source edge has wrong source")
+      (ensure (string= (operational-kb-entry-record-id source)
+                       (tek9:edge-target edge))
+              "promotion source edge lost operational assertion identity"))
+    (handler-case
+        (progn
+          (make-long-term-kb-promotion
+           :promotion-id "p-bad"
+           :source-assertion
+           (make-operational-kb-retraction
+            :retraction-id "r-1"
+            :operation-id "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "1"
+            :target-assertion-id (operational-kb-entry-record-id source)
+            :evidence-ids '("result-2")
+            :provenance '(:source "fixture"))
+           :promoted-by "operator-policy"
+           :promoter-version "1"
+           :evidence-ids '("review-2")
+           :provenance '(:reason "invalid"))
+          (error "retraction unexpectedly promoted into long-term KB"))
+      (long-term-kb-validation-error () t)))
+  t)


### PR DESCRIPTION
Bounded database-owned slice for #24/#27 after merged operational KB #45.

Adds an explicit promotion boundary from operation-scoped assertions into reusable long-term knowledge:
- immutable promotion records in the canonical Tek9 graph;
- exact source operation/assertion/run/expert/version provenance;
- source evidence is copied forward and promotion evidence is separately required;
- promotion key/value are derived from the source assertion, not caller-rewritten;
- deterministic replay-safe promotion IDs;
- retractions cannot be promoted;
- no implicit global export and no Hackpert orchestration changes.

This is intentionally a promotion ledger, not a mutable aggregate or second KB authority. Multiple operations may independently promote corroborating knowledge; later global export can select from these durable records explicitly.

RED commits: 2cc57c17f5a8f19f0d1d95f72ded7b5e5ec4156e / 7c7848376df3b41ebc9bd2d3476ee6dc00afced9
Current exact head: 10f9f31fe03066f3341b9079d8341d9022a732d6