### PR TITLE
Database: add explicit global KB export lifecycle

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -89,3 +89,23 @@
   "Fetch one long-term KB promotion by its stable record identity."
   (tek9:fetch-node database record-id
                    :database-name (long-term-kb-graph-name)))
+
+(defun persist-global-kb-export (database export)
+  "Persist one explicit immutable export through canonical Tek9 graph APIs."
+  (let ((graph-name (global-kb-graph-name)))
+    (tek9:put-nodes database
+                    (list (global-kb-root-node)
+                          (global-kb-export->tek9-node export))
+                    :database-name graph-name)
+    (tek9:put-edge database
+                   (global-kb-membership-edge export)
+                   :database-name graph-name)
+    (tek9:put-edge database
+                   (global-kb-source-edge export)
+                   :database-name graph-name))
+  export)
+
+(defun fetch-global-kb-export (database record-id)
+  "Fetch one explicit global KB export by stable record identity."
+  (tek9:fetch-node database record-id
+                   :database-name (global-kb-graph-name)))

--- a/source/hackmode-database/global-kb.lisp
+++ b/source/hackmode-database/global-kb.lisp
@@ -1,0 +1,150 @@
+(in-package :hackmode-database)
+
+(define-condition global-kb-validation-error (error)
+  ((field :initarg :field :reader global-kb-error-field)
+   (value :initarg :value :reader global-kb-error-value)
+   (reason :initarg :reason :reader global-kb-error-reason))
+  (:report (lambda (condition stream)
+             (format stream "Invalid global KB field ~S: ~A (~S)"
+                     (global-kb-error-field condition)
+                     (global-kb-error-reason condition)
+                     (global-kb-error-value condition)))))
+
+(defstruct (global-kb-export
+             (:constructor %make-global-kb-export))
+  record-id
+  source-promotion-id
+  source-operation-id
+  source-assertion-id
+  source-run-id
+  source-expert-id
+  source-expert-version
+  source-evidence-ids
+  promotion-evidence-ids
+  key
+  value
+  exported-by
+  exporter-version
+  evidence-ids
+  provenance)
+
+(defun %global-require-string (field value)
+  (unless (%non-empty-string-p value)
+    (error 'global-kb-validation-error
+           :field field :value value :reason "expected non-empty string"))
+  value)
+
+(defun %global-require-evidence (field value)
+  (unless (and (listp value) value (every #'%non-empty-string-p value))
+    (error 'global-kb-validation-error
+           :field field :value value
+           :reason "at least one non-empty evidence ID is required"))
+  value)
+
+(defun global-kb-graph-name ()
+  "Return the canonical explicitly exported reusable-knowledge graph name."
+  "hackmode/kb/global")
+
+(defun global-kb-root-id ()
+  (%record-id "global-kb-root"))
+
+(defun make-global-kb-export
+    (&key export-id source-promotion exported-by exporter-version
+          evidence-ids provenance)
+  "Create one explicit immutable export from long-term knowledge.
+
+The exported key/value and source provenance are copied from SOURCE-PROMOTION.
+Callers cannot rewrite the promoted claim while exporting it. Constructing an
+export does not persist it; persistence remains an explicit canonical Tek9 write."
+  (%global-require-string :export-id export-id)
+  (%global-require-string :exported-by exported-by)
+  (%global-require-string :exporter-version exporter-version)
+  (%global-require-evidence :evidence-ids evidence-ids)
+  (unless provenance
+    (error 'global-kb-validation-error
+           :field :provenance :value provenance :reason "provenance is required"))
+  (unless (typep source-promotion 'long-term-kb-promotion)
+    (error 'global-kb-validation-error
+           :field :source-promotion :value source-promotion
+           :reason "expected long-term KB promotion"))
+  (%global-require-evidence
+   :source-evidence-ids
+   (long-term-kb-promotion-source-evidence-ids source-promotion))
+  (%global-require-evidence
+   :promotion-evidence-ids
+   (long-term-kb-promotion-evidence-ids source-promotion))
+  (%make-global-kb-export
+   :record-id (%record-id "global-kb-export"
+                          (long-term-kb-promotion-record-id source-promotion)
+                          export-id)
+   :source-promotion-id (long-term-kb-promotion-record-id source-promotion)
+   :source-operation-id (long-term-kb-promotion-source-operation-id source-promotion)
+   :source-assertion-id (long-term-kb-promotion-source-assertion-id source-promotion)
+   :source-run-id (long-term-kb-promotion-source-run-id source-promotion)
+   :source-expert-id (long-term-kb-promotion-source-expert-id source-promotion)
+   :source-expert-version
+   (long-term-kb-promotion-source-expert-version source-promotion)
+   :source-evidence-ids
+   (copy-list (long-term-kb-promotion-source-evidence-ids source-promotion))
+   :promotion-evidence-ids
+   (copy-list (long-term-kb-promotion-evidence-ids source-promotion))
+   :key (long-term-kb-promotion-key source-promotion)
+   :value (long-term-kb-promotion-value source-promotion)
+   :exported-by exported-by
+   :exporter-version exporter-version
+   :evidence-ids (copy-list evidence-ids)
+   :provenance provenance))
+
+(defun global-kb-export->tek9-node (export)
+  (make-instance 'tek9:node
+                 :id (global-kb-export-record-id export)
+                 :props
+                 (list :kind :global-kb-export
+                       :source-promotion-id
+                       (global-kb-export-source-promotion-id export)
+                       :source-operation-id
+                       (global-kb-export-source-operation-id export)
+                       :source-assertion-id
+                       (global-kb-export-source-assertion-id export)
+                       :source-run-id
+                       (global-kb-export-source-run-id export)
+                       :source-expert-id
+                       (global-kb-export-source-expert-id export)
+                       :source-expert-version
+                       (global-kb-export-source-expert-version export)
+                       :source-evidence-ids
+                       (global-kb-export-source-evidence-ids export)
+                       :promotion-evidence-ids
+                       (global-kb-export-promotion-evidence-ids export)
+                       :key (global-kb-export-key export)
+                       :value (global-kb-export-value export)
+                       :exported-by (global-kb-export-exported-by export)
+                       :exporter-version
+                       (global-kb-export-exporter-version export)
+                       :evidence-ids
+                       (global-kb-export-evidence-ids export)
+                       :provenance
+                       (global-kb-export-provenance export))))
+
+(defun global-kb-root-node ()
+  (make-instance 'tek9:node
+                 :id (global-kb-root-id)
+                 :props (list :kind :global-kb-root)))
+
+(defun global-kb-membership-edge (export)
+  (make-instance 'tek9:edge
+                 :id (%record-id "global-kb-membership"
+                                 (global-kb-export-record-id export))
+                 :source (global-kb-root-id)
+                 :predicate :contains
+                 :target (global-kb-export-record-id export)))
+
+(defun global-kb-source-edge (export)
+  "Return the provenance edge to the exact long-term promotion record."
+  (make-instance 'tek9:edge
+                 :id (%record-id "global-kb-exported-from"
+                                 (global-kb-export-record-id export)
+                                 (global-kb-export-source-promotion-id export))
+                 :source (global-kb-export-record-id export)
+                 :predicate :exported-from
+                 :target (global-kb-export-source-promotion-id export)))

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -3,8 +3,10 @@
   :depends-on (#:hackmode-database)
   :serial t
   :components ((:file "tests/execution-graph")
-               (:file "tests/long-term-kb"))
+               (:file "tests/long-term-kb")
+               (:file "tests/global-kb"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
-             (uiop:symbol-call :hackmode-database-tests :run-long-term-kb-tests)))
+             (uiop:symbol-call :hackmode-database-tests :run-long-term-kb-tests)
+             (uiop:symbol-call :hackmode-database-tests :run-global-kb-tests)))

--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -10,4 +10,5 @@
                (:file "execution-graph")
                (:file "operational-kb")
                (:file "long-term-kb")
+               (:file "global-kb")
                (:file "db")))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -67,5 +67,30 @@
    #:long-term-kb-source-edge
    #:persist-long-term-kb-promotion
    #:fetch-long-term-kb-promotion
