### PR TITLE
Database: persist typed HTTP exchange evidence in execution graph

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -44,7 +44,8 @@
   (%require-string :operation-id operation-id)
   (when run-id
     (%require-string :run-id run-id))
-  (when (and kind (not (member kind '(:tool-call :tool-result) :test #'eq)))
+  (when (and kind
+             (not (member kind '(:tool-call :tool-result :http-exchange) :test #'eq)))
     (error 'execution-graph-validation-error
            :field :kind :value kind :reason "unsupported execution record filter"))
   (let ((records

--- a/source/hackmode-database/execution-graph.lisp
+++ b/source/hackmode-database/execution-graph.lisp
@@ -36,6 +36,52 @@
            :field :provenance :value value :reason "provenance is required"))
   value)
 
+(defun %require-http-port (value)
+  (unless (and (integerp value) (<= 1 value 65535))
+    (error 'execution-graph-validation-error
+           :field :port :value value :reason "expected TCP port in range 1..65535"))
+  value)
+
+(defun %require-http-status (value)
+  (unless (and (integerp value) (<= 100 value 599))
+    (error 'execution-graph-validation-error
+           :field :response-status :value value
+           :reason "expected HTTP response status in range 100..599"))
+  value)
+
+(defun %require-duration-ms (value)
+  (unless (and (integerp value) (not (minusp value)))
+    (error 'execution-graph-validation-error
+           :field :duration-ms :value value
+           :reason "expected non-negative integer milliseconds"))
+  value)
+
+(defun %require-optional-string (field value)
+  (when value
+    (%require-string field value))
+  value)
+
+(defun %validate-http-exchange-payload (payload)
+  (unless (listp payload)
+    (error 'execution-graph-validation-error
+           :field :payload :value payload :reason "expected HTTP exchange property list"))
+  (%require-string :method (getf payload :method))
+  (let ((scheme (getf payload :scheme)))
+    (%require-string :scheme scheme)
+    (unless (member scheme '("http" "https") :test #'string-equal)
+      (error 'execution-graph-validation-error
+             :field :scheme :value scheme :reason "expected http or https scheme")))
+  (%require-string :host (getf payload :host))
+  (%require-http-port (getf payload :port))
+  (%require-string :path (getf payload :path))
+  (%require-http-status (getf payload :response-status))
+  (%require-optional-string :request-body-digest (getf payload :request-body-digest))
+  (%require-optional-string :response-body-digest (getf payload :response-body-digest))
+  (%require-string :raw-evidence-ref (getf payload :raw-evidence-ref))
+  (%require-string :observed-at (getf payload :observed-at))
+  (%require-duration-ms (getf payload :duration-ms))
+  payload)
+
 (defun %key-part (value)
   (let ((string (princ-to-string value)))
     (format nil "~D:~A" (length string) string)))
@@ -81,6 +127,37 @@
    :payload output
    :provenance provenance))
 
+(defun make-http-exchange-record
+    (&key operation-id capture-session-id exchange-id method scheme host port path
+          response-status request-body-digest response-body-digest raw-evidence-ref
+          observed-at duration-ms provenance)
+  "Construct one immutable HTTP exchange evidence record for the operation graph."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-string :exchange-id exchange-id)
+  (%require-provenance provenance)
+  (let ((payload (list :method method
+                       :scheme scheme
+                       :host host
+                       :port port
+                       :path path
+                       :response-status response-status
+                       :request-body-digest request-body-digest
+                       :response-body-digest response-body-digest
+                       :raw-evidence-ref raw-evidence-ref
+                       :observed-at observed-at
+                       :duration-ms duration-ms)))
+    (%validate-http-exchange-payload payload)
+    (%make-execution-record
+     :kind :http-exchange
+     :operation-id operation-id
+     :run-id capture-session-id
+     :call-id exchange-id
+     :record-id (%record-id "http-exchange"
+                            operation-id capture-session-id exchange-id)
+     :payload payload
+     :provenance provenance)))
+
 (defun validate-tool-result-link (call result)
   (unless (eq :tool-call (execution-record-kind call))
     (error 'execution-graph-validation-error
@@ -121,8 +198,9 @@
          (call-id (getf props :call-id))
          (capability-id (getf props :capability-id))
          (status (getf props :status))
+         (payload (getf props :payload))
          (provenance (getf props :provenance)))
-    (unless (member kind '(:tool-call :tool-result) :test #'eq)
+    (unless (member kind '(:tool-call :tool-result :http-exchange) :test #'eq)
       (error 'execution-graph-validation-error
              :field :kind :value kind :reason "unsupported stored execution record kind"))
     (%require-string :operation-id operation-id)
@@ -136,6 +214,8 @@
                (not (member status '(:succeeded :failed :cancelled :timed-out) :test #'eq)))
       (error 'execution-graph-validation-error
              :field :status :value status :reason "unsupported stored tool result status"))
+    (when (eq kind :http-exchange)
+      (%validate-http-exchange-payload payload))
     (%make-execution-record
      :kind kind
      :operation-id operation-id
@@ -144,7 +224,7 @@
      :record-id (tek9:node-id node)
      :capability-id capability-id
      :status status
-     :payload (getf props :payload)
+     :payload payload
      :provenance provenance)))
 
 (defun tool-result-link-edge (call result)

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -8,7 +8,8 @@
                (:file "tests/replay-conflict")
                (:file "tests/kb-seed-import")
                (:file "tests/execution-outcome-kb")
-               (:file "tests/effective-operational-kb"))
+               (:file "tests/effective-operational-kb")
+               (:file "tests/http-exchange-graph"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
@@ -19,4 +20,6 @@
              (uiop:symbol-call :hackmode-database-execution-outcome-tests
                                :run-execution-outcome-kb-tests)
              (uiop:symbol-call :hackmode-database-tests
-                               :run-effective-operational-kb-tests)))
+                               :run-effective-operational-kb-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-http-exchange-graph-tests)))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -26,6 +26,7 @@
    #:execution-record-provenance
    #:make-tool-call-record
    #:make-tool-result-record
