### PR TITLE
Database: quarantine malformed capture evidence

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -45,7 +45,8 @@
   (when run-id
     (%require-string :run-id run-id))
   (when (and kind
-             (not (member kind '(:tool-call :tool-result :http-exchange :capture-checkpoint)
+             (not (member kind '(:tool-call :tool-result :http-exchange
+                                  :capture-checkpoint :capture-quarantine)
                           :test #'eq)))
     (error 'execution-graph-validation-error
            :field :kind :value kind :reason "unsupported execution record filter"))
@@ -84,6 +85,24 @@
             (setf latest record
                   latest-offset offset)))))
     latest))
+
+(defun fetch-capture-quarantine-records
+    (database operation-id capture-session-id source-id)
+  "Return quarantined capture evidence for one source in durable offset order."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-string :source-id source-id)
+  (sort
+   (remove-if-not
+    (lambda (record)
+      (string= source-id (execution-record-call-id record)))
+    (fetch-operation-execution-records
+     database operation-id
+     :run-id capture-session-id
+     :kind :capture-quarantine))
+   #'<
+   :key (lambda (record)
+          (getf (execution-record-payload record) :offset))))
 
 (defun persist-operational-kb-entry (database entry)
   "Persist one replay-safe operational KB assertion or retraction through Tek9."

--- a/source/hackmode-database/execution-graph.lisp
+++ b/source/hackmode-database/execution-graph.lisp
@@ -99,6 +99,18 @@
   (%require-string :framing-version (getf payload :framing-version))
   payload)
 
+(defun %validate-capture-quarantine-payload (payload)
+  (unless (listp payload)
+    (error 'execution-graph-validation-error
+           :field :payload :value payload
+           :reason "expected capture quarantine property list"))
+  (%require-non-negative-integer :offset (getf payload :offset))
+  (%require-non-negative-integer :length (getf payload :length))
+  (%require-string :reason (getf payload :reason))
+  (%require-string :raw-evidence-ref (getf payload :raw-evidence-ref))
+  (%require-string :framing-version (getf payload :framing-version))
+  payload)
+
 (defun %key-part (value)
   (let ((string (princ-to-string value)))
     (format nil "~D:~A" (length string) string)))
@@ -197,6 +209,30 @@
      :payload payload
      :provenance provenance)))
 
+(defun make-capture-quarantine-record
+    (&key operation-id capture-session-id source-id offset length reason
+          raw-evidence-ref framing-version provenance)
+  "Construct immutable evidence for one malformed or truncated capture frame."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-string :source-id source-id)
+  (%require-provenance provenance)
+  (let ((payload (list :offset offset
+                       :length length
+                       :reason reason
+                       :raw-evidence-ref raw-evidence-ref
+                       :framing-version framing-version)))
+    (%validate-capture-quarantine-payload payload)
+    (%make-execution-record
+     :kind :capture-quarantine
+     :operation-id operation-id
+     :run-id capture-session-id
+     :call-id source-id
+     :record-id (%record-id "capture-quarantine"
+                            operation-id capture-session-id source-id offset)
+     :payload payload
+     :provenance provenance)))
+
 (defun validate-tool-result-link (call result)
   (unless (eq :tool-call (execution-record-kind call))
     (error 'execution-graph-validation-error
@@ -239,7 +275,8 @@
          (status (getf props :status))
          (payload (getf props :payload))
          (provenance (getf props :provenance)))
-    (unless (member kind '(:tool-call :tool-result :http-exchange :capture-checkpoint)
+    (unless (member kind '(:tool-call :tool-result :http-exchange
+                           :capture-checkpoint :capture-quarantine)
                     :test #'eq)
       (error 'execution-graph-validation-error
              :field :kind :value kind :reason "unsupported stored execution record kind"))
@@ -258,6 +295,8 @@
       (%validate-http-exchange-payload payload))
     (when (eq kind :capture-checkpoint)
       (%validate-capture-checkpoint-payload payload))
+    (when (eq kind :capture-quarantine)
+      (%validate-capture-quarantine-payload payload))
     (%make-execution-record
      :kind kind
      :operation-id operation-id

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -10,7 +10,8 @@
                (:file "tests/execution-outcome-kb")
                (:file "tests/effective-operational-kb")
                (:file "tests/http-exchange-graph")
-               (:file "tests/capture-checkpoint"))
+               (:file "tests/capture-checkpoint")
+               (:file "tests/capture-quarantine"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
@@ -25,4 +26,6 @@
              (uiop:symbol-call :hackmode-database-tests
                                :run-http-exchange-graph-tests)
              (uiop:symbol-call :hackmode-database-tests
-                               :run-capture-checkpoint-tests)))
+                               :run-capture-checkpoint-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-capture-quarantine-tests)))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -28,6 +28,7 @@
    #:make-tool-result-record
    #:make-http-exchange-record
    #:make-capture-checkpoint-record
