### PR TITLE
Hackpert: project HTTP exchange evidence into passive snapshots

### DIFF
--- a/source/hackmode-core/expert/state-snapshot.lisp
+++ b/source/hackmode-core/expert/state-snapshot.lisp
@@ -14,19 +14,42 @@
                (*print-pretty* nil))
            (prin1 value stream))))))
 
+(defun expert-write-http-exchange-fact (stream record)
+  "Project one canonical HTTP exchange into bounded passive reasoning data."
+  (let ((payload (hack-db:execution-record-payload record)))
+    (write-expert-fact
+     stream
+     "http_exchange"
+     (hack-db:execution-record-record-id record)
+     (hack-db:execution-record-operation-id record)
+     (hack-db:execution-record-run-id record)
+     (hack-db:execution-record-call-id record)
+     (getf payload :method)
+     (getf payload :scheme)
+     (getf payload :host)
+     (getf payload :port)
+     (getf payload :path)
+     (getf payload :response-status)
+     (expert-data-string (getf payload :request-body-digest))
+     (expert-data-string (getf payload :response-body-digest))
+     (getf payload :observed-at)
+     (getf payload :duration-ms))))
+
 (defun expert-write-execution-record-fact (stream record)
-  (write-expert-fact
-   stream
-   "execution_record"
-   (hack-db:execution-record-record-id record)
-   (expert-data-string (hack-db:execution-record-kind record))
-   (hack-db:execution-record-operation-id record)
-   (hack-db:execution-record-run-id record)
-   (hack-db:execution-record-call-id record)
-   (expert-data-string (hack-db:execution-record-capability-id record))
-   (expert-data-string (hack-db:execution-record-status record))
-   (expert-data-string (hack-db:execution-record-payload record))
-   (expert-data-string (hack-db:execution-record-provenance record))))
+  (if (eq :http-exchange (hack-db:execution-record-kind record))
+      (expert-write-http-exchange-fact stream record)
+      (write-expert-fact
+       stream
+       "execution_record"
+       (hack-db:execution-record-record-id record)
+       (expert-data-string (hack-db:execution-record-kind record))
+       (hack-db:execution-record-operation-id record)
+       (hack-db:execution-record-run-id record)
+       (hack-db:execution-record-call-id record)
+       (expert-data-string (hack-db:execution-record-capability-id record))
+       (expert-data-string (hack-db:execution-record-status record))
+       (expert-data-string (hack-db:execution-record-payload record))
+       (expert-data-string (hack-db:execution-record-provenance record)))))
 
 (defun expert-write-operational-kb-entry-fact (stream entry)
   (write-expert-fact

--- a/source/hackmode-core/tests/expert-state-snapshot.lisp
+++ b/source/hackmode-core/tests/expert-state-snapshot.lisp
@@ -38,6 +38,56 @@
               "Execution facts must sort by stable record ID."))
     t))
 
+(defun run-expert-http-exchange-projection-test ()
+  (let* ((exchange
+           (hack-db:make-http-exchange-record
+            :operation-id "op-http"
+            :capture-session-id "capture-1"
+            :exchange-id "exchange-1"
+            :method "GET"
+            :scheme "https"
+            :host "example.test"
+            :port 443
+            :path "/login?next=%2F"
+            :response-status 302
+            :request-body-digest "sha256:req"
+            :response-body-digest "sha256:res"
+            :raw-evidence-ref "/private/captures/session.har#42"
+            :observed-at "2026-08-30T19:00:00Z"
+            :duration-ms 37
+            :provenance '(:source :capture-fixture)))
+         (snapshot
+           (hackmode:expert-snapshot
+            :operation nil :assets nil :providers nil
+            :execution-records (list exchange)
+            :operational-kb-entries nil)))
+    (assert (search "http_exchange(" snapshot)
+            ()
+            "HTTP evidence must have a typed passive snapshot fact.")
+    (dolist (expected '("\"op-http\""
+                        "\"capture-1\""
+                        "\"exchange-1\""
+                        "\"GET\""
+                        "\"https\""
+                        "\"example.test\""
+                        "443"
+                        "\"/login?next=%2F\""
+                        "302"
+                        "\"sha256:req\""
+                        "\"sha256:res\""
+                        "\"2026-08-30T19:00:00Z\""
+                        "37"))
+      (assert (search expected snapshot)
+              ()
+              "Typed HTTP exchange fact is missing ~S." expected))
+    (assert (not (search "/private/captures/session.har#42" snapshot))
+            ()
+            "Raw evidence references must not be copied into Prolog snapshots.")
+    (assert (not (search "execution_record(" snapshot))
+            ()
+            "HTTP exchanges must use their bounded typed projection instead of the generic payload fact.")
+    t))
+
 (defun run-expert-persisted-snapshot-refresh-test ()
   (let* ((path (merge-pathnames
                 (format nil "hackmode-expert-refresh-~D/" (random 1000000000))
@@ -119,5 +169,6 @@
 
 (defun run-expert-state-snapshot-tests ()
   (run-expert-state-projection-test)
+  (run-expert-http-exchange-projection-test)
   (run-expert-persisted-snapshot-refresh-test)
   t)


### PR DESCRIPTION
Issue #26 bounded Hackpert-owned slice over database #84.

Typed canonical HTTP exchange records project into a dedicated bounded `http_exchange(...)` Prolog fact carrying operation/capture/exchange identity and non-secret request/response metadata. Raw capture evidence references and generic payload/provenance serialization are excluded from the Prolog snapshot.

No database internals, provider execution, capture implementation, StarIntel product work, second scheduler, or mutation authority is touched.

RED head: `1dfcedf3c41173078d47cf4c58da87b7fb757552` — core failed specifically because the dedicated HTTP fact was absent; monorepo and agent-framework-boundary passed.
GREEN identical head: `750ea18f813909b53cef4ec3d89be13888b74923` — core, monorepo, and agent-framework-boundary passed.

This non-draft PR reuses the identical green head after the draft ready-for-review mutation failed due to GitHub connector `fullDatabaseId` GraphQL incompatibility.