+   #:global-kb-validation-error
+   #:global-kb-export
+   #:global-kb-export-record-id
+   #:global-kb-export-source-promotion-id
+   #:global-kb-export-source-operation-id
+   #:global-kb-export-source-assertion-id
+   #:global-kb-export-source-run-id
+   #:global-kb-export-source-expert-id
+   #:global-kb-export-source-expert-version
+   #:global-kb-export-source-evidence-ids
+   #:global-kb-export-promotion-evidence-ids
+   #:global-kb-export-key
+   #:global-kb-export-value
+   #:global-kb-export-exported-by
+   #:global-kb-export-exporter-version
+   #:global-kb-export-evidence-ids
+   #:global-kb-export-provenance
+   #:make-global-kb-export
+   #:global-kb-graph-name
+   #:global-kb-root-id
+   #:global-kb-export->tek9-node
+   #:global-kb-membership-edge
+   #:global-kb-source-edge
+   #:persist-global-kb-export
+   #:fetch-global-kb-export
    #:put-doc
    #:put-docs))

--- a/source/hackmode-database/tests/global-kb.lisp
+++ b/source/hackmode-database/tests/global-kb.lisp
@@ -1,0 +1,75 @@
+(in-package :hackmode-database-tests)
+
+(defun run-global-kb-tests ()
+  (let* ((source
+           (make-operational-kb-assertion
+            :assertion-id "a-global"
+            :operation-id "op-global"
+            :run-id "run-global"
+            :expert-id "recon"
+            :expert-version "1"
+            :key '(:service-pattern "nginx")
+            :value '(:stable t)
+            :evidence-ids '("call-global" "result-global")
+            :provenance '(:source "fixture")))
+         (promotion
+           (make-long-term-kb-promotion
+            :promotion-id "p-global"
+            :source-assertion source
+            :promoted-by "operator-policy"
+            :promoter-version "1"
+            :evidence-ids '("review-global")
+            :provenance '(:reason "validated reusable pattern")))
+         (export
+           (make-global-kb-export
+            :export-id "export-1"
+            :source-promotion promotion
+            :exported-by "operator"
+            :exporter-version "1"
+            :evidence-ids '("approval-global")
+            :provenance '(:reason "explicit loot")))
+         (same
+           (make-global-kb-export
+            :export-id "export-1"
+            :source-promotion promotion
+            :exported-by "operator"
+            :exporter-version "1"
+            :evidence-ids '("approval-global")
+            :provenance '(:reason "explicit loot"))))
+    (ensure (string= (global-kb-export-record-id export)
+                     (global-kb-export-record-id same))
+            "replaying global export changed its identity")
+    (ensure (string= (long-term-kb-promotion-record-id promotion)
+                     (global-kb-export-source-promotion-id export))
+            "global export lost source promotion identity")
+    (ensure (string= "op-global"
+                     (global-kb-export-source-operation-id export))
+            "global export lost source operation provenance")
+    (ensure (equal (long-term-kb-promotion-key promotion)
+                   (global-kb-export-key export))
+            "global export key drifted from long-term promotion")
+    (ensure (equal (long-term-kb-promotion-value promotion)
+                   (global-kb-export-value export))
+            "global export value drifted from long-term promotion")
+    (ensure (equal '("approval-global")
+                   (global-kb-export-evidence-ids export))
+            "global export lost explicit export evidence")
+    (let ((edge (global-kb-source-edge export)))
+      (ensure (string= (global-kb-export-record-id export)
+                       (tek9:edge-source edge))
+              "global source edge has wrong source")
+      (ensure (string= (long-term-kb-promotion-record-id promotion)
+                       (tek9:edge-target edge))
+              "global source edge lost exact long-term promotion"))
+    (handler-case
+        (progn
+          (make-global-kb-export
+           :export-id "export-no-evidence"
+           :source-promotion promotion
+           :exported-by "operator"
+           :exporter-version "1"
+           :evidence-ids nil
+           :provenance '(:reason "invalid"))
+          (error "global export unexpectedly accepted without evidence"))
+      (global-kb-validation-error () t)))
+  t)


### PR DESCRIPTION
Bounded database-owned slice for #24/#27 after merged long-term promotion #49.

Superseded by a forward-reconciled PR on current master after sibling #52 advanced master. The original exact head was green, but it was six commits behind current master; no stale-tested merge is being performed.

Original RED head: 9026b1e02568f1bfd763b68d31a87060d4dedf2c
Original implementation head: 6baf48095d915f17add315d5bf785a3aba2463fa