### PR TITLE
Database: add typed reusable KB reads

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -136,6 +136,7 @@
       (persist-graph-nodes-replay-safe
        database
        (list (long-term-kb-root-node)
+             (long-term-kb-source-reference-node promotion)
              (long-term-kb-promotion->tek9-node promotion))
        :database-name graph-name)
       (persist-graph-edges-replay-safe
@@ -171,6 +172,7 @@
       (persist-graph-nodes-replay-safe
        database
        (list (global-kb-root-node)
+             (global-kb-source-reference-node export)
              (global-kb-export->tek9-node export))
        :database-name graph-name)
       (persist-graph-edges-replay-safe

--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -150,6 +150,20 @@
   (tek9:fetch-node database record-id
                    :database-name (long-term-kb-graph-name)))
 
+(defun fetch-long-term-kb-promotions (database &key source-operation-id)
+  "Return typed long-term KB promotions in deterministic record-ID order."
+  (when source-operation-id
+    (%long-term-require-string :source-operation-id source-operation-id))
+  (let ((promotions nil))
+    (dolist (node (tek9:fetch-graph-nodes database (long-term-kb-graph-name)))
+      (when (eq :long-term-kb-promotion (getf (tek9:node-props node) :kind))
+        (let ((promotion (tek9-node->long-term-kb-promotion node)))
+          (when (or (null source-operation-id)
+                    (string= source-operation-id
+                             (long-term-kb-promotion-source-operation-id promotion)))
+            (push promotion promotions)))))
+    (sort promotions #'string< :key #'long-term-kb-promotion-record-id)))
+
 (defun persist-global-kb-export (database export)
   "Persist one explicit immutable export through canonical Tek9 graph APIs."
   (let ((graph-name (global-kb-graph-name)))
@@ -170,3 +184,17 @@
   "Fetch one explicit global KB export by stable record identity."
   (tek9:fetch-node database record-id
                    :database-name (global-kb-graph-name)))
+
+(defun fetch-global-kb-exports (database &key source-operation-id)
+  "Return typed global KB exports in deterministic record-ID order."
+  (when source-operation-id
+    (%global-require-string :source-operation-id source-operation-id))
+  (let ((exports nil))
+    (dolist (node (tek9:fetch-graph-nodes database (global-kb-graph-name)))
+      (when (eq :global-kb-export (getf (tek9:node-props node) :kind))
+        (let ((export (tek9-node->global-kb-export node)))
+          (when (or (null source-operation-id)
+                    (string= source-operation-id
+                             (global-kb-export-source-operation-id export)))
+            (push export exports)))))
+    (sort exports #'string< :key #'global-kb-export-record-id)))

--- a/source/hackmode-database/global-kb.lisp
+++ b/source/hackmode-database/global-kb.lisp
@@ -126,6 +126,65 @@ export does not persist it; persistence remains an explicit canonical Tek9 write
                        :provenance
                        (global-kb-export-provenance export))))
 
+(defun tek9-node->global-kb-export (node)
+  "Reconstruct and validate one typed global export from NODE."
+  (let ((props (tek9:node-props node)))
+    (unless (eq :global-kb-export (getf props :kind))
+      (error 'global-kb-validation-error
+             :field :kind :value (getf props :kind)
+             :reason "expected global KB export node"))
+    (let ((record-id (%global-require-string :record-id (tek9:node-id node)))
+          (source-promotion-id
+            (%global-require-string
+             :source-promotion-id (getf props :source-promotion-id)))
+          (source-operation-id
+            (%global-require-string
+             :source-operation-id (getf props :source-operation-id)))
+          (source-assertion-id
+            (%global-require-string
+             :source-assertion-id (getf props :source-assertion-id)))
+          (source-run-id
+            (%global-require-string :source-run-id (getf props :source-run-id)))
+          (source-expert-id
+            (%global-require-string
+             :source-expert-id (getf props :source-expert-id)))
+          (source-expert-version
+            (%global-require-string
+             :source-expert-version (getf props :source-expert-version)))
+          (source-evidence-ids
+            (%global-require-evidence
+             :source-evidence-ids (getf props :source-evidence-ids)))
+          (promotion-evidence-ids
+            (%global-require-evidence
+             :promotion-evidence-ids (getf props :promotion-evidence-ids)))
+          (exported-by
+            (%global-require-string :exported-by (getf props :exported-by)))
+          (exporter-version
+            (%global-require-string
+             :exporter-version (getf props :exporter-version)))
+          (evidence-ids
+            (%global-require-evidence :evidence-ids (getf props :evidence-ids)))
+          (provenance (getf props :provenance)))
+      (unless provenance
+        (error 'global-kb-validation-error
+               :field :provenance :value provenance :reason "provenance is required"))
+      (%make-global-kb-export
+       :record-id record-id
+       :source-promotion-id source-promotion-id
+       :source-operation-id source-operation-id
+       :source-assertion-id source-assertion-id
+       :source-run-id source-run-id
+       :source-expert-id source-expert-id
+       :source-expert-version source-expert-version
+       :source-evidence-ids (copy-list source-evidence-ids)
+       :promotion-evidence-ids (copy-list promotion-evidence-ids)
+       :key (getf props :key)
+       :value (getf props :value)
+       :exported-by exported-by
+       :exporter-version exporter-version
+       :evidence-ids (copy-list evidence-ids)
+       :provenance provenance))))
+
 (defun global-kb-root-node ()
   (make-instance 'tek9:node
                  :id (global-kb-root-id)

--- a/source/hackmode-database/global-kb.lisp
+++ b/source/hackmode-database/global-kb.lisp
@@ -190,6 +190,23 @@ export does not persist it; persistence remains an explicit canonical Tek9 write
                  :id (global-kb-root-id)
                  :props (list :kind :global-kb-root)))
 
+(defun global-kb-source-reference-node (export)
+  "Return an immutable graph-local foreign-key anchor for EXPORT's promotion."
+  (make-instance 'tek9:node
+                 :id (global-kb-export-source-promotion-id export)
+                 :props
+                 (list :kind :long-term-kb-reference
+                       :source-operation-id
+                       (global-kb-export-source-operation-id export)
+                       :source-assertion-id
+                       (global-kb-export-source-assertion-id export)
+                       :source-run-id
+                       (global-kb-export-source-run-id export)
+                       :source-expert-id
+                       (global-kb-export-source-expert-id export)
+                       :source-expert-version
+                       (global-kb-export-source-expert-version export))))
+
 (defun global-kb-membership-edge (export)
   (make-instance 'tek9:edge
                  :id (%record-id "global-kb-membership"

--- a/source/hackmode-database/long-term-kb.lisp
+++ b/source/hackmode-database/long-term-kb.lisp
@@ -118,6 +118,57 @@ export. Multiple operations may independently promote corroborating knowledge."
                        :provenance
                        (long-term-kb-promotion-provenance promotion))))
 
+(defun tek9-node->long-term-kb-promotion (node)
+  "Reconstruct and validate one typed long-term promotion from NODE."
+  (let ((props (tek9:node-props node)))
+    (unless (eq :long-term-kb-promotion (getf props :kind))
+      (error 'long-term-kb-validation-error
+             :field :kind :value (getf props :kind)
+             :reason "expected long-term KB promotion node"))
+    (let ((record-id (%long-term-require-string :record-id (tek9:node-id node)))
+          (source-operation-id
+            (%long-term-require-string
+             :source-operation-id (getf props :source-operation-id)))
+          (source-assertion-id
+            (%long-term-require-string
+             :source-assertion-id (getf props :source-assertion-id)))
+          (source-run-id
+            (%long-term-require-string :source-run-id (getf props :source-run-id)))
+          (source-expert-id
+            (%long-term-require-string
+             :source-expert-id (getf props :source-expert-id)))
+          (source-expert-version
+            (%long-term-require-string
+             :source-expert-version (getf props :source-expert-version)))
+          (source-evidence-ids
+            (%long-term-require-evidence
+             :source-evidence-ids (getf props :source-evidence-ids)))
+          (promoted-by
+            (%long-term-require-string :promoted-by (getf props :promoted-by)))
+          (promoter-version
+            (%long-term-require-string
+             :promoter-version (getf props :promoter-version)))
+          (evidence-ids
+            (%long-term-require-evidence :evidence-ids (getf props :evidence-ids)))
+          (provenance (getf props :provenance)))
+      (unless provenance
+        (error 'long-term-kb-validation-error
+               :field :provenance :value provenance :reason "provenance is required"))
+      (%make-long-term-kb-promotion
+       :record-id record-id
+       :source-operation-id source-operation-id
+       :source-assertion-id source-assertion-id
+       :source-run-id source-run-id
+       :source-expert-id source-expert-id
+       :source-expert-version source-expert-version
+       :source-evidence-ids (copy-list source-evidence-ids)
+       :key (getf props :key)
+       :value (getf props :value)
+       :promoted-by promoted-by
+       :promoter-version promoter-version
+       :evidence-ids (copy-list evidence-ids)
+       :provenance provenance))))
+
 (defun long-term-kb-root-node ()
   (make-instance 'tek9:node
                  :id (long-term-kb-root-id)

--- a/source/hackmode-database/long-term-kb.lisp
+++ b/source/hackmode-database/long-term-kb.lisp
@@ -174,6 +174,21 @@ export. Multiple operations may independently promote corroborating knowledge."
                  :id (long-term-kb-root-id)
                  :props (list :kind :long-term-kb-root)))
 
+(defun long-term-kb-source-reference-node (promotion)
+  "Return an immutable graph-local foreign-key anchor for PROMOTION's source."
+  (make-instance 'tek9:node
+                 :id (long-term-kb-promotion-source-assertion-id promotion)
+                 :props
+                 (list :kind :operational-kb-reference
+                       :source-operation-id
+                       (long-term-kb-promotion-source-operation-id promotion)
+                       :source-run-id
+                       (long-term-kb-promotion-source-run-id promotion)
+                       :source-expert-id
+                       (long-term-kb-promotion-source-expert-id promotion)
+                       :source-expert-version
+                       (long-term-kb-promotion-source-expert-version promotion))))
+
 (defun long-term-kb-membership-edge (promotion)
   (make-instance 'tek9:edge
                  :id (%record-id "long-term-kb-membership"

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -77,10 +77,12 @@
    #:long-term-kb-graph-name
    #:long-term-kb-root-id
    #:long-term-kb-promotion->tek9-node
+   #:tek9-node->long-term-kb-promotion
    #:long-term-kb-membership-edge
    #:long-term-kb-source-edge
    #:persist-long-term-kb-promotion
    #:fetch-long-term-kb-promotion
+   #:fetch-long-term-kb-promotions
    #:global-kb-validation-error
    #:global-kb-export
    #:global-kb-export-record-id
@@ -102,9 +104,11 @@
    #:global-kb-graph-name
    #:global-kb-root-id
    #:global-kb-export->tek9-node
+   #:tek9-node->global-kb-export
    #:global-kb-membership-edge
    #:global-kb-source-edge
    #:persist-global-kb-export
    #:fetch-global-kb-export
+   #:fetch-global-kb-exports
    #:put-doc
    #:put-docs))

--- a/source/hackmode-database/tests/global-kb.lisp
+++ b/source/hackmode-database/tests/global-kb.lisp
@@ -72,4 +72,74 @@
            :provenance '(:reason "invalid"))
           (error "global export unexpectedly accepted without evidence"))
       (global-kb-validation-error () t)))
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-global-read-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-global-read-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (flet ((promotion (operation assertion promotion-id)
+                    (make-long-term-kb-promotion
+                     :promotion-id promotion-id
+                     :source-assertion
+                     (make-operational-kb-assertion
+                      :assertion-id assertion
+                      :operation-id operation
+                      :run-id "run-1"
+                      :expert-id "recon"
+                      :expert-version "1"
+                      :key (list :operation operation)
+                      :value '(:validated t)
+                      :evidence-ids (list (format nil "result-~A" operation))
+                      :provenance '(:source "fixture"))
+                     :promoted-by "operator"
+                     :promoter-version "1"
+                     :evidence-ids (list (format nil "review-~A" operation))
+                     :provenance '(:reason "reusable"))))
+             (let* ((promotion-a (promotion "op-a" "a-a" "p-a"))
+                    (promotion-b (promotion "op-b" "a-b" "p-b"))
+                    (export-b
+                      (make-global-kb-export
+                       :export-id "e-b"
+                       :source-promotion promotion-b
+                       :exported-by "operator"
+                       :exporter-version "1"
+                       :evidence-ids '("approval-b")
+                       :provenance '(:reason "shared")))
+                    (export-a
+                      (make-global-kb-export
+                       :export-id "e-a"
+                       :source-promotion promotion-a
+                       :exported-by "operator"
+                       :exporter-version "1"
+                       :evidence-ids '("approval-a")
+                       :provenance '(:reason "shared"))))
+               (persist-global-kb-export database export-b)
+               (persist-global-kb-export database export-a)
+               (let ((all (fetch-global-kb-exports database))
+                     (op-a (fetch-global-kb-exports
+                            database :source-operation-id "op-a")))
+                 (ensure (= 2 (length all))
+                         "global KB enumeration lost exports")
+                 (ensure (every (lambda (item) (typep item 'global-kb-export)) all)
+                         "global KB enumeration leaked raw Tek9 nodes")
+                 (ensure (equal (sort (mapcar #'global-kb-export-record-id
+                                             (copy-list all))
+                                      #'string<)
+                                (mapcar #'global-kb-export-record-id all))
+                         "global KB enumeration is not deterministic")
+                 (ensure (= 1 (length op-a))
+                         "global KB operation filter returned wrong count")
+                 (ensure (string= "op-a"
+                                  (global-kb-export-source-operation-id
+                                   (first op-a)))
+                         "global KB operation filter leaked another operation")
+                 (ensure (equal '("approval-a")
+                                (global-kb-export-evidence-ids (first op-a)))
+                         "global KB read lost export evidence provenance")))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
   t)

--- a/source/hackmode-database/tests/long-term-kb.lisp
+++ b/source/hackmode-database/tests/long-term-kb.lisp
@@ -80,4 +80,73 @@
            :provenance '(:reason "invalid"))
           (error "retraction unexpectedly promoted into long-term KB"))
       (long-term-kb-validation-error () t)))
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-long-term-read-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-long-term-read-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (flet ((source (operation assertion run expert key value evidence)
+                    (make-operational-kb-assertion
+                     :assertion-id assertion
+                     :operation-id operation
+                     :run-id run
+                     :expert-id expert
+                     :expert-version "1"
+                     :key key
+                     :value value
+                     :evidence-ids evidence
+                     :provenance '(:source "fixture"))))
+             (let* ((source-a (source "op-a" "a-1" "run-1" "recon"
+                                      '(:service "http") '(:port 80) '("result-a")))
+                    (source-b (source "op-b" "a-2" "run-2" "web"
+                                      '(:service "https") '(:port 443) '("result-b")))
+                    (promotion-b
+                      (make-long-term-kb-promotion
+                       :promotion-id "p-b"
+                       :source-assertion source-b
+                       :promoted-by "operator"
+                       :promoter-version "1"
+                       :evidence-ids '("review-b")
+                       :provenance '(:reason "reusable")))
+                    (promotion-a
+                      (make-long-term-kb-promotion
+                       :promotion-id "p-a"
+                       :source-assertion source-a
+                       :promoted-by "operator"
+                       :promoter-version "1"
+                       :evidence-ids '("review-a")
+                       :provenance '(:reason "reusable"))))
+               ;; Persist reverse lexical order so the read contract proves sorting.
+               (persist-long-term-kb-promotion database promotion-b)
+               (persist-long-term-kb-promotion database promotion-a)
+               (let ((all (fetch-long-term-kb-promotions database))
+                     (op-a (fetch-long-term-kb-promotions
+                            database :source-operation-id "op-a")))
+                 (ensure (= 2 (length all))
+                         "long-term KB enumeration lost promotions")
+                 (ensure (every (lambda (item)
+                                  (typep item 'long-term-kb-promotion))
+                                all)
+                         "long-term KB enumeration leaked raw Tek9 nodes")
+                 (ensure (equal (sort (mapcar #'long-term-kb-promotion-record-id
+                                             (copy-list all))
+                                      #'string<)
+                                (mapcar #'long-term-kb-promotion-record-id all))
+                         "long-term KB enumeration is not deterministic")
+                 (ensure (= 1 (length op-a))
+                         "long-term KB operation filter returned wrong count")
+                 (ensure (string= "op-a"
+                                  (long-term-kb-promotion-source-operation-id
+                                   (first op-a)))
+                         "long-term KB operation filter leaked another operation")
+                 (ensure (equal '("result-a")
+                                (long-term-kb-promotion-source-evidence-ids
+                                 (first op-a)))
+                         "long-term KB read lost source evidence provenance")))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
   t)


### PR DESCRIPTION
Bounded database-owned slice for #24.

Adds the missing read side for the reusable KB lifecycle:
- reconstruct long-term promotion Tek9 nodes as validated `long-term-kb-promotion` values;
- reconstruct global export nodes as validated `global-kb-export` values;
- enumerate each canonical graph in deterministic record-ID order;
- optionally filter by source operation;
- preserve source/promotion/export evidence and provenance;
- ignore graph root nodes rather than leaking raw storage objects.

No Hackpert code, provider execution, new persistence authority, or shadow KB is introduced.

RED head: `4dcdd8d7698cd0d7480942e6a6220e6eef86249c`
Implementation head: `82b88fa3881b497bc8f11df3108f0ef7eb0e2fe6`