### PR TITLE
Hackpert: forward-reconcile concrete recon providers

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -104,12 +104,16 @@ jobs:
             --eval '(asdf:load-asd (truename "source/hackmode-database/hackmode-database-tests.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-providers/dns/hackmode-provider-dns.asd"))' \
             --eval '(asdf:load-asd (truename "source/hackmode-providers/dns/hackmode-provider-dns-tests.asd"))' \
+            --eval '(asdf:load-asd (truename "source/hackmode-providers/recon/hackmode-provider-recon.asd"))' \
+            --eval '(asdf:load-asd (truename "source/hackmode-providers/recon/hackmode-provider-recon-tests.asd"))' \
             --eval '(ql:quickload :hackmode-tests)' \
             --eval '(ql:quickload :hackmode-database-tests)' \
             --eval '(ql:quickload :hackmode-provider-dns-tests)' \
+            --eval '(ql:quickload :hackmode-provider-recon-tests)' \
             --eval '(asdf:test-system :hackmode)' \
             --eval '(asdf:test-system :hackmode-database)' \
             --eval '(asdf:test-system :hackmode-provider-dns)' \
+            --eval '(asdf:test-system :hackmode-provider-recon)' \
             2>&1 | tee "$RUNNER_TEMP/hackmode-core.log"
 
       - name: Upload Common Lisp diagnostic log

--- a/source/hackmode-providers/recon/hackmode-provider-recon-tests.asd
+++ b/source/hackmode-providers/recon/hackmode-provider-recon-tests.asd
@@ -1,0 +1,10 @@
+(asdf:defsystem :hackmode-provider-recon-tests
+  :description "Regression tests for Hackmode recon providers"
+  :depends-on (#:hackmode-provider-recon)
+  :serial t
+  :components ((:module "tests"
+                :serial t
+                :components ((:file "recon-tests"))))
+  :perform (test-op (operation component)
+             (declare (ignore operation component))
+             (uiop:symbol-call :hackmode-provider-recon-tests :run-tests)))

--- a/source/hackmode-providers/recon/hackmode-provider-recon.asd
+++ b/source/hackmode-providers/recon/hackmode-provider-recon.asd
@@ -1,0 +1,11 @@
+(asdf:defsystem :hackmode-provider-recon
+  :description "Concrete typed recon providers for Hackmode"
+  :author "nsaspy"
+  :license "LGLV3"
+  :version "0.1.0"
+  :serial t
+  :in-order-to ((test-op (test-op "hackmode-provider-recon-tests")))
+  :depends-on (#:hackmode #:jsown #:dexador)
+  :components ((:file "package")
+               (:file "recon")
+               (:file "http-runner")))

--- a/source/hackmode-providers/recon/hackmode-provider-recon.asd
+++ b/source/hackmode-providers/recon/hackmode-provider-recon.asd
@@ -8,4 +8,5 @@
   :depends-on (#:hackmode #:jsown #:dexador)
   :components ((:file "package")
                (:file "recon")
-               (:file "http-runner")))
+               (:file "http-runner")
+               (:file "registration")))

--- a/source/hackmode-providers/recon/http-runner.lisp
+++ b/source/hackmode-providers/recon/http-runner.lisp
@@ -30,6 +30,3 @@
              exit-code
              (trim-text stderr)))
     (or stdout "")))
