### PR TITLE
Hackpert: expose typed plan inspection state

### DIFF
--- a/source/hackmode-core/expert/inspection.lisp
+++ b/source/hackmode-core/expert/inspection.lisp
@@ -27,10 +27,88 @@ not accidentally treat a strategy transition as an authority change."
    :non-progress-count (expert-loop-state-non-progress-count state)
    :last-reason (expert-loop-state-last-reason state)))
 
+(defstruct (expert-plan-inspection-state
+             (:constructor %make-expert-plan-inspection-state
+                 (&key plan-id objective-id current-step-id
+                       raw-required-capabilities success-next failure-next
+                       terminal raw-stop-conditions)))
+  "Pure operator-facing snapshot of one instantiated expert plan."
+  (plan-id nil :read-only t)
+  (objective-id nil :read-only t)
+  (current-step-id nil :read-only t)
+  (raw-required-capabilities nil :read-only t)
+  (success-next nil :read-only t)
+  (failure-next nil :read-only t)
+  (terminal nil :read-only t)
+  (raw-stop-conditions nil :read-only t))
+
+(defun expert-plan-inspection (plan)
+  "Return a side-effect-free snapshot of PLAN's current operator-visible state.
+
+The snapshot exposes only plan structure already present in the canonical expert
+plan object. It does not advance the plan, dispatch providers, or mutate state."
+  (check-type plan expert-plan)
+  (let* ((step (expert-plan-current-step plan))
+         (capabilities
+           (sort (copy-list (expert-playbook-step-required-capabilities step))
+                 #'string<))
+         (stop-conditions
+           (sort
+            (mapcar #'expert-stop-condition-kind
+                    (expert-playbook-stop-conditions
+                     (expert-plan-playbook plan)))
+            #'string<
+            :key #'symbol-name)))
+    (%make-expert-plan-inspection-state
+     :plan-id (expert-plan-id plan)
+     :objective-id (expert-plan-objective-id plan)
+     :current-step-id (expert-playbook-step-id step)
+     :raw-required-capabilities capabilities
+     :success-next (expert-playbook-step-success-next step)
+     :failure-next (expert-playbook-step-failure-next step)
+     :terminal (expert-playbook-step-terminal step)
+     :raw-stop-conditions stop-conditions)))
+
+(defun expert-plan-inspection-plan-id (inspection)
+  (expert-plan-inspection-state-plan-id inspection))
+
+(defun expert-plan-inspection-objective-id (inspection)
+  (expert-plan-inspection-state-objective-id inspection))
+
+(defun expert-plan-inspection-current-step-id (inspection)
+  (expert-plan-inspection-state-current-step-id inspection))
+
+(defun expert-plan-inspection-required-capabilities (inspection)
+  "Return a defensive copy of current-step capability requirements."
+  (copy-list
+   (expert-plan-inspection-state-raw-required-capabilities inspection)))
+
+(defun expert-plan-inspection-success-next (inspection)
+  (expert-plan-inspection-state-success-next inspection))
+
+(defun expert-plan-inspection-failure-next (inspection)
+  (expert-plan-inspection-state-failure-next inspection))
+
+(defun expert-plan-inspection-terminal (inspection)
+  (expert-plan-inspection-state-terminal inspection))
+
+(defun expert-plan-inspection-stop-conditions (inspection)
+  "Return a defensive copy of deterministically ordered stop-condition kinds."
+  (copy-list (expert-plan-inspection-state-raw-stop-conditions inspection)))
+
 (export '(expert-run-inspection
           expert-run-inspection-operation
           expert-run-inspection-run-id
           expert-run-inspection-authority
           expert-run-inspection-strategy
           expert-run-inspection-non-progress-count
-          expert-run-inspection-last-reason))
+          expert-run-inspection-last-reason
+          expert-plan-inspection
+          expert-plan-inspection-plan-id
+          expert-plan-inspection-objective-id
+          expert-plan-inspection-current-step-id
+          expert-plan-inspection-required-capabilities
+          expert-plan-inspection-success-next
+          expert-plan-inspection-failure-next
+          expert-plan-inspection-terminal
+          expert-plan-inspection-stop-conditions))

--- a/source/hackmode-core/tests/expert-inspection.lisp
+++ b/source/hackmode-core/tests/expert-inspection.lisp
@@ -19,5 +19,64 @@
                   "inspection exposes stall count")
     (assert-equal :direct-non-progress
                   (hackmode:expert-run-inspection-last-reason status)
-                  "inspection exposes last reasoning reason")
-    t))
+                  "inspection exposes last reasoning reason"))
+  (let* ((scan
+           (hackmode:make-expert-playbook-step
+            :id "scan"
+            :required-capabilities '("http-probe" "subdomain-enumerate")
+            :success-next "done"
+            :failure-next "scan"))
+         (done
+           (hackmode:make-expert-playbook-step
+            :id "done" :terminal :succeeded))
+         (playbook
+           (hackmode:make-expert-playbook
+            :id "recon-plan"
+            :version "2"
+            :entry-step "scan"
+            :steps (list scan done)
+            :stop-conditions
+            (list
+             (hackmode:make-expert-stop-condition :kind :goal-satisfied)
+             (hackmode:make-expert-stop-condition :kind :budget-exhausted))))
+         (plan
+           (hackmode:instantiate-expert-plan
+            playbook
+            :id "plan-1"
+            :operation "op-1"
+            :run-id "run-1"
+            :objective-id "objective-1"))
+         (status (hackmode:expert-plan-inspection plan)))
+    (assert-equal "plan-1" (hackmode:expert-plan-inspection-plan-id status)
+                  "plan inspection retains plan identity")
+    (assert-equal "objective-1"
+                  (hackmode:expert-plan-inspection-objective-id status)
+                  "plan inspection retains objective identity")
+    (assert-equal "scan" (hackmode:expert-plan-inspection-current-step-id status)
+                  "plan inspection exposes current step")
+    (assert-equal '("http-probe" "subdomain-enumerate")
+                  (hackmode:expert-plan-inspection-required-capabilities status)
+                  "plan inspection exposes current step capabilities")
+    (assert-equal "done" (hackmode:expert-plan-inspection-success-next status)
+                  "plan inspection exposes success branch")
+    (assert-equal "scan" (hackmode:expert-plan-inspection-failure-next status)
+                  "plan inspection exposes failure branch")
+    (assert-equal nil (hackmode:expert-plan-inspection-terminal status)
+                  "plan inspection exposes terminal state")
+    (assert-equal '(:budget-exhausted :goal-satisfied)
+                  (hackmode:expert-plan-inspection-stop-conditions status)
+                  "plan inspection normalizes stop conditions deterministically")
+    (let ((capabilities
+            (hackmode:expert-plan-inspection-required-capabilities status))
+          (conditions
+            (hackmode:expert-plan-inspection-stop-conditions status)))
+      (setf (car capabilities) "tampered"
+            (car conditions) :tampered)
+      (assert-equal "http-probe"
+                    (first
+                     (hackmode:expert-plan-inspection-required-capabilities status))
+                    "plan inspection returns defensive capability copies")
+      (assert-equal :budget-exhausted
+                    (first (hackmode:expert-plan-inspection-stop-conditions status))
+                    "plan inspection returns defensive stop-condition copies")))
+  t)


### PR DESCRIPTION
Issue #27 bounded Hackpert-owned operator-inspection slice.

Adds side-effect-free typed plan inspection alongside run inspection: plan/objective identity, current step, required capabilities, success/failure branches, terminal state, and deterministically normalized stop conditions. Returned list-valued fields are defensive copies.

RED head: `8ba7df814811a158c0b1d4459d83469748800c95` — core failed against the missing plan-inspection API; monorepo and agent-framework-boundary passed.
GREEN head: `b69cc5603d1a31d07f2048fe1763aa63e75e49c8` — core, monorepo, and agent-framework-boundary all pass exact-head.

No provider execution, canonical mutation, database internals, second scheduler, or StarIntel product work.