+   #:make-http-exchange-record
    #:validate-tool-result-link
    #:execution-graph-name
    #:execution-record->tek9-node

--- a/source/hackmode-database/tests/http-exchange-graph.lisp
+++ b/source/hackmode-database/tests/http-exchange-graph.lisp
@@ -1,0 +1,85 @@
+(in-package :hackmode-database-tests)
+
+(defun run-http-exchange-graph-tests ()
+  (let* ((first (hackmode-database:make-http-exchange-record
+                 :operation-id "op-http"
+                 :capture-session-id "capture-1"
+                 :exchange-id "exchange-1"
+                 :method "GET"
+                 :scheme "https"
+                 :host "example.com"
+                 :port 443
+                 :path "/login?next=%2F"
+                 :response-status 302
+                 :request-body-digest "sha256:req"
+                 :response-body-digest "sha256:resp"
+                 :raw-evidence-ref "capture-1:120-418"
+                 :observed-at "2026-08-30T18:55:00Z"
+                 :duration-ms 17
+                 :provenance '(:parser "ipx-http/1")))
+         (same (hackmode-database:make-http-exchange-record
+                :operation-id "op-http"
+                :capture-session-id "capture-1"
+                :exchange-id "exchange-1"
+                :method "GET"
+                :scheme "https"
+                :host "example.com"
+                :port 443
+                :path "/login?next=%2F"
+                :response-status 302
+                :request-body-digest "sha256:req"
+                :response-body-digest "sha256:resp"
+                :raw-evidence-ref "capture-1:120-418"
+                :observed-at "2026-08-30T18:55:00Z"
+                :duration-ms 17
+                :provenance '(:parser "ipx-http/1"))))
+    (ensure (eq :http-exchange (hackmode-database:execution-record-kind first))
+            "HTTP exchange has wrong execution kind")
+    (ensure (string= (hackmode-database:execution-record-record-id first)
+                     (hackmode-database:execution-record-record-id same))
+            "replaying the same HTTP exchange changed stable identity")
+    (ensure (string= "capture-1" (hackmode-database:execution-record-run-id first))
+            "capture session identity was not retained")
+    (ensure (string= "exchange-1" (hackmode-database:execution-record-call-id first))
+            "exchange correlation identity was not retained")
+    (let* ((path (merge-pathnames
+                  (format nil "hackmode-http-exchange-~D/" (random 1000000000))
+                  (uiop:temporary-directory)))
+           (database (tek9:new-database "hackmode-http-exchange-test" :path path)))
+      (unwind-protect
+           (progn
+             (tek9:open-database database)
+             (hackmode-database:persist-execution-record database first)
+             (hackmode-database:persist-execution-record database same)
+             (let ((records
+                     (hackmode-database:fetch-operation-execution-records
+                      database "op-http" :kind :http-exchange)))
+               (ensure (= 1 (length records))
+                       "HTTP exchange replay duplicated canonical graph evidence")
+               (ensure (equal (hackmode-database:execution-record-payload first)
+                              (hackmode-database:execution-record-payload
+                               (first records)))
+                       "HTTP exchange metadata changed during Tek9 round-trip")))
+        (when (tek9:db-is-open-p database)
+          (tek9:close-database database))
+        (when (probe-file path)
+          (uiop:delete-directory-tree path :validate t))))
+    (handler-case
+        (progn
+          (hackmode-database:make-http-exchange-record
+           :operation-id "op-http"
+           :capture-session-id "capture-1"
+           :exchange-id "bad-port"
+           :method "GET"
+           :scheme "https"
+           :host "example.com"
+           :port 70000
+           :path "/"
+           :response-status 200
+           :raw-evidence-ref "capture-1:0-10"
+           :observed-at "2026-08-30T18:55:00Z"
+           :duration-ms 1
+           :provenance '(:parser "ipx-http/1"))
+          (error "invalid HTTP port unexpectedly accepted"))
+      (hackmode-database:execution-graph-validation-error () t)))
+  t)


### PR DESCRIPTION
## Slice
Issue #26 database-owned prerequisite: add typed HTTP exchange evidence records to the canonical operation-scoped Tek9 execution graph.

## Contract
- deterministic operation / capture-session / exchange identity;
- typed `:http-exchange` execution records;
- replay-idempotent canonical persistence;
- bounded HTTP metadata plus digest/raw-evidence references and provenance;
- typed round-trip reads through the existing operation execution graph;
- fail-closed transport metadata validation.

## RED / GREEN
RED `0b1cde84cf1986588d8aea42a6a650327295e247`: core failed at the new database test; monorepo and agent-framework-boundary passed.

GREEN exact head `e29ad25cb3592ad52071f535ef5633423ecb5ccb`: core, monorepo, and agent-framework-boundary all passed.

This is the identical green head from draft #83; that PR was closed only because the connector ready-for-review mutation is broken. No proxy, parser actor, Hackpert reasoning, StarIntel product work, or second persistence authority is included.