-
-(eval-when (:load-toplevel :execute)
-  (register-http-probe-provider :runner #'run-http-probe))

--- a/source/hackmode-providers/recon/http-runner.lisp
+++ b/source/hackmode-providers/recon/http-runner.lisp
@@ -1,0 +1,35 @@
+(in-package :hackmode-provider-recon)
+
+(defun http-probe-write-out-format ()
+  "Return curl's bounded probe format with literal tab delimiters."
+  (format nil
+          "%{http_code}~C%{url_effective}~C%{content_type}~C%{remote_ip}~C%{num_redirects}~%"
+          #\Tab #\Tab #\Tab #\Tab))
+
+(defun run-http-probe (url)
+  "Run a bounded HEAD-style HTTP probe for typed URL and return one result row."
+  (check-type url hackmode:url)
+  (hackmode:normalize-asset url)
+  (multiple-value-bind (stdout stderr exit-code)
+      (uiop:run-program
+       (list *http-probe-program*
+             "--silent"
+             "--show-error"
+             "--head"
+             "--location"
+             "--max-time" "10"
+             "--max-redirs" "5"
+             "--output" "/dev/null"
+             "--write-out" (http-probe-write-out-format)
+             (hackmode:asset-canonical-value url))
+       :output :string
+       :error-output :string
+       :ignore-error-status t)
+    (unless (or (null exit-code) (zerop exit-code))
+      (error "HTTP probe exited with status ~a: ~a"
+             exit-code
+             (trim-text stderr)))
+    (or stdout "")))
+
+(eval-when (:load-toplevel :execute)
+  (register-http-probe-provider :runner #'run-http-probe))

--- a/source/hackmode-providers/recon/package.lisp
+++ b/source/hackmode-providers/recon/package.lisp
@@ -1,0 +1,21 @@
+(uiop:define-package :hackmode-provider-recon
+  (:use :cl)
+  (:nicknames :hackmode.providers.recon)
+  (:export
+   :*subfinder-program*
+   :*http-probe-program*
+   :parse-subfinder-output
+   :run-subfinder
+   :subfinder-enumerate
+   :register-subfinder-provider
+   :parse-crtsh-response
+   :run-crtsh-json
+   :crtsh-enumerate
+   :register-crtsh-provider
+   :parse-http-probe-output
+   :run-http-probe
+   :http-probe
+   :register-http-probe-provider
+   :register-recon-providers))
+
+(in-package :hackmode-provider-recon)

--- a/source/hackmode-providers/recon/recon.lisp
+++ b/source/hackmode-providers/recon/recon.lisp
@@ -1,0 +1,188 @@
+(in-package :hackmode-provider-recon)
+
+(defparameter *subfinder-program*
+  (or (uiop:getenv "HACKMODE_SUBFINDER_PROGRAM") "subfinder")
+  "Subfinder executable used by the subdomain-enumeration provider.")
+
+(defparameter *http-probe-program*
+  (or (uiop:getenv "HACKMODE_HTTP_PROBE_PROGRAM") "curl")
+  "curl-compatible executable used by the HTTP probe provider.")
+
+(defun trim-text (value)
+  (string-trim '(#\Space #\Tab #\Newline #\Return) (or value "")))
+
+(defun normalize-domain-candidate (value)
+  (let* ((trimmed (string-downcase (trim-text value)))
+         (without-dot (string-right-trim '(#\.) trimmed)))
+    (if (and (>= (length without-dot) 2)
+             (string= "*." without-dot :end2 2))
+        (subseq without-dot 2)
+        without-dot)))
+
+(defun domain-under-root-p (candidate root)
+  (let* ((candidate (normalize-domain-candidate candidate))
+         (root (normalize-domain-candidate root))
+         (candidate-length (length candidate))
+         (root-length (length root)))
+    (or (string= candidate root)
+        (and (> candidate-length root-length)
+             (char= #\. (char candidate (- candidate-length root-length 1)))
+             (string= root candidate :start2 (- candidate-length root-length))))))
+
+(defun domain-assets-from-names (names root tool tags)
+  (let ((seen (make-hash-table :test #'equal))
+        assets)
+    (dolist (name names)
+      (let ((candidate (normalize-domain-candidate name)))
+        (when (and (plusp (length candidate))
+                   (not (find #\@ candidate))
+                   (domain-under-root-p candidate root)
+                   (not (gethash candidate seen)))
+          (setf (gethash candidate seen) t)
+          (push (make-instance 'hackmode:domain
+                               :record candidate
+                               :tool tool
+                               :tags tags)
+                assets))))
+    (nreverse assets)))
+
+(defun parse-subfinder-output (output root-domain)
+  "Parse Subfinder newline OUTPUT into typed domains scoped beneath ROOT-DOMAIN."
+  (domain-assets-from-names
+   (uiop:split-string (or output "") :separator '(#\Newline #\Return))
+   root-domain
+   "subfinder"
+   '("dns" "subfinder")))
+
+(defun run-subfinder (domain)
+  "Run Subfinder for typed DOMAIN and return its raw stdout."
+  (check-type domain hackmode:domain)
+  (multiple-value-bind (stdout stderr exit-code)
+      (uiop:run-program
+       (list *subfinder-program*
+             "-silent"
+             "-d"
+             (hackmode:domain-name domain))
+       :output :string
+       :error-output :string
+       :ignore-error-status t)
+    (unless (or (null exit-code) (zerop exit-code))
+      (error "Subfinder exited with status ~a: ~a"
+             exit-code
+             (trim-text stderr)))
+    (or stdout "")))
+
+(defun subfinder-enumerate (domain &key (runner #'run-subfinder))
+  "Enumerate subdomains for typed DOMAIN through RUNNER."
+  (check-type domain hackmode:domain)
+  (parse-subfinder-output
+   (funcall runner domain)
+   (hackmode:domain-name domain)))
+
+(defun register-subfinder-provider (&key (runner #'run-subfinder) (priority 20))
+  "Register Subfinder as a typed SUBDOMAIN-ENUMERATE provider."
+  (hackmode:register-capability-provider
+   :subdomain-enumerate
+   :subfinder
+   (lambda (domain)
+     (subfinder-enumerate domain :runner runner))
+   :input-type 'hackmode:domain
+   :output-types '(hackmode:domain)
+   :priority priority))
+
+(defun crtsh-name-values (json)
+  (let ((objects (jsown:parse (or json "[]"))))
+    (loop for object in objects
+          for value = (jsown:val-safe object "name_value")
+          when (stringp value)
+            append (uiop:split-string value :separator '(#\Newline #\Return)))))
+
+(defun parse-crtsh-response (json root-domain)
+  "Parse crt.sh JSON into unique typed domains beneath ROOT-DOMAIN."
+  (domain-assets-from-names
+   (crtsh-name-values json)
+   root-domain
+   "crt.sh"
+   '("dns" "crt.sh")))
+
+(defun run-crtsh-json (domain)
+  "Query crt.sh for typed DOMAIN and return the JSON response body."
+  (check-type domain hackmode:domain)
+  (dex:get
+   (format nil "https://crt.sh/?q=%25.~a&output=json"
+           (hackmode:domain-name domain))
+   :headers '(("User-Agent" . "Hackmode")
+              ("Accept" . "application/json"))))
+
+(defun crtsh-enumerate (domain &key (runner #'run-crtsh-json))
+  "Enumerate certificate-transparency names for typed DOMAIN through RUNNER."
+  (check-type domain hackmode:domain)
+  (parse-crtsh-response
+   (funcall runner domain)
+   (hackmode:domain-name domain)))
+
+(defun register-crtsh-provider (&key (runner #'run-crtsh-json) (priority 40))
+  "Register crt.sh as a typed SUBDOMAIN-ENUMERATE provider."
+  (hackmode:register-capability-provider
+   :subdomain-enumerate
+   :crtsh
+   (lambda (domain)
+     (crtsh-enumerate domain :runner runner))
+   :input-type 'hackmode:domain
+   :output-types '(hackmode:domain)
+   :priority priority))
+
+(defun parse-http-probe-output (output)
+  "Parse one tab-separated curl write-out record into a property list."
+  (let* ((line (trim-text output))
+         (parts (uiop:split-string line :separator '(#\Tab))))
+    (unless (= 5 (length parts))
+      (error "Invalid HTTP probe output: ~s" output))
+    (list :status (parse-integer (first parts))
+          :effective-url (second parts)
+          :content-type (third parts)
+          :remote-ip (fourth parts)
+          :redirects (parse-integer (fifth parts)))))
+
+(defun http-observation-data (observation)
+  (format nil
+          "status=~d~%effective-url=~a~%content-type=~a~%remote-ip=~a~%redirects=~d"
+          (getf observation :status)
+          (getf observation :effective-url)
+          (getf observation :content-type)
+          (getf observation :remote-ip)
+          (getf observation :redirects)))
+
+(defun http-probe (url &key (runner #'run-http-probe))
+  "Probe typed URL through RUNNER and return one typed HTTP observation finding."
+  (check-type url hackmode:url)
+  (hackmode:normalize-asset url)
+  (let ((observation (parse-http-probe-output (funcall runner url))))
+    (list
+     (make-instance 'hackmode:finding
+                    :document-id (hackmode:asset-deterministic-id url)
+                    :finding-type "http-observation"
+                    :data (http-observation-data observation)
+                    :tool "curl"
+                    :tags '("http" "probe")))))
+
+(defun register-http-probe-provider (&key (runner #'run-http-probe) (priority 20))
+  "Register the bounded HTTP probe as a typed HTTP-PROBE provider."
+  (hackmode:register-capability-provider
+   :http-probe
+   :curl
+   (lambda (url)
+     (http-probe url :runner runner))
+   :input-type 'hackmode:url
+   :output-types '(hackmode:finding)
+   :priority priority))
+
+(defun register-recon-providers ()
+  "Register the baseline concrete recon providers."
+  (register-subfinder-provider)
+  (register-crtsh-provider)
+  (register-http-probe-provider)
+  t)
+
+(eval-when (:load-toplevel :execute)
+  (register-recon-providers))

--- a/source/hackmode-providers/recon/recon.lisp
+++ b/source/hackmode-providers/recon/recon.lisp
@@ -178,11 +178,8 @@
    :priority priority))
 
 (defun register-recon-providers ()
-  "Register the baseline concrete recon providers."
+  "Register the baseline concrete recon providers after every runner is loaded."
   (register-subfinder-provider)
   (register-crtsh-provider)
   (register-http-probe-provider)
   t)
-
-(eval-when (:load-toplevel :execute)
-  (register-recon-providers))

--- a/source/hackmode-providers/recon/registration.lisp
+++ b/source/hackmode-providers/recon/registration.lisp
@@ -1,0 +1,4 @@
+(in-package :hackmode-provider-recon)
+
+(eval-when (:load-toplevel :execute)
+  (register-recon-providers))

--- a/source/hackmode-providers/recon/tests/recon-tests.lisp
+++ b/source/hackmode-providers/recon/tests/recon-tests.lisp
@@ -18,6 +18,9 @@
     (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)))
 
 (defun run-load-registration-test ()
+  (assert (fboundp 'hackmode-provider-recon:run-http-probe))
+  (hackmode:clear-capability-providers)
+  (hackmode-provider-recon:register-recon-providers)
   (assert (hackmode:find-capability-provider :subdomain-enumerate :subfinder))
   (assert (hackmode:find-capability-provider :subdomain-enumerate :crtsh))
   (assert (hackmode:find-capability-provider :http-probe :curl)))

--- a/source/hackmode-providers/recon/tests/recon-tests.lisp
+++ b/source/hackmode-providers/recon/tests/recon-tests.lisp
@@ -17,6 +17,11 @@
   (ignore-errors
     (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)))
 
+(defun run-load-registration-test ()
+  (assert (hackmode:find-capability-provider :subdomain-enumerate :subfinder))
+  (assert (hackmode:find-capability-provider :subdomain-enumerate :crtsh))
+  (assert (hackmode:find-capability-provider :http-probe :curl)))
+
 (defun run-subfinder-parser-test ()
   (let ((assets
           (hackmode-provider-recon:parse-subfinder-output
@@ -144,6 +149,7 @@
       (remove-test-path root))))
 
 (defun run-tests ()
+  (run-load-registration-test)
   (run-subfinder-parser-test)
   (run-crtsh-parser-test)
   (run-http-parser-test)

--- a/source/hackmode-providers/recon/tests/recon-tests.lisp
+++ b/source/hackmode-providers/recon/tests/recon-tests.lisp
@@ -1,0 +1,153 @@
+(defpackage :hackmode-provider-recon-tests
+  (:use :cl)
+  (:export :run-tests))
+
+(in-package :hackmode-provider-recon-tests)
+
+(defun assert-equal (expected actual &optional (label "values"))
+  (assert (equal expected actual) ()
+          "Expected ~a to be ~s, got ~s" label expected actual))
+
+(defun fresh-test-path ()
+  (merge-pathnames
+   (format nil "hackmode-provider-recon-~a/" (tek9:make-key-id))
+   (uiop:temporary-directory)))
+
+(defun remove-test-path (path)
+  (ignore-errors
+    (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)))
+
+(defun run-subfinder-parser-test ()
+  (let ((assets
+          (hackmode-provider-recon:parse-subfinder-output
+           (format nil
+                   "WWW.Example.COM~%api.example.com~%*.wild.example.com~%outside.test~%api.example.com~%")
+           "example.com")))
+    (assert-equal '("www.example.com" "api.example.com" "wild.example.com")
+                  (mapcar #'hackmode:domain-name assets)
+                  "subfinder scoped domains")))
+
+(defun run-crtsh-parser-test ()
+  (let* ((json
+           "[{\"name_value\":\"*.example.com\\napi.example.com\"},{\"name_value\":\"admin@example.com\"},{\"name_value\":\"outside.test\"}]")
+         (assets
+           (hackmode-provider-recon:parse-crtsh-response json "example.com")))
+    (assert-equal '("example.com" "api.example.com")
+                  (mapcar #'hackmode:domain-name assets)
+                  "crt.sh scoped domains")))
+
+(defun run-http-parser-test ()
+  (let ((result
+          (hackmode-provider-recon:parse-http-probe-output
+           (format nil "200~Chttps://example.com/~Ctext/html~C93.184.216.34~C1~%"
+                   #\Tab #\Tab #\Tab #\Tab))))
+    (assert (= 200 (getf result :status)))
+    (assert-equal "https://example.com/"
+                  (getf result :effective-url)
+                  "HTTP effective URL")
+    (assert-equal "text/html"
+                  (getf result :content-type)
+                  "HTTP content type")
+    (assert-equal "93.184.216.34"
+                  (getf result :remote-ip)
+                  "HTTP remote IP")
+    (assert (= 1 (getf result :redirects)))))
+
+(defun run-http-write-out-format-test ()
+  (let ((value (hackmode-provider-recon::http-probe-write-out-format)))
+    (assert (= 4 (count #\Tab value)))
+    (assert (search "%{http_code}" value))
+    (assert (search "%{url_effective}" value))))
+
+(defun run-provider-test ()
+  (let* ((root (fresh-test-path))
+         (db (tek9:new-database "operation" :path root))
+         (hackmode:*asset-event-hook*
+           (make-instance 'nhooks:hook-any :handlers nil)))
+    (unwind-protect
+         (progn
+           (tek9:open-database db)
+           (hackmode:clear-capability-providers)
+
+           (hackmode-provider-recon:register-subfinder-provider
+            :runner
+            (lambda (domain)
+              (declare (ignore domain))
+              (format nil "www.example.com~%api.example.com~%")))
+           (hackmode-provider-recon:register-crtsh-provider
+            :runner
+            (lambda (domain)
+              (declare (ignore domain))
+              "[{\"name_value\":\"cert.example.com\"}]"))
+           (hackmode-provider-recon:register-http-probe-provider
+            :runner
+            (lambda (url)
+              (declare (ignore url))
+              (format nil "200~Chttps://example.com/~Ctext/html~C93.184.216.34~C0~%"
+                      #\Tab #\Tab #\Tab #\Tab)))
+
+           (let* ((domain
+                    (make-instance 'hackmode:domain
+                                   :record "example.com"
+                                   :record-type "A"))
+                  (subdomains
+                    (hackmode:run-capability
+                     :subdomain-enumerate domain
+                     :provider :subfinder
+                     :database db))
+                  (certificate-names
+                    (hackmode:run-capability
+                     :subdomain-enumerate domain
+                     :provider :crtsh
+                     :database db)))
+             (assert (eq :succeeded
+                         (hackmode:provider-job-result-state subdomains)))
+             (assert (= 2
+                        (hackmode:provider-job-result-created-count subdomains)))
+             (assert (eq :succeeded
+                         (hackmode:provider-job-result-state certificate-names)))
+             (assert (= 1
+                        (hackmode:provider-job-result-created-count
+                         certificate-names))))
+
+           (let* ((url
+                    (make-instance 'hackmode:url
+                                   :scheme "https"
+                                   :host "example.com"
+                                   :port 443
+                                   :path "/"))
+                  (probe
+                    (hackmode:run-capability
+                     :http-probe url
+                     :provider :curl
+                     :database db))
+                  (asset (first (hackmode:provider-job-result-assets probe))))
+             (assert (eq :succeeded
+                         (hackmode:provider-job-result-state probe)))
+             (assert (= 1 (hackmode:provider-job-result-created-count probe)))
+             (assert (typep asset 'hackmode:finding))
+             (assert-equal "http-observation"
+                           (hackmode:finding-finding-type asset)
+                           "HTTP finding type")
+             (assert (search "status=200"
+                             (hackmode:finding-data asset))))
+
+           (let ((providers
+                   (hackmode:list-capability-providers
+                    :subdomain-enumerate)))
+             (assert-equal '("subfinder" "crtsh")
+                           (mapcar #'hackmode:capability-provider-name providers)
+                           "provider priority order")))
+      (hackmode:clear-capability-providers)
+      (when (tek9:db-is-open-p db)
+        (tek9:close-database db))
+      (remove-test-path root))))
+
+(defun run-tests ()
+  (run-subfinder-parser-test)
+  (run-crtsh-parser-test)
+  (run-http-parser-test)
+  (run-http-write-out-format-test)
+  (run-provider-test)
+  (format t "Hackmode recon provider tests passed.~%")
+  t)


### PR DESCRIPTION
Bounded Hackpert/provider slice for #24/#27, forward-reconciled from stale green PR #48 onto current master `8ad7fb8100996eae6094dcd0da8df4fb9de0eaf6`.

This carries only executable product changes and CI wiring. It intentionally does **not** carry forward #48's worker-profile mandate rewrite because current explicit operator direction is authoritative.

Concrete capabilities:
- `subdomain-enumerate / subfinder`
- `subdomain-enumerate / crtsh`
- `http-probe / curl`

Invariants:
- typed Hackmode inputs/outputs;
- canonical capability/provider runtime remains the only executor;
- external programs use argv lists, not interpolated shell commands;
- deterministic parser/provider tests use injected runners and no live targets;
- outputs persist only through the existing provider completion/discovery path;
- no database internals, direct Tek9 mutation, or second executor.

Prior TDD/RED history and regression development is preserved in superseded PR #48; its exact head `2a3600df4a06e84ee122005fc9f62be0327d9974` passed core, monorepo, and agent-framework-boundary before forward reconciliation.

Replacement branch starts from current master and carries the tested product delta only.