### PR TITLE
Database: make graph and KB replay conflict-safe

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: lost-rob0t/tek9
-          ref: 6ff2e40a6f7e3a5eadafef94c2779c74566b7fd7
+          ref: a9f5b595f5d965163d2b7c518c72a2efd9be13fe
           path: deps/tek9-ci
           fetch-depth: 1
 

--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -16,53 +16,62 @@
 
 (defun persist-execution-record (database record)
   "Persist one typed execution RECORD into its operation-scoped Tek9 graph."
-  (tek9:put-node database
-                 (execution-record->tek9-node record)
-                 :database-name (execution-graph-name
-                                 (execution-record-operation-id record)))
+  (persist-graph-node-replay-safe
+   database
+   (execution-record->tek9-node record)
+   :database-name (execution-graph-name
+                   (execution-record-operation-id record)))
   record)
 
 (defun persist-tool-execution (database call result)
   "Persist CALL, RESULT, and their typed relation through Tek9's graph API."
   (validate-tool-result-link call result)
   (let ((graph-name (execution-graph-name (execution-record-operation-id call))))
-    (tek9:put-nodes database
-                    (list (execution-record->tek9-node call)
-                          (execution-record->tek9-node result))
-                    :database-name graph-name)
-    (tek9:put-edge database
-                   (tool-result-link-edge call result)
-                   :database-name graph-name))
+    (tek9:with-write-transaction (database)
+      (persist-graph-nodes-replay-safe
+       database
+       (list (execution-record->tek9-node call)
+             (execution-record->tek9-node result))
+       :database-name graph-name)
+      (persist-graph-edge-replay-safe
+       database
+       (tool-result-link-edge call result)
+       :database-name graph-name)))
   (values call result))
 
 (defun persist-operational-kb-entry (database entry)
   "Persist one replay-safe operational KB assertion or retraction through Tek9."
   (let ((graph-name (operational-kb-graph-name
                      (operational-kb-entry-operation-id entry))))
-    (ecase (operational-kb-entry-kind entry)
-      (:assert
-       (tek9:put-nodes database
-                       (list (operational-kb-root-node
-                              (operational-kb-entry-operation-id entry))
-                             (operational-kb-entry->tek9-node entry))
-                       :database-name graph-name)
-       (tek9:put-edge database
-                      (operational-kb-membership-edge entry)
-                      :database-name graph-name))
-      (:retract
-       (unless (tek9:fetch-node database
-                                (operational-kb-entry-target-assertion-id entry)
-                                :database-name graph-name)
-         (error 'operational-kb-validation-error
-                :field :target-assertion-id
-                :value (operational-kb-entry-target-assertion-id entry)
-                :reason "target assertion does not exist"))
-       (tek9:put-node database
-                      (operational-kb-entry->tek9-node entry)
-                      :database-name graph-name)
-       (tek9:put-edge database
-                      (operational-kb-retraction-edge entry)
-                      :database-name graph-name)))
+    (tek9:with-write-transaction (database)
+      (ecase (operational-kb-entry-kind entry)
+        (:assert
+         (persist-graph-nodes-replay-safe
+          database
+          (list (operational-kb-root-node
+                 (operational-kb-entry-operation-id entry))
+                (operational-kb-entry->tek9-node entry))
+          :database-name graph-name)
+         (persist-graph-edge-replay-safe
+          database
+          (operational-kb-membership-edge entry)
+          :database-name graph-name))
+        (:retract
+         (unless (tek9:fetch-node database
+                                  (operational-kb-entry-target-assertion-id entry)
+                                  :database-name graph-name)
+           (error 'operational-kb-validation-error
+                  :field :target-assertion-id
+                  :value (operational-kb-entry-target-assertion-id entry)
+                  :reason "target assertion does not exist"))
+         (persist-graph-node-replay-safe
+          database
+          (operational-kb-entry->tek9-node entry)
+          :database-name graph-name)
+         (persist-graph-edge-replay-safe
+          database
+          (operational-kb-retraction-edge entry)
+          :database-name graph-name))))
     entry))
 
 (defun fetch-operational-kb-entry (database operation-id record-id)
@@ -73,16 +82,17 @@
 (defun persist-long-term-kb-promotion (database promotion)
   "Persist one immutable evidence-backed promotion through canonical Tek9 graph APIs."
   (let ((graph-name (long-term-kb-graph-name)))
-    (tek9:put-nodes database
-                    (list (long-term-kb-root-node)
-                          (long-term-kb-promotion->tek9-node promotion))
-                    :database-name graph-name)
-    (tek9:put-edge database
-                   (long-term-kb-membership-edge promotion)
-                   :database-name graph-name)
-    (tek9:put-edge database
-                   (long-term-kb-source-edge promotion)
-                   :database-name graph-name))
+    (tek9:with-write-transaction (database)
+      (persist-graph-nodes-replay-safe
+       database
+       (list (long-term-kb-root-node)
+             (long-term-kb-promotion->tek9-node promotion))
+       :database-name graph-name)
+      (persist-graph-edges-replay-safe
+       database
+       (list (long-term-kb-membership-edge promotion)
+             (long-term-kb-source-edge promotion))
+       :database-name graph-name)))
   promotion)
 
 (defun fetch-long-term-kb-promotion (database record-id)
@@ -93,16 +103,17 @@
 (defun persist-global-kb-export (database export)
   "Persist one explicit immutable export through canonical Tek9 graph APIs."
   (let ((graph-name (global-kb-graph-name)))
-    (tek9:put-nodes database
-                    (list (global-kb-root-node)
-                          (global-kb-export->tek9-node export))
-                    :database-name graph-name)
-    (tek9:put-edge database
-                   (global-kb-membership-edge export)
-                   :database-name graph-name)
-    (tek9:put-edge database
-                   (global-kb-source-edge export)
-                   :database-name graph-name))
+    (tek9:with-write-transaction (database)
+      (persist-graph-nodes-replay-safe
+       database
+       (list (global-kb-root-node)
+             (global-kb-export->tek9-node export))
+       :database-name graph-name)
+      (persist-graph-edges-replay-safe
+       database
+       (list (global-kb-membership-edge export)
+             (global-kb-source-edge export))
+       :database-name graph-name)))
   export)
 
 (defun fetch-global-kb-export (database record-id)

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -4,9 +4,11 @@
   :serial t
   :components ((:file "tests/execution-graph")
                (:file "tests/long-term-kb")
-               (:file "tests/global-kb"))
+               (:file "tests/global-kb")
+               (:file "tests/replay-conflict"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
              (uiop:symbol-call :hackmode-database-tests :run-long-term-kb-tests)
-             (uiop:symbol-call :hackmode-database-tests :run-global-kb-tests)))
+             (uiop:symbol-call :hackmode-database-tests :run-global-kb-tests)
+             (uiop:symbol-call :hackmode-database-tests :run-replay-conflict-tests)))

