### PR TITLE
Database: add typed operation snapshot reads

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -111,24 +111,22 @@
   (when (and kind (not (member kind '(:assert :retract) :test #'eq)))
     (error 'operational-kb-validation-error
            :field :kind :value kind :reason "unsupported operational KB filter"))
-  (let ((entries
-          (loop for node in (tek9:fetch-graph-nodes
-                             database (operational-kb-graph-name operation-id))
-                for stored-kind = (getf (tek9:node-props node) :kind)
-                when (member stored-kind '(:assert :retract) :test #'eq)
-                  for entry = (tek9-node->operational-kb-entry node)
-                  and do (unless (string= operation-id
-                                          (operational-kb-entry-operation-id entry))
-                           (error 'operational-kb-validation-error
-                                  :field :operation-id
-                                  :value (operational-kb-entry-operation-id entry)
-                                  :reason "stored entry does not match graph operation scope"))
-                  and when (and (or (null run-id)
-                                    (string= run-id
-                                             (operational-kb-entry-run-id entry)))
-                                (or (null kind)
-                                    (eq kind (operational-kb-entry-kind entry))))
-                    collect entry)))
+  (let ((entries nil))
+    (dolist (node (tek9:fetch-graph-nodes
+                   database (operational-kb-graph-name operation-id)))
+      (when (member (getf (tek9:node-props node) :kind)
+                    '(:assert :retract) :test #'eq)
+        (let ((entry (tek9-node->operational-kb-entry node)))
+          (unless (string= operation-id (operational-kb-entry-operation-id entry))
+            (error 'operational-kb-validation-error
+                   :field :operation-id
+                   :value (operational-kb-entry-operation-id entry)
+                   :reason "stored entry does not match graph operation scope"))
+          (when (and (or (null run-id)
+                         (string= run-id (operational-kb-entry-run-id entry)))
+                     (or (null kind)
+                         (eq kind (operational-kb-entry-kind entry))))
+            (push entry entries)))))
     (sort entries #'string< :key #'operational-kb-entry-record-id)))
 
 (defun persist-long-term-kb-promotion (database promotion)

--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -39,6 +39,30 @@
        :database-name graph-name)))
   (values call result))
 
