### PR TITLE
Database: persist durable capture replay checkpoints

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -45,7 +45,8 @@
   (when run-id
     (%require-string :run-id run-id))
   (when (and kind
-             (not (member kind '(:tool-call :tool-result :http-exchange) :test #'eq)))
+             (not (member kind '(:tool-call :tool-result :http-exchange :capture-checkpoint)
+                          :test #'eq)))
     (error 'execution-graph-validation-error
            :field :kind :value kind :reason "unsupported execution record filter"))
   (let ((records
@@ -63,6 +64,26 @@
                               (eq kind (execution-record-kind record))))
                   collect record)))
     (sort records #'string< :key #'execution-record-record-id)))
+
+(defun fetch-latest-capture-checkpoint
+    (database operation-id capture-session-id source-id)
+  "Return the greatest durable checkpoint for one capture source, or NIL."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-string :source-id source-id)
+  (let ((latest nil)
+        (latest-offset nil))
+    (dolist (record
+             (fetch-operation-execution-records
+              database operation-id
+              :run-id capture-session-id
+              :kind :capture-checkpoint))
+      (when (string= source-id (execution-record-call-id record))
+        (let ((offset (getf (execution-record-payload record) :offset)))
+          (when (or (null latest-offset) (> offset latest-offset))
+            (setf latest record
+                  latest-offset offset)))))
+    latest))
 
 (defun persist-operational-kb-entry (database entry)
   "Persist one replay-safe operational KB assertion or retraction through Tek9."

--- a/source/hackmode-database/execution-graph.lisp
+++ b/source/hackmode-database/execution-graph.lisp
@@ -56,6 +56,13 @@
            :reason "expected non-negative integer milliseconds"))
   value)
 
+(defun %require-non-negative-integer (field value)
+  (unless (and (integerp value) (not (minusp value)))
+    (error 'execution-graph-validation-error
+           :field field :value value
+           :reason "expected non-negative integer"))
+  value)
+
 (defun %require-optional-string (field value)
   (when value
     (%require-string field value))
@@ -80,6 +87,16 @@
   (%require-string :raw-evidence-ref (getf payload :raw-evidence-ref))
   (%require-string :observed-at (getf payload :observed-at))
   (%require-duration-ms (getf payload :duration-ms))
+  payload)
+
+(defun %validate-capture-checkpoint-payload (payload)
+  (unless (listp payload)
+    (error 'execution-graph-validation-error
+           :field :payload :value payload
+           :reason "expected capture checkpoint property list"))
+  (%require-non-negative-integer :offset (getf payload :offset))
+  (%require-optional-string :last-record-id (getf payload :last-record-id))
+  (%require-string :framing-version (getf payload :framing-version))
   payload)
 
 (defun %key-part (value)
@@ -158,6 +175,28 @@
      :payload payload
      :provenance provenance)))
 
+(defun make-capture-checkpoint-record
+    (&key operation-id capture-session-id source-id offset last-record-id
+          framing-version provenance)
+  "Construct one immutable replay checkpoint in the operation execution graph."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-string :source-id source-id)
+  (%require-provenance provenance)
+  (let ((payload (list :offset offset
+                       :last-record-id last-record-id
+                       :framing-version framing-version)))
+    (%validate-capture-checkpoint-payload payload)
+    (%make-execution-record
+     :kind :capture-checkpoint
+     :operation-id operation-id
+     :run-id capture-session-id
+     :call-id source-id
+     :record-id (%record-id "capture-checkpoint"
+                            operation-id capture-session-id source-id offset)
+     :payload payload
+     :provenance provenance)))
+
 (defun validate-tool-result-link (call result)
   (unless (eq :tool-call (execution-record-kind call))
     (error 'execution-graph-validation-error
@@ -200,7 +239,8 @@
          (status (getf props :status))
          (payload (getf props :payload))
          (provenance (getf props :provenance)))
-    (unless (member kind '(:tool-call :tool-result :http-exchange) :test #'eq)
+    (unless (member kind '(:tool-call :tool-result :http-exchange :capture-checkpoint)
+                    :test #'eq)
       (error 'execution-graph-validation-error
              :field :kind :value kind :reason "unsupported stored execution record kind"))
     (%require-string :operation-id operation-id)
@@ -216,6 +256,8 @@
              :field :status :value status :reason "unsupported stored tool result status"))
     (when (eq kind :http-exchange)
       (%validate-http-exchange-payload payload))
+    (when (eq kind :capture-checkpoint)
+      (%validate-capture-checkpoint-payload payload))
     (%make-execution-record
      :kind kind
      :operation-id operation-id

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -9,7 +9,8 @@
                (:file "tests/kb-seed-import")
                (:file "tests/execution-outcome-kb")
                (:file "tests/effective-operational-kb")
-               (:file "tests/http-exchange-graph"))
+               (:file "tests/http-exchange-graph")
+               (:file "tests/capture-checkpoint"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
@@ -22,4 +23,6 @@
              (uiop:symbol-call :hackmode-database-tests
                                :run-effective-operational-kb-tests)
              (uiop:symbol-call :hackmode-database-tests
-                               :run-http-exchange-graph-tests)))
+                               :run-http-exchange-graph-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-capture-checkpoint-tests)))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -27,6 +27,7 @@
    #:make-tool-call-record
    #:make-tool-result-record
    #:make-http-exchange-record
+   #:make-capture-checkpoint-record
    #:validate-tool-result-link
    #:execution-graph-name
    #:execution-record->tek9-node
