### PR TITLE
Hackpert: reconcile typed provider orchestration onto current master

### DIFF
--- a/source/hackmode-core/expert/orchestration.lisp
+++ b/source/hackmode-core/expert/orchestration.lisp
@@ -1,0 +1,38 @@
+(in-package :hackmode)
+
+(defstruct expert-dispatch-request
+  "Result of admitting one Hackpert dispatch action into Hackmode's provider path."
+  action
+  result)
+
+(defun dispatch-expert-action (engine action
+                               &key operation run-id
+                                 (dispatcher #'dispatch-capability)
+                                 actor time-out)
+  "Validate ACTION, then route a dispatch request through Hackmode's canonical provider dispatcher.
+
+This function owns no tool executor and performs no direct persistence. It only
+admits one :DISPATCH action after authority/scope validation and delegates the
+actual execution path to DISPATCHER, which defaults to DISPATCH-CAPABILITY."
+  (check-type dispatcher function)
+  (validate-expert-active-action engine action
+                                 :operation operation
+                                 :run-id run-id)
+  (unless (eq :dispatch (expert-active-action-kind action))
+    (invalid-expert-action action
+                           "provider orchestration accepts :DISPATCH actions only"))
+  (let* ((payload (expert-active-action-payload action))
+         (result
+           (funcall dispatcher
+                    (expert-dispatch-payload-capability payload)
+                    (expert-dispatch-payload-input payload)
+                    :provider (expert-dispatch-payload-provider payload)
+                    :actor actor
+                    :time-out time-out)))
+    (make-expert-dispatch-request :action action :result result)))
+
+(export '(expert-dispatch-request
+          make-expert-dispatch-request
+          expert-dispatch-request-action
+          expert-dispatch-request-result
+          dispatch-expert-action))

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -3,8 +3,10 @@
   :depends-on (#:hackmode)
   :serial t
   :components ((:file "tests/core-state")
-               (:file "tests/expert"))
+               (:file "tests/expert")
+               (:file "tests/expert-orchestration"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
-             (uiop:symbol-call :hackmode-tests :run-expert-tests)))
+             (uiop:symbol-call :hackmode-tests :run-expert-tests)
+             (uiop:symbol-call :hackmode-tests :run-expert-orchestration-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -34,7 +34,8 @@
                (:module "expert-actions"
                 :pathname "expert/"
                 :serial t
-                :components ((:file "actions")))
+                :components ((:file "actions")
+                             (:file "orchestration")))
                (:file "functions")
                (:file "exploits")
                (:file "hackmode")))

--- a/source/hackmode-core/tests/expert-orchestration.lisp
+++ b/source/hackmode-core/tests/expert-orchestration.lisp
@@ -1,0 +1,69 @@
+(in-package :hackmode-tests)
+
+(defun run-expert-orchestration-tests ()
+  (let* ((passive (hackmode:make-expert-engine))
+         (active (hackmode:make-expert-engine :mode :active))
+         (payload (hackmode:make-expert-dispatch-payload
+                   :capability "dns-resolve"
+                   :provider "fixture"
+                   :input "example.com"))
+         (action (hackmode:make-expert-active-action
+                  :id "dispatch-1"
+                  :kind :dispatch
+                  :operation "op-1"
+                  :run-id "run-1"
+                  :expert-id "recon"
+                  :expert-version "1"
+                  :evidence-ids '("evidence-1")
+                  :payload payload))
+         (calls 0)
+         (seen nil)
+         (dispatcher
+           (lambda (capability input &key provider actor time-out)
+             (declare (ignore actor time-out))
+             (incf calls)
+             (setf seen (list capability input provider))
+             :future-token)))
+    (let ((dispatch
+            (hackmode:dispatch-expert-action
+             active action
+             :operation "op-1"
+             :run-id "run-1"
+             :dispatcher dispatcher)))
+      (assert-equal 1 calls "active dispatch calls canonical dispatcher once")
+      (assert-equal '("dns-resolve" "example.com" "fixture") seen
+                    "active dispatch preserves typed provider request")
+      (assert-equal action (hackmode:expert-dispatch-request-action dispatch)
+                    "dispatch result retains source action")
+      (assert-equal :future-token (hackmode:expert-dispatch-request-result dispatch)
+                    "dispatch result retains canonical dispatcher result"))
+    (handler-case
+        (progn
+          (hackmode:dispatch-expert-action passive action
+                                           :operation "op-1" :run-id "run-1"
+                                           :dispatcher dispatcher)
+          (error "passive Hackpert unexpectedly dispatched a provider"))
+      (hackmode:expert-effect-denied () t))
+    (assert-equal 1 calls "passive rejection happens before dispatch")
+    (handler-case
+        (progn
+          (hackmode:dispatch-expert-action active action
+                                           :operation "other-op" :run-id "run-1"
+                                           :dispatcher dispatcher)
+          (error "cross-operation action unexpectedly dispatched"))
+      (hackmode:invalid-expert-action () t))
+    (assert-equal 1 calls "scope mismatch happens before dispatch")
+    (let ((mutation
+            (hackmode:make-expert-active-action
+             :id "mutation-1" :kind :discover :operation "op-1" :run-id "run-1"
+             :expert-id "recon" :expert-version "1"
+             :payload (hackmode:make-expert-discover-payload :asset "asset-1"))))
+      (handler-case
+          (progn
+            (hackmode:dispatch-expert-action active mutation
+                                             :operation "op-1" :run-id "run-1"
+                                             :dispatcher dispatcher)
+            (error "non-dispatch active action unexpectedly entered provider path"))
+        (hackmode:invalid-expert-action () t)))
+    (assert-equal 1 calls "provider orchestration accepts dispatch actions only")
+    t))


### PR DESCRIPTION
Forward reconciliation of #47 onto current master after database #45 merged.

Bounded #27 slice:
- validates active authority plus exact operation/run scope before effects;
- accepts typed `:dispatch` actions only;
- delegates to canonical `dispatch-capability` provider runtime;
- preserves source action and canonical dispatcher result;
- passive, cross-operation, and non-dispatch actions fail before provider invocation;
- no direct Tek9/KB persistence and no second executor.

The original #47 exact head `218bf0b97b75f00022bc4413e8f10076e432a01f` passed core, monorepo, and boundary CI before master moved. This branch reconstructs the same product slice from current master `01cfaf29d513e7669da8fc73ad62c4ddef8cc540`, preserving the newly merged operational-KB work without modifying database internals.

Current exact head: `2e2191e168bced54dd0a74046bcc8cf44100c573`.

Open provider PR #48 changes separate provider/workflow/profile files; no overlapping product files were absorbed.