### PR TITLE
Hackpert: rebuild expert snapshots from canonical operation state

### DIFF
--- a/source/hackmode-core/expert/state-snapshot.lisp
+++ b/source/hackmode-core/expert/state-snapshot.lisp
@@ -81,4 +81,44 @@ not enumerate storage, persist data, dispatch providers, or widen authority."
             :query-asset query-asset)
    (expert-state-facts execution-records operational-kb-entries)))
 
-(export '(expert-state-facts))
+(defun expert-operation-snapshot (&key
+                                    (database *db*)
+                                    (operation (current-operation))
+                                    run-id
+                                    (assets nil assets-supplied-p)
+                                    (providers (list-capability-providers))
+                                    query-target
+                                    query-asset)
+  "Rebuild an expert snapshot from canonical persisted operation state.
+
+The database package remains the storage authority. This function consumes its
+typed operation-scoped read APIs, then delegates to EXPERT-SNAPSHOT for the
+pure Prolog projection. RUN-ID optionally limits execution and operational-KB
+history to one expert run. Repeated calls intentionally re-read canonical state
+so a later reasoning iteration observes newly persisted evidence."
+  (unless database
+    (error "EXPERT-OPERATION-SNAPSHOT requires an operation database."))
+  (unless operation
+    (error "EXPERT-OPERATION-SNAPSHOT requires an operation."))
+  (let* ((operation-id (operation-name operation))
+         (execution-records
+           (hack-db:fetch-operation-execution-records
+            database operation-id :run-id run-id))
+         (operational-kb-entries
+           (hack-db:fetch-operational-kb-entries
+            database operation-id :run-id run-id))
+         (effective-assets
+           (if assets-supplied-p
+               assets
+               (query-assets :database database))))
+    (expert-snapshot
+     :operation operation
+     :assets effective-assets
+     :providers providers
+     :query-target query-target
+     :query-asset query-asset
+     :execution-records execution-records
+     :operational-kb-entries operational-kb-entries)))
+
+(export '(expert-state-facts
+          expert-operation-snapshot))

--- a/source/hackmode-core/tests/expert-state-snapshot.lisp
+++ b/source/hackmode-core/tests/expert-state-snapshot.lisp
@@ -1,6 +1,6 @@
 (in-package :hackmode-tests)
 
-(defun run-expert-state-snapshot-tests ()
+(defun run-expert-state-projection-test ()
   (let* ((call (hack-db:make-tool-call-record
                 :operation-id "op-1" :run-id "run-1" :call-id "call-1"
                 :capability-id "http-probe" :input '(:url "https://example.test")
@@ -37,3 +37,87 @@
               ()
               "Execution facts must sort by stable record ID."))
     t))
+
+(defun run-expert-persisted-snapshot-refresh-test ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-expert-refresh-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-expert-refresh" :path path))
+         (operation (make-instance 'hackmode:operation
+                                   :name "op-refresh"
+                                   :dir "/tmp/op-refresh/")))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((call (hack-db:make-tool-call-record
+                         :operation-id "op-refresh"
+                         :run-id "run-1"
+                         :call-id "call-1"
+                         :capability-id "http-probe"
+                         :input '(:url "https://example.test")
+                         :provenance '(:source "fixture")))
+                  (result (hack-db:make-tool-result-record
+                           :operation-id "op-refresh"
+                           :run-id "run-1"
+                           :call-id "call-1"
+                           :result-id "result-1"
+                           :status :succeeded
+                           :output '(:status 200)
+                           :provenance '(:source "fixture")))
+                  (assertion (hack-db:make-operational-kb-assertion
+                              :assertion-id "status-1"
+                              :operation-id "op-refresh"
+                              :run-id "run-1"
+                              :expert-id "recon"
+                              :expert-version "1"
+                              :key "http.status"
+                              :value 200
+                              :evidence-ids
+                              (list (hack-db:execution-record-record-id result))
+                              :provenance '(:source "fixture"))))
+             (hack-db:persist-tool-execution database call result)
+             (hack-db:persist-operational-kb-entry database assertion)
+             (let ((snapshot
+                     (hackmode:expert-operation-snapshot
+                      :database database
+                      :operation operation
+                      :run-id "run-1"
+                      :assets nil
+                      :providers nil)))
+               (assert (search (hack-db:execution-record-record-id call) snapshot))
+               (assert (search (hack-db:execution-record-record-id result) snapshot))
+               (assert (search (hack-db:operational-kb-entry-record-id assertion)
+                               snapshot)))
+             (let ((next-assertion
+                     (hack-db:make-operational-kb-assertion
+                      :assertion-id "next-step"
+                      :operation-id "op-refresh"
+                      :run-id "run-1"
+                      :expert-id "recon"
+                      :expert-version "1"
+                      :key "recon.next"
+                      :value "subdomain-enumerate"
+                      :evidence-ids (list (hack-db:execution-record-record-id result))
+                      :provenance '(:source "fixture"))))
+               (hack-db:persist-operational-kb-entry database next-assertion)
+               (let ((refreshed
+                       (hackmode:expert-operation-snapshot
+                        :database database
+                        :operation operation
+                        :run-id "run-1"
+                        :assets nil
+                        :providers nil)))
+                 (assert (search (hack-db:operational-kb-entry-record-id next-assertion)
+                                 refreshed)
+                         ()
+                         "Fresh expert iteration must observe newly persisted KB evidence.")))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)
+
+(defun run-expert-state-snapshot-tests ()
+  (run-expert-state-projection-test)
+  (run-expert-persisted-snapshot-refresh-test)
+  t)


### PR DESCRIPTION
Bounded Hackpert-owned slice for #27 after database #58.

RED-first acceptance target: an expert iteration must be able to rebuild its snapshot from canonical operation-scoped execution records and operational-KB entries, then observe newly persisted KB evidence on the next refresh.

This slice consumes only the database sibling's typed read APIs. It adds no direct Tek9 traversal/mutation, no storage internals, no provider executor, and no second graph/KB authority.

RED commit: `166b3558767f9c290afb581d5f123bfb83622b87` — exact-head core failed as intended while monorepo/boundary remained green.
GREEN exact head: `f6b60c875447d0cf2d27b24d9f4b7bc04646e19b` — core, monorepo, and agent-framework-boundary all passed.

Superseded by a non-draft PR for the identical exact head because the GitHub connector's ready-for-review mutation fails internally. No code/head change is involved.