@@ -35,6 +36,7 @@
    #:persist-execution-record
    #:persist-tool-execution
    #:fetch-operation-execution-records
+   #:fetch-latest-capture-checkpoint
    #:operational-kb-validation-error
    #:operational-kb-entry
    #:operational-kb-entry-kind

--- a/source/hackmode-database/tests/capture-checkpoint.lisp
+++ b/source/hackmode-database/tests/capture-checkpoint.lisp
@@ -1,0 +1,93 @@
+(in-package :hackmode-database-tests)
+
+(defun run-capture-checkpoint-tests ()
+  (let* ((first (hackmode-database:make-capture-checkpoint-record
+                 :operation-id "op-capture"
+                 :capture-session-id "capture-1"
+                 :source-id "spool-a"
+                 :offset 128
+                 :last-record-id "exchange-1"
+                 :framing-version "ipx/1"
+                 :provenance '(:parser "ipx-http/1")))
+         (same (hackmode-database:make-capture-checkpoint-record
+                :operation-id "op-capture"
+                :capture-session-id "capture-1"
+                :source-id "spool-a"
+                :offset 128
+                :last-record-id "exchange-1"
+                :framing-version "ipx/1"
+                :provenance '(:parser "ipx-http/1")))
+         (later (hackmode-database:make-capture-checkpoint-record
+                 :operation-id "op-capture"
+                 :capture-session-id "capture-1"
+                 :source-id "spool-a"
+                 :offset 512
+                 :last-record-id "exchange-2"
+                 :framing-version "ipx/1"
+                 :provenance '(:parser "ipx-http/1"))))
+    (ensure (eq :capture-checkpoint
+                (hackmode-database:execution-record-kind first))
+            "capture checkpoint has wrong execution kind")
+    (ensure (string= "capture-1"
+                     (hackmode-database:execution-record-run-id first))
+            "capture session identity was not retained")
+    (ensure (string= "spool-a"
+                     (hackmode-database:execution-record-call-id first))
+            "capture source identity was not retained")
+    (ensure (string= (hackmode-database:execution-record-record-id first)
+                     (hackmode-database:execution-record-record-id same))
+            "identical checkpoint replay changed stable identity")
+    (let* ((path (merge-pathnames
+                  (format nil "hackmode-capture-checkpoint-~D/"
+                          (random 1000000000))
+                  (uiop:temporary-directory)))
+           (database (tek9:new-database "hackmode-capture-checkpoint-test"
+                                        :path path)))
+      (unwind-protect
+           (progn
+             (tek9:open-database database)
+             (hackmode-database:persist-execution-record database first)
+             (hackmode-database:persist-execution-record database same)
+             (hackmode-database:persist-execution-record database later)
+             (let ((checkpoint
+                     (hackmode-database:fetch-latest-capture-checkpoint
+                      database "op-capture" "capture-1" "spool-a")))
+               (ensure checkpoint "latest checkpoint was not found")
+               (ensure (= 512
+                          (getf (hackmode-database:execution-record-payload checkpoint)
+                                :offset))
+                       "latest checkpoint did not select greatest durable offset")
+               (ensure (string= "exchange-2"
+                                (getf (hackmode-database:execution-record-payload checkpoint)
+                                      :last-record-id))
+                       "latest checkpoint lost last-record evidence identity"))
+             (ensure (null (hackmode-database:fetch-latest-capture-checkpoint
+                            database "op-capture" "capture-1" "spool-missing"))
+                     "checkpoint lookup leaked across capture sources"))
+        (when (tek9:db-is-open-p database)
+          (tek9:close-database database))
+        (when (probe-file path)
+          (uiop:delete-directory-tree path :validate t))))
+    (handler-case
+        (progn
+          (hackmode-database:make-capture-checkpoint-record
+           :operation-id "op-capture"
+           :capture-session-id "capture-1"
+           :source-id "spool-a"
+           :offset -1
+           :framing-version "ipx/1"
+           :provenance '(:parser "ipx-http/1"))
+          (error "negative checkpoint offset unexpectedly accepted"))
+      (hackmode-database:execution-graph-validation-error () t))
+    (handler-case
+        (progn
+          (hackmode-database:make-capture-checkpoint-record
+           :operation-id "op-capture"
+           :capture-session-id "capture-1"
+           :source-id "spool-a"
+           :offset 128
+           :framing-version ""
+           :provenance '(:parser "ipx-http/1"))
+          (error "empty framing version unexpectedly accepted"))
+      (hackmode-database:execution-graph-validation-error () t)))
+  t)


### PR DESCRIPTION
Issue #26 database-owned replay prerequisite.

RED-first acceptance at head `2b8dc9164879a38b54c3b13b4a50116cac2fbf40`:
- capture checkpoints are typed execution-graph records scoped by operation + capture session + source;
- identical checkpoint construction preserves stable identity;
- canonical persistence replay is idempotent;
- latest checkpoint resolves deterministically to the greatest durable offset for one source;
- source isolation is enforced;
- negative offsets and invalid framing versions fail closed.

RED evidence: `common-lisp-core` failed on the intentionally missing checkpoint API while monorepo/boundary passed.

GREEN exact head `82b0a7ee38b89219cf241804ad1c809f9f18462e`: core, monorepo, and agent-framework-boundary all pass.

Implementation remains under the canonical Hackmode/Tek9 execution-graph boundary. No parser actor, proxy, Hackpert reasoning, StarIntel product work, second database, or shadow graph is included.