--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -11,4 +11,5 @@
                (:file "operational-kb")
                (:file "long-term-kb")
                (:file "global-kb")
+               (:file "replay")
                (:file "db")))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -3,6 +3,16 @@
   (:use :cl)
   (:export
    #:*db*
+   #:persistence-replay-conflict
+   #:persistence-replay-conflict-record-kind
+   #:persistence-replay-conflict-record-id
+   #:persistence-replay-conflict-database-name
+   #:persistence-replay-conflict-existing
+   #:persistence-replay-conflict-incoming
+   #:persist-graph-node-replay-safe
+   #:persist-graph-edge-replay-safe
+   #:persist-graph-nodes-replay-safe
+   #:persist-graph-edges-replay-safe
    #:execution-graph-validation-error
    #:execution-record
    #:execution-record-kind

--- a/source/hackmode-database/replay.lisp
+++ b/source/hackmode-database/replay.lisp
@@ -1,0 +1,87 @@
+(in-package :hackmode-database)
+
+(define-condition persistence-replay-conflict (error)
+  ((record-kind :initarg :record-kind :reader persistence-replay-conflict-record-kind)
+   (record-id :initarg :record-id :reader persistence-replay-conflict-record-id)
+   (database-name :initarg :database-name
+                  :reader persistence-replay-conflict-database-name)
+   (existing :initarg :existing :reader persistence-replay-conflict-existing)
+   (incoming :initarg :incoming :reader persistence-replay-conflict-incoming))
+  (:report
+   (lambda (condition stream)
+     (format stream "Conflicting ~A replay for stable ID ~S in graph ~S."
+             (persistence-replay-conflict-record-kind condition)
+             (persistence-replay-conflict-record-id condition)
+             (persistence-replay-conflict-database-name condition)))))
+
+(defun %same-graph-node-p (left right)
+  (and (string= (tek9:node-id left) (tek9:node-id right))
+       (equal (tek9:node-props left) (tek9:node-props right))))
+
+(defun %same-graph-edge-p (left right)
+  (and (string= (tek9:edge-id left) (tek9:edge-id right))
+       (equal (tek9:edge-source left) (tek9:edge-source right))
+       (equal (tek9:edge-predicate left) (tek9:edge-predicate right))
+       (equal (tek9:edge-target left) (tek9:edge-target right))))
+
+(defun %signal-replay-conflict (kind id database-name existing incoming)
+  (error 'persistence-replay-conflict
+         :record-kind kind
+         :record-id id
+         :database-name database-name
+         :existing existing
+         :incoming incoming))
+
+(defun persist-graph-node-replay-safe (database node &key database-name)
+  "Atomically insert NODE, accept an identical replay, or fail on ID conflict.
+
+The read and possible write share one Tek9 write transaction. Concurrent writers
+therefore cannot both observe a missing stable ID and silently replace one
+another. Existing content is authoritative when the same ID carries different
+properties."
+  (check-type node tek9:node)
+  (tek9:with-write-transaction (database)
+    (let* ((id (tek9:node-id node))
+           (existing (tek9:fetch-node database id :database-name database-name)))
+      (cond
+        ((null existing)
+         (tek9:put-node database node :database-name database-name)
+         :inserted)
+        ((%same-graph-node-p existing node)
+         :replayed)
+        (t
+         (%signal-replay-conflict :node id database-name existing node))))))
+
+(defun persist-graph-edge-replay-safe (database edge &key database-name)
+  "Atomically insert EDGE, accept an identical replay, or fail on ID conflict."
+  (check-type edge tek9:edge)
+  (tek9:with-write-transaction (database)
+    (let* ((id (tek9:edge-id edge))
+           (existing (tek9:fetch-edge database id :database-name database-name)))
+      (cond
+        ((null existing)
+         (tek9:put-edge database edge :database-name database-name)
+         :inserted)
+        ((%same-graph-edge-p existing edge)
+         :replayed)
+        (t
+         (%signal-replay-conflict :edge id database-name existing edge))))))
+
+(defun persist-graph-nodes-replay-safe (database nodes &key database-name)
+  "Persist NODES under one conflict-safe Tek9 transaction.
+
+Any conflicting stable ID aborts the whole batch. The return value is a list of
+:INSERTED/:REPLAYED outcomes corresponding to NODES."
+  (tek9:with-write-transaction (database)
+    (mapcar (lambda (node)
+              (persist-graph-node-replay-safe database node
+                                              :database-name database-name))
+            nodes)))
+
+(defun persist-graph-edges-replay-safe (database edges &key database-name)
+  "Persist EDGES under one conflict-safe Tek9 transaction."
+  (tek9:with-write-transaction (database)
+    (mapcar (lambda (edge)
+              (persist-graph-edge-replay-safe database edge
+                                              :database-name database-name))
+            edges)))

--- a/source/hackmode-database/tests/replay-conflict.lisp
+++ b/source/hackmode-database/tests/replay-conflict.lisp
@@ -1,0 +1,92 @@
+(in-package :hackmode-database-tests)
+
+(defun run-replay-conflict-tests ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-replay-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-replay-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((graph "hackmode/replay-test")
+                  (first (make-instance 'tek9:node
+                                        :id "node-1"
+                                        :props '(:kind :evidence
+                                                 :payload (:value 1))))
+                  (same (make-instance 'tek9:node
+                                       :id "node-1"
+                                       :props '(:kind :evidence
+                                                :payload (:value 1))))
+                  (conflict (make-instance 'tek9:node
+                                           :id "node-1"
+                                           :props '(:kind :evidence
+                                                    :payload (:value 2)))))
+             (ensure (eq :inserted
+                         (persist-graph-node-replay-safe database first
+                                                        :database-name graph))
+                     "first replay-safe node write was not inserted")
+             (ensure (eq :replayed
+                         (persist-graph-node-replay-safe database same
+                                                        :database-name graph))
+                     "identical node replay was not idempotent")
+             (ensure (equal '(:kind :evidence :payload (:value 1))
+                            (tek9:node-props
+                             (tek9:fetch-node database "node-1"
+                                              :database-name graph)))
+                     "identical replay changed canonical node content")
+             (handler-case
+                 (progn
+                   (persist-graph-node-replay-safe database conflict
+                                                   :database-name graph)
+                   (error "same-ID/different-content node replay unexpectedly overwrote canonical evidence"))
+               (persistence-replay-conflict (condition)
+                 (ensure (string= "node-1"
+                                  (persistence-replay-conflict-record-id condition))
+                         "node conflict lost record identity")))
+             (ensure (equal '(:kind :evidence :payload (:value 1))
+                            (tek9:node-props
+                             (tek9:fetch-node database "node-1"
+                                              :database-name graph)))
+                     "conflicting replay modified canonical node content")
+             (let* ((edge (make-instance 'tek9:edge
+                                         :id "edge-1"
+                                         :source "node-1"
+                                         :predicate :derived-from
+                                         :target "node-2"))
+                    (same-edge (make-instance 'tek9:edge
+                                              :id "edge-1"
+                                              :source "node-1"
+                                              :predicate :derived-from
+                                              :target "node-2"))
+                    (conflict-edge (make-instance 'tek9:edge
+                                                  :id "edge-1"
+                                                  :source "node-1"
+                                                  :predicate :derived-from
+                                                  :target "node-3")))
+               (persist-graph-node-replay-safe
+                database
+                (make-instance 'tek9:node :id "node-2" :props '(:kind :target))
+                :database-name graph)
+               (persist-graph-node-replay-safe
+                database
+                (make-instance 'tek9:node :id "node-3" :props '(:kind :target))
+                :database-name graph)
+               (ensure (eq :inserted
+                           (persist-graph-edge-replay-safe database edge
+                                                          :database-name graph))
+                       "first replay-safe edge write was not inserted")
+               (ensure (eq :replayed
+                           (persist-graph-edge-replay-safe database same-edge
+                                                          :database-name graph))
+                       "identical edge replay was not idempotent")
+               (handler-case
+                   (progn
+                     (persist-graph-edge-replay-safe database conflict-edge
+                                                     :database-name graph)
+                     (error "same-ID/different-content edge replay unexpectedly overwrote canonical evidence"))
+                 (persistence-replay-conflict () t)))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)


### PR DESCRIPTION
Database-owned bounded slice for #24/#27/#30.

Adds atomic replay admission at the canonical Tek9 graph boundary:
- first stable-ID node/edge write inserts;
- identical replay is accepted as idempotent;
- same stable ID with different content signals `persistence-replay-conflict` and aborts the transaction;
- execution graph, operational KB, long-term promotion, and global export persistence all use the same replay-safe boundary;
- checks and writes occur inside Tek9's composable write transaction, so concurrent writers cannot race through a non-atomic fetch-then-put window;
- no provider/expert execution changes and no shadow graph/KB.

RED head: `50c441682e04fbfe958b30532d75459baa632e9c`.

The first implementation run correctly exposed that Hackmode CI's old Tek9 pin (`6ff2e40…`) predates the public composable transaction API. A process-local lock would not satisfy multi-worker safety, so this PR minimally advances the CI Tek9 pin to current tested Tek9 `a9f5b595f5d965163d2b7c518c72a2efd9be13fe`, which exports the documented composable transaction boundary.

Current exact head: `d0b8c40bff40cd4044138f1fe5ba83dc7a132a36`.

Acceptance: exact-head core + monorepo + Agent Zero boundary gates must pass before merge.