### PR TITLE
Database: add effective operational KB snapshots

### DIFF
--- a/source/hackmode-database/effective-operational-kb.lisp
+++ b/source/hackmode-database/effective-operational-kb.lisp
@@ -1,0 +1,36 @@
+(in-package :hackmode-database)
+
+(defun fetch-effective-operational-kb-assertions
+    (database operation-id &key run-id)
+  "Return live operational-KB assertions after resolving all canonical retractions.
+
+Retractions are resolved across the whole operation before RUN-ID filters the
+remaining assertions. This prevents a later run from retracting an assertion and
+a filtered read from accidentally resurrecting it."
+  (%kb-require-string :operation-id operation-id)
+  (when run-id
+    (%kb-require-string :run-id run-id))
+  (let* ((entries (fetch-operational-kb-entries database operation-id))
+         (assertions (make-hash-table :test #'equal))
+         (retracted (make-hash-table :test #'equal)))
+    (dolist (entry entries)
+      (when (eq :assert (operational-kb-entry-kind entry))
+        (setf (gethash (operational-kb-entry-record-id entry) assertions)
+              entry)))
+    (dolist (entry entries)
+      (when (eq :retract (operational-kb-entry-kind entry))
+        (let ((target-id (operational-kb-entry-target-assertion-id entry)))
+          (unless (gethash target-id assertions)
+            (error 'operational-kb-validation-error
+                   :field :target-assertion-id
+                   :value target-id
+                   :reason "stored retraction target assertion is missing"))
+          (setf (gethash target-id retracted) t))))
+    (loop for entry in entries
+          when (and (eq :assert (operational-kb-entry-kind entry))
+                    (not (gethash (operational-kb-entry-record-id entry)
+                                  retracted))
+                    (or (null run-id)
+                        (string= run-id
+                                 (operational-kb-entry-run-id entry))))
+            collect entry)))

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -7,7 +7,8 @@
                (:file "tests/global-kb")
                (:file "tests/replay-conflict")
                (:file "tests/kb-seed-import")
-               (:file "tests/execution-outcome-kb"))
+               (:file "tests/execution-outcome-kb")
+               (:file "tests/effective-operational-kb"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
@@ -16,4 +17,6 @@
              (uiop:symbol-call :hackmode-database-tests :run-replay-conflict-tests)
              (uiop:symbol-call :hackmode-database-tests :run-kb-seed-import-tests)
              (uiop:symbol-call :hackmode-database-execution-outcome-tests
-                               :run-execution-outcome-kb-tests)))
+                               :run-execution-outcome-kb-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-effective-operational-kb-tests)))

--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -14,4 +14,5 @@
                (:file "long-term-kb")
                (:file "global-kb")
                (:file "replay")
-               (:file "db")))
+               (:file "db")
+               (:file "effective-operational-kb")))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -58,6 +58,7 @@
    #:persist-operational-kb-entry
    #:fetch-operational-kb-entry
    #:fetch-operational-kb-entries
+   #:fetch-effective-operational-kb-assertions
    #:make-execution-outcome-kb-candidate
    #:+operational-kb-seed-import-limit+
    #:+operational-kb-seed-kinds+

--- a/source/hackmode-database/tests/effective-operational-kb.lisp
+++ b/source/hackmode-database/tests/effective-operational-kb.lisp
@@ -1,0 +1,73 @@
+(in-package :hackmode-database-tests)
+
+(defun run-effective-operational-kb-tests ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-effective-kb-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-effective-kb-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((first
+                    (hackmode-database:make-operational-kb-assertion
+                     :assertion-id "first"
+                     :operation-id "op-1"
+                     :run-id "run-1"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key '(:host "example.com")
+                     :value '(:status :alive)
+                     :evidence-ids '("evidence-1")
+                     :provenance '(:source :fixture)))
+                  (second
+                    (hackmode-database:make-operational-kb-assertion
+                     :assertion-id "second"
+                     :operation-id "op-1"
+                     :run-id "run-2"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key '(:service "example.com" 443)
+                     :value '(:status :open)
+                     :evidence-ids '("evidence-2")
+                     :provenance '(:source :fixture)))
+                  (retraction
+                    (hackmode-database:make-operational-kb-retraction
+                     :retraction-id "retract-first"
+                     :operation-id "op-1"
+                     :run-id "run-2"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :target-assertion-id
+                     (hackmode-database:operational-kb-entry-record-id first)
+                     :evidence-ids '("evidence-3")
+                     :provenance '(:source :fixture))))
+             (hackmode-database:persist-operational-kb-entry database first)
+             (hackmode-database:persist-operational-kb-entry database second)
+             (hackmode-database:persist-operational-kb-entry database retraction)
+             (let ((effective
+                     (hackmode-database:fetch-effective-operational-kb-assertions
+                      database "op-1")))
+               (ensure (= 1 (length effective))
+                       "effective snapshot did not remove the retracted assertion")
+               (ensure (string=
+                        (hackmode-database:operational-kb-entry-record-id second)
+                        (hackmode-database:operational-kb-entry-record-id (first effective)))
+                       "effective snapshot returned the wrong assertion"))
+             (ensure
+              (null (hackmode-database:fetch-effective-operational-kb-assertions
+                     database "op-1" :run-id "run-1"))
+              "run filtering resurrected an assertion retracted by a later run")
+             (let ((run-2
+                     (hackmode-database:fetch-effective-operational-kb-assertions
+                      database "op-1" :run-id "run-2")))
+               (ensure (= 1 (length run-2))
+                       "run-filtered effective snapshot lost a live assertion")
+               (ensure (string=
+                        (hackmode-database:operational-kb-entry-record-id second)
+                        (hackmode-database:operational-kb-entry-record-id (first run-2)))
+                       "run-filtered effective snapshot returned the wrong assertion"))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)


### PR DESCRIPTION
## Slice
Add a canonical database read that resolves operational-KB assertions minus retractions so consumers do not reimplement KB state resolution.

## RED acceptance
- effective snapshot excludes retracted assertions;
- a retraction from a later run still suppresses an earlier-run assertion when `:run-id` filters the resulting live assertions;
- live assertions remain deterministically typed and operation-scoped.

Database-only ownership. No Hackpert behavior changes, no provider execution, no shadow KB/database.