+(defun fetch-operation-execution-records (database operation-id &key run-id kind)
+  "Return typed execution records for one operation, optionally filtered by RUN-ID or KIND."
+  (%require-string :operation-id operation-id)
+  (when run-id
+    (%require-string :run-id run-id))
+  (when (and kind (not (member kind '(:tool-call :tool-result) :test #'eq)))
+    (error 'execution-graph-validation-error
+           :field :kind :value kind :reason "unsupported execution record filter"))
+  (let ((records
+          (loop for node in (tek9:fetch-graph-nodes
+                             database (execution-graph-name operation-id))
+                for record = (tek9-node->execution-record node)
+                unless (string= operation-id (execution-record-operation-id record))
+                  do (error 'execution-graph-validation-error
+                            :field :operation-id
+                            :value (execution-record-operation-id record)
+                            :reason "stored record does not match graph operation scope")
+                when (and (or (null run-id)
+                              (string= run-id (execution-record-run-id record)))
+                          (or (null kind)
+                              (eq kind (execution-record-kind record))))
+                  collect record)))
+    (sort records #'string< :key #'execution-record-record-id)))
+
 (defun persist-operational-kb-entry (database entry)
   "Persist one replay-safe operational KB assertion or retraction through Tek9."
   (let ((graph-name (operational-kb-graph-name
@@ -78,6 +102,34 @@
   "Fetch one operational KB graph node by stable RECORD-ID."
   (tek9:fetch-node database record-id
                    :database-name (operational-kb-graph-name operation-id)))
+
+(defun fetch-operational-kb-entries (database operation-id &key run-id kind)
+  "Return typed operational-KB entries for one operation, including retractions."
+  (%kb-require-string :operation-id operation-id)
+  (when run-id
+    (%kb-require-string :run-id run-id))
+  (when (and kind (not (member kind '(:assert :retract) :test #'eq)))
+    (error 'operational-kb-validation-error
+           :field :kind :value kind :reason "unsupported operational KB filter"))
+  (let ((entries
+          (loop for node in (tek9:fetch-graph-nodes
+                             database (operational-kb-graph-name operation-id))
+                for stored-kind = (getf (tek9:node-props node) :kind)
+                when (member stored-kind '(:assert :retract) :test #'eq)
+                  for entry = (tek9-node->operational-kb-entry node)
+                  and do (unless (string= operation-id
+                                          (operational-kb-entry-operation-id entry))
+                           (error 'operational-kb-validation-error
+                                  :field :operation-id
+                                  :value (operational-kb-entry-operation-id entry)
+                                  :reason "stored entry does not match graph operation scope"))
+                  and when (and (or (null run-id)
+                                    (string= run-id
+                                             (operational-kb-entry-run-id entry)))
+                                (or (null kind)
+                                    (eq kind (operational-kb-entry-kind entry))))
+                    collect entry)))
+    (sort entries #'string< :key #'operational-kb-entry-record-id)))
 
 (defun persist-long-term-kb-promotion (database promotion)
   "Persist one immutable evidence-backed promotion through canonical Tek9 graph APIs."

--- a/source/hackmode-database/execution-graph.lisp
+++ b/source/hackmode-database/execution-graph.lisp
@@ -112,6 +112,41 @@
                               :payload (execution-record-payload record)
                               :provenance (execution-record-provenance record))))
 
+(defun tek9-node->execution-record (node)
+  "Reconstruct one typed execution record from a canonical Tek9 graph node."
+  (let* ((props (tek9:node-props node))
+         (kind (getf props :kind))
+         (operation-id (getf props :operation-id))
+         (run-id (getf props :run-id))
+         (call-id (getf props :call-id))
+         (capability-id (getf props :capability-id))
+         (status (getf props :status))
+         (provenance (getf props :provenance)))
+    (unless (member kind '(:tool-call :tool-result) :test #'eq)
+      (error 'execution-graph-validation-error
+             :field :kind :value kind :reason "unsupported stored execution record kind"))
+    (%require-string :operation-id operation-id)
+    (%require-string :run-id run-id)
+    (%require-string :call-id call-id)
+    (%require-string :record-id (tek9:node-id node))
+    (%require-provenance provenance)
+    (when (eq kind :tool-call)
+      (%require-string :capability-id capability-id))
+    (when (and (eq kind :tool-result)
+               (not (member status '(:succeeded :failed :cancelled :timed-out) :test #'eq)))
+      (error 'execution-graph-validation-error
+             :field :status :value status :reason "unsupported stored tool result status"))
+    (%make-execution-record
+     :kind kind
+     :operation-id operation-id
+     :run-id run-id
+     :call-id call-id
+     :record-id (tek9:node-id node)
+     :capability-id capability-id
+     :status status
+     :payload (getf props :payload)
+     :provenance provenance)))
+
 (defun tool-result-link-edge (call result)
   (validate-tool-result-link call result)
   (make-instance 'tek9:edge

--- a/source/hackmode-database/operational-kb.lisp
+++ b/source/hackmode-database/operational-kb.lisp
@@ -125,6 +125,45 @@
                               :provenance
                               (operational-kb-entry-provenance entry))))
 
+(defun tek9-node->operational-kb-entry (node)
+  "Reconstruct one typed operational-KB entry from a canonical Tek9 node."
+  (let* ((props (tek9:node-props node))
+         (kind (getf props :kind))
+         (operation-id (getf props :operation-id))
+         (run-id (getf props :run-id))
+         (expert-id (getf props :expert-id))
+         (expert-version (getf props :expert-version))
+         (target-assertion-id (getf props :target-assertion-id))
+         (evidence-ids (getf props :evidence-ids))
+         (provenance (getf props :provenance)))
+    (unless (member kind '(:assert :retract) :test #'eq)
+      (error 'operational-kb-validation-error
+             :field :kind :value kind :reason "unsupported stored operational KB kind"))
+    (%kb-require-string :operation-id operation-id)
+    (%kb-require-string :run-id run-id)
+    (%kb-require-string :expert-id expert-id)
+    (%kb-require-string :expert-version expert-version)
+    (%kb-require-string :record-id (tek9:node-id node))
+    (%kb-require-evidence evidence-ids)
+    (%kb-require-provenance provenance)
+    (when (and (eq kind :assert) (null (getf props :key)))
+      (error 'operational-kb-validation-error
+             :field :key :value nil :reason "stored assertion key is required"))
+    (when (eq kind :retract)
+      (%kb-require-string :target-assertion-id target-assertion-id))
+    (%make-operational-kb-entry
+     :kind kind
+     :operation-id operation-id
+     :run-id run-id
+     :expert-id expert-id
+     :expert-version expert-version
+     :record-id (tek9:node-id node)
+     :key (getf props :key)
+     :value (getf props :value)
+     :target-assertion-id target-assertion-id
+     :evidence-ids (copy-list evidence-ids)
+     :provenance provenance)))
+
 (defun operational-kb-root-node (operation-id)
   (make-instance 'tek9:node
                  :id (operational-kb-root-id operation-id)

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -29,9 +29,11 @@
    #:validate-tool-result-link
    #:execution-graph-name
    #:execution-record->tek9-node
+   #:tek9-node->execution-record
    #:tool-result-link-edge
    #:persist-execution-record
    #:persist-tool-execution
+   #:fetch-operation-execution-records
    #:operational-kb-validation-error
    #:operational-kb-entry
    #:operational-kb-entry-kind
@@ -50,10 +52,12 @@
    #:operational-kb-graph-name
    #:operational-kb-root-id
    #:operational-kb-entry->tek9-node
+   #:tek9-node->operational-kb-entry
    #:operational-kb-membership-edge
    #:operational-kb-retraction-edge
    #:persist-operational-kb-entry
    #:fetch-operational-kb-entry
+   #:fetch-operational-kb-entries
    #:long-term-kb-validation-error
    #:long-term-kb-promotion
    #:long-term-kb-promotion-record-id

--- a/source/hackmode-database/tests/execution-graph.lisp
+++ b/source/hackmode-database/tests/execution-graph.lisp
@@ -15,7 +15,7 @@
                 :call-id "call-1"
                 :capability-id "dns.resolve"
                 :input '(:domain "example.com")
-                :provenance '(:worker "database-test")))
+                :provenance '(:source "database-test")))
          (result (make-tool-result-record
                   :operation-id "op-1"
                   :run-id "run-1"
@@ -62,7 +62,7 @@
            :call-id "call-2"
            :capability-id "dns.resolve"
            :input nil
-           :provenance '(:worker "database-test"))
+           :provenance '(:source "database-test"))
           (error "empty operation identity unexpectedly accepted"))
       (execution-graph-validation-error () t))))
 
@@ -77,7 +77,7 @@
             :key '(:hypothesis "wildcard-dns")
             :value '(:confidence 80)
             :evidence-ids '("call-1" "result-1")
-            :provenance '(:worker "database-test")))
+            :provenance '(:source "database-test")))
          (same
            (make-operational-kb-assertion
             :assertion-id "a-1"
@@ -88,7 +88,7 @@
             :key '(:hypothesis "wildcard-dns")
             :value '(:confidence 80)
             :evidence-ids '("call-1" "result-1")
-            :provenance '(:worker "database-test")))
+            :provenance '(:source "database-test")))
          (retraction
            (make-operational-kb-retraction
             :retraction-id "r-1"
@@ -98,7 +98,7 @@
             :expert-version "1"
             :target-assertion-id (operational-kb-entry-record-id assertion)
             :evidence-ids '("result-2")
-            :provenance '(:worker "database-test"))))
+            :provenance '(:source "database-test"))))
     (ensure (eq :assert (operational-kb-entry-kind assertion))
             "operational KB assertion has wrong kind")
     (ensure (equal (operational-kb-entry-record-id assertion)
@@ -131,11 +131,81 @@
            :expert-version "1"
            :target-assertion-id (operational-kb-entry-record-id assertion)
            :evidence-ids '("result-x")
-           :provenance '(:worker "database-test"))
+           :provenance '(:source "database-test"))
           (error "cross-operation retraction unexpectedly accepted"))
       (operational-kb-validation-error () t))))
+
+(defun run-operation-snapshot-read-tests ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-snapshot-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-snapshot-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((call-a (make-tool-call-record
+                           :operation-id "op-a" :run-id "run-1" :call-id "call-a"
+                           :capability-id "dns.resolve" :input '(:domain "a.example")
+                           :provenance '(:source "fixture")))
+                  (result-a (make-tool-result-record
+                             :operation-id "op-a" :run-id "run-1" :call-id "call-a"
+                             :result-id "result-a" :status :succeeded
+                             :output '(:addresses ("192.0.2.10"))
+                             :provenance '(:source "fixture")))
+                  (call-b (make-tool-call-record
+                           :operation-id "op-a" :run-id "run-2" :call-id "call-b"
+                           :capability-id "http.probe" :input '(:url "https://a.example")
+                           :provenance '(:source "fixture")))
+                  (foreign (make-tool-call-record
+                            :operation-id "op-b" :run-id "run-1" :call-id "call-x"
+                            :capability-id "dns.resolve" :input '(:domain "b.example")
+                            :provenance '(:source "fixture")))
+                  (assertion (make-operational-kb-assertion
+                              :assertion-id "hyp-1" :operation-id "op-a"
+                              :run-id "run-1" :expert-id "recon" :expert-version "1"
+                              :key '(:hypothesis "wildcard-dns") :value '(:confidence 80)
+                              :evidence-ids (list (execution-record-record-id result-a))
+                              :provenance '(:source "fixture")))
+                  (retraction (make-operational-kb-retraction
+                               :retraction-id "hyp-1-retracted" :operation-id "op-a"
+                               :run-id "run-2" :expert-id "recon" :expert-version "1"
+                               :target-assertion-id (operational-kb-entry-record-id assertion)
+                               :evidence-ids (list (execution-record-record-id call-b))
+                               :provenance '(:source "fixture"))))
+             (persist-tool-execution database call-a result-a)
+             (persist-execution-record database call-b)
+             (persist-execution-record database foreign)
+             (persist-operational-kb-entry database assertion)
+             (persist-operational-kb-entry database retraction)
+             (let ((records (fetch-operation-execution-records database "op-a"))
+                   (run-1 (fetch-operation-execution-records database "op-a" :run-id "run-1"))
+                   (kb (fetch-operational-kb-entries database "op-a")))
+               (ensure (= 3 (length records))
+                       "operation execution snapshot did not return all typed records")
+               (ensure (every (lambda (record)
+                                (string= "op-a" (execution-record-operation-id record)))
+                              records)
+                       "operation execution snapshot leaked another operation")
+               (ensure (= 2 (length run-1))
+                       "run filter did not return call/result pair")
+               (ensure (= 2 (length kb))
+                       "operational KB snapshot did not include assertion and retraction")
+               (ensure (every (lambda (entry)
+                                (string= "op-a" (operational-kb-entry-operation-id entry)))
+                              kb)
+                       "operational KB snapshot leaked another operation")
+               (ensure (find :assert kb :key #'operational-kb-entry-kind)
+                       "operational KB snapshot lost assertion")
+               (ensure (find :retract kb :key #'operational-kb-entry-kind)
+                       "operational KB snapshot lost retraction"))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)
 
 (defun run-tests ()
   (run-execution-graph-tests)
   (run-operational-kb-tests)
+  (run-operation-snapshot-read-tests)
   t)


### PR DESCRIPTION
Bounded database-owned slice for #24/#27.

RED-first acceptance target:
- enumerate typed execution records for one operation without leaking another operation;
- optionally filter execution records by run identity;
- enumerate typed operational-KB assertions and retractions for one operation;
- reconstruct typed Common Lisp records from canonical Tek9 graph nodes;
- read path remains projection-only: no provider execution, no expert behavior, no second graph/KB authority.

RED head: `02a8f98212baceb462f1b45c0f00c6b50ad2788e`.
GREEN exact head: `244eff751e366dd8d6e5993fe8cef7f2296d618e` (`core`, `monorepo`, `agent-framework-boundary` all passed).

Superseded by a non-draft PR at the identical exact head because the GitHub connector's ready-for-review mutation fails internally. No code/head change.