+   #:make-capture-quarantine-record
    #:validate-tool-result-link
    #:execution-graph-name
    #:execution-record->tek9-node
@@ -37,6 +38,7 @@
    #:persist-tool-execution
    #:fetch-operation-execution-records
    #:fetch-latest-capture-checkpoint
+   #:fetch-capture-quarantine-records
    #:operational-kb-validation-error
    #:operational-kb-entry
    #:operational-kb-entry-kind

--- a/source/hackmode-database/tests/capture-quarantine.lisp
+++ b/source/hackmode-database/tests/capture-quarantine.lisp
@@ -1,0 +1,65 @@
+(in-package :hackmode-database-tests)
+
+(defun run-capture-quarantine-tests ()
+  (let* ((record (hackmode-database:make-capture-quarantine-record
+                  :operation-id "op-capture"
+                  :capture-session-id "capture-1"
+                  :source-id "spool-a"
+                  :offset 256
+                  :length 48
+                  :reason "truncated-frame"
+                  :raw-evidence-ref "spool-a#256+48"
+                  :framing-version "ipx/1"
+                  :provenance '(:parser "ipx-http/1")))
+         (same (hackmode-database:make-capture-quarantine-record
+                :operation-id "op-capture"
+                :capture-session-id "capture-1"
+                :source-id "spool-a"
+                :offset 256
+                :length 48
+                :reason "truncated-frame"
+                :raw-evidence-ref "spool-a#256+48"
+                :framing-version "ipx/1"
+                :provenance '(:parser "ipx-http/1"))))
+    (ensure (eq :capture-quarantine
+                (hackmode-database:execution-record-kind record))
+            "capture quarantine has wrong execution kind")
+    (ensure (string= (hackmode-database:execution-record-record-id record)
+                     (hackmode-database:execution-record-record-id same))
+            "identical quarantine replay changed stable identity")
+    (let* ((path (merge-pathnames
+                  (format nil "hackmode-capture-quarantine-~D/" (random 1000000000))
+                  (uiop:temporary-directory)))
+           (database (tek9:new-database "hackmode-capture-quarantine-test" :path path)))
+      (unwind-protect
+           (progn
+             (tek9:open-database database)
+             (hackmode-database:persist-execution-record database record)
+             (hackmode-database:persist-execution-record database same)
+             (let ((records (hackmode-database:fetch-capture-quarantine-records
+                             database "op-capture" "capture-1" "spool-a")))
+               (ensure (= 1 (length records)) "quarantine replay duplicated evidence")
+               (ensure (= 256 (getf (hackmode-database:execution-record-payload
+                                      (first records)) :offset))
+                       "quarantine offset was not retained")))
+        (when (tek9:db-is-open-p database) (tek9:close-database database))
+        (when (probe-file path) (uiop:delete-directory-tree path :validate t))))
+    (handler-case
+        (progn
+          (hackmode-database:make-capture-quarantine-record
+           :operation-id "op-capture" :capture-session-id "capture-1"
+           :source-id "spool-a" :offset -1 :length 1 :reason "corrupt"
+           :raw-evidence-ref "ref" :framing-version "ipx/1"
+           :provenance '(:parser "ipx-http/1"))
+          (error "negative quarantine offset unexpectedly accepted"))
+      (hackmode-database:execution-graph-validation-error () t))
+    (handler-case
+        (progn
+          (hackmode-database:make-capture-quarantine-record
+           :operation-id "op-capture" :capture-session-id "capture-1"
+           :source-id "spool-a" :offset 1 :length 0 :reason ""
+           :raw-evidence-ref "ref" :framing-version "ipx/1"
+           :provenance '(:parser "ipx-http/1"))
+          (error "empty quarantine reason unexpectedly accepted"))
+      (hackmode-database:execution-graph-validation-error () t)))
+  t)


### PR DESCRIPTION
Forward-reconciles the database/execution-graph slice for #26 onto current master after sibling Hackpert #92 advanced the base. Adds typed operation-scoped quarantine evidence for malformed/truncated capture frames so parser/tailer work can fail closed while retaining inspectable provenance. The five-file database delta is unchanged in behavior from the previously green #90 head; no parser actor, Hackpert policy, proxy, StarIntel product work, or second persistence authority.