### PR TITLE
Hackpert: expose bounded action inspection state

### DIFF
--- a/source/hackmode-core/expert/inspection.lisp
+++ b/source/hackmode-core/expert/inspection.lisp
@@ -13,10 +13,7 @@
   (last-reason nil :read-only t))
 
 (defun expert-run-inspection (engine state)
-  "Return a side-effect-free inspection snapshot for ENGINE and loop STATE.
-
-Authority and reasoning strategy remain separate fields so shell/UI clients do
-not accidentally treat a strategy transition as an authority change."
+  "Return a side-effect-free inspection snapshot for ENGINE and loop STATE."
   (check-type engine expert-engine)
   (check-type state expert-loop-state)
   (%make-expert-run-inspection
@@ -32,7 +29,6 @@ not accidentally treat a strategy transition as an authority change."
                  (&key plan-id objective-id current-step-id
                        raw-required-capabilities success-next failure-next
                        terminal raw-stop-conditions)))
-  "Pure operator-facing snapshot of one instantiated expert plan."
   (plan-id nil :read-only t)
   (objective-id nil :read-only t)
   (current-step-id nil :read-only t)
@@ -43,10 +39,7 @@ not accidentally treat a strategy transition as an authority change."
   (raw-stop-conditions nil :read-only t))
 
 (defun expert-plan-inspection (plan)
-  "Return a side-effect-free snapshot of PLAN's current operator-visible state.
-
-The snapshot exposes only plan structure already present in the canonical expert
-plan object. It does not advance the plan, dispatch providers, or mutate state."
+  "Return a side-effect-free snapshot of PLAN's current operator-visible state."
   (check-type plan expert-plan)
   (let* ((step (expert-plan-current-step plan))
          (capabilities
@@ -57,8 +50,7 @@ plan object. It does not advance the plan, dispatch providers, or mutate state."
             (mapcar #'expert-stop-condition-kind
                     (expert-playbook-stop-conditions
                      (expert-plan-playbook plan)))
-            #'string<
-            :key #'symbol-name)))
+            #'string< :key #'symbol-name)))
     (%make-expert-plan-inspection-state
      :plan-id (expert-plan-id plan)
      :objective-id (expert-plan-objective-id plan)
@@ -71,44 +63,93 @@ plan object. It does not advance the plan, dispatch providers, or mutate state."
 
 (defun expert-plan-inspection-plan-id (inspection)
   (expert-plan-inspection-state-plan-id inspection))
-
 (defun expert-plan-inspection-objective-id (inspection)
   (expert-plan-inspection-state-objective-id inspection))
-
 (defun expert-plan-inspection-current-step-id (inspection)
   (expert-plan-inspection-state-current-step-id inspection))
-
 (defun expert-plan-inspection-required-capabilities (inspection)
-  "Return a defensive copy of current-step capability requirements."
-  (copy-list
-   (expert-plan-inspection-state-raw-required-capabilities inspection)))
-
+  (copy-list (expert-plan-inspection-state-raw-required-capabilities inspection)))
 (defun expert-plan-inspection-success-next (inspection)
   (expert-plan-inspection-state-success-next inspection))
-
 (defun expert-plan-inspection-failure-next (inspection)
   (expert-plan-inspection-state-failure-next inspection))
-
 (defun expert-plan-inspection-terminal (inspection)
   (expert-plan-inspection-state-terminal inspection))
-
 (defun expert-plan-inspection-stop-conditions (inspection)
-  "Return a defensive copy of deterministically ordered stop-condition kinds."
   (copy-list (expert-plan-inspection-state-raw-stop-conditions inspection)))
 
+(defstruct (expert-action-inspection-state
+             (:constructor %make-expert-action-inspection-state
+                 (&key id kind effect-kind operation run-id expert-id expert-version
+                       raw-evidence-ids raw-summary)))
+  (id nil :read-only t)
+  (kind nil :read-only t)
+  (effect-kind nil :read-only t)
+  (operation nil :read-only t)
+  (run-id nil :read-only t)
+  (expert-id nil :read-only t)
+  (expert-version nil :read-only t)
+  (raw-evidence-ids nil :read-only t)
+  (raw-summary nil :read-only t))
+
+(defun expert-action-inspection-payload-summary (action)
+  (let ((payload (expert-active-action-payload action)))
+    (case (expert-active-action-kind action)
+      (:dispatch
+       (list :capability (expert-dispatch-payload-capability payload)
+             :provider (expert-dispatch-payload-provider payload)))
+      (:graph-delta
+       (list :node-count (length (expert-graph-delta-payload-nodes payload))
+             :edge-count (length (expert-graph-delta-payload-edges payload))))
+      (:discover (list :asset-type (type-of (expert-discover-payload-asset payload))))
+      (:operational-kb-delta
+       (list :assertion-count (length (expert-kb-delta-payload-assertions payload))
+             :retraction-count (length (expert-kb-delta-payload-retractions payload))))
+      (:plan-transition
+       (list :plan-id (expert-plan-transition-payload-plan-id payload)
+             :step-id (expert-plan-transition-payload-step-id payload)
+             :transition (expert-plan-transition-payload-transition payload)))
+      (:control
+       (list :directive (expert-control-payload-directive payload)
+             :reason (expert-control-payload-reason payload))))))
+
+(defun expert-action-inspection (action)
+  "Return bounded metadata for ACTION without exposing raw effect payloads."
+  (check-type action expert-active-action)
+  (%make-expert-action-inspection-state
+   :id (expert-active-action-id action)
+   :kind (expert-active-action-kind action)
+   :effect-kind (expert-active-action-effect-kind action)
+   :operation (expert-active-action-operation action)
+   :run-id (expert-active-action-run-id action)
+   :expert-id (expert-active-action-expert-id action)
+   :expert-version (expert-active-action-expert-version action)
+   :raw-evidence-ids (sort (copy-list (expert-active-action-evidence-ids action)) #'string<)
+   :raw-summary (expert-action-inspection-payload-summary action)))
+
+(defun expert-action-inspection-id (x) (expert-action-inspection-state-id x))
+(defun expert-action-inspection-kind (x) (expert-action-inspection-state-kind x))
+(defun expert-action-inspection-effect-kind (x) (expert-action-inspection-state-effect-kind x))
+(defun expert-action-inspection-operation (x) (expert-action-inspection-state-operation x))
+(defun expert-action-inspection-run-id (x) (expert-action-inspection-state-run-id x))
+(defun expert-action-inspection-expert-id (x) (expert-action-inspection-state-expert-id x))
+(defun expert-action-inspection-expert-version (x) (expert-action-inspection-state-expert-version x))
+(defun expert-action-inspection-evidence-ids (x)
+  (copy-list (expert-action-inspection-state-raw-evidence-ids x)))
+(defun expert-action-inspection-summary (x)
+  (copy-tree (expert-action-inspection-state-raw-summary x)))
+
 (export '(expert-run-inspection
-          expert-run-inspection-operation
-          expert-run-inspection-run-id
-          expert-run-inspection-authority
-          expert-run-inspection-strategy
-          expert-run-inspection-non-progress-count
-          expert-run-inspection-last-reason
-          expert-plan-inspection
-          expert-plan-inspection-plan-id
-          expert-plan-inspection-objective-id
-          expert-plan-inspection-current-step-id
-          expert-plan-inspection-required-capabilities
-          expert-plan-inspection-success-next
-          expert-plan-inspection-failure-next
-          expert-plan-inspection-terminal
-          expert-plan-inspection-stop-conditions))
+          expert-run-inspection-operation expert-run-inspection-run-id
+          expert-run-inspection-authority expert-run-inspection-strategy
+          expert-run-inspection-non-progress-count expert-run-inspection-last-reason
+          expert-plan-inspection expert-plan-inspection-plan-id
+          expert-plan-inspection-objective-id expert-plan-inspection-current-step-id
+          expert-plan-inspection-required-capabilities expert-plan-inspection-success-next
+          expert-plan-inspection-failure-next expert-plan-inspection-terminal
+          expert-plan-inspection-stop-conditions
+          expert-action-inspection expert-action-inspection-id
+          expert-action-inspection-kind expert-action-inspection-effect-kind
+          expert-action-inspection-operation expert-action-inspection-run-id
+          expert-action-inspection-expert-id expert-action-inspection-expert-version
+          expert-action-inspection-evidence-ids expert-action-inspection-summary))

--- a/source/hackmode-core/tests/expert-inspection.lisp
+++ b/source/hackmode-core/tests/expert-inspection.lisp
@@ -79,4 +79,50 @@
       (assert-equal :budget-exhausted
                     (first (hackmode:expert-plan-inspection-stop-conditions status))
                     "plan inspection returns defensive stop-condition copies")))
+  (let* ((action
+           (hackmode:make-expert-active-action
+            :id "dispatch-1"
+            :kind :dispatch
+            :operation "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "3"
+            :evidence-ids '("evidence-2" "evidence-1")
+            :payload
+            (hackmode:make-expert-dispatch-payload
+             :capability "http-probe"
+             :provider "curl"
+             :input "https://secret.example/token=do-not-expose")))
+         (status (hackmode:expert-action-inspection action)))
+    (assert-equal "dispatch-1" (hackmode:expert-action-inspection-id status)
+                  "action inspection retains action identity")
+    (assert-equal :dispatch (hackmode:expert-action-inspection-kind status)
+                  "action inspection exposes typed action kind")
+    (assert-equal :provider-dispatch
+                  (hackmode:expert-action-inspection-effect-kind status)
+                  "action inspection exposes required effect class")
+    (assert-equal "op-1" (hackmode:expert-action-inspection-operation status)
+                  "action inspection retains operation scope")
+    (assert-equal "run-1" (hackmode:expert-action-inspection-run-id status)
+                  "action inspection retains run scope")
+    (assert-equal "recon" (hackmode:expert-action-inspection-expert-id status)
+                  "action inspection retains expert provenance")
+    (assert-equal "3" (hackmode:expert-action-inspection-expert-version status)
+                  "action inspection retains expert version")
+    (assert-equal '("evidence-1" "evidence-2")
+                  (hackmode:expert-action-inspection-evidence-ids status)
+                  "action inspection normalizes evidence identity")
+    (assert-equal '(:capability "http-probe" :provider "curl")
+                  (hackmode:expert-action-inspection-summary status)
+                  "dispatch inspection exposes bounded metadata only")
+    (assert-equal nil
+                  (search "do-not-expose"
+                          (prin1-to-string
+                           (hackmode:expert-action-inspection-summary status)))
+                  "dispatch inspection never exposes provider input")
+    (let ((evidence (hackmode:expert-action-inspection-evidence-ids status)))
+      (setf (car evidence) "tampered")
+      (assert-equal "evidence-1"
+                    (first (hackmode:expert-action-inspection-evidence-ids status))
+                    "action inspection returns defensive evidence copies")))
   t)


### PR DESCRIPTION
Issue #27 bounded Hackpert-owned operator-inspection slice.

RED `c681f7dbc8309ca1a0c42f231ab32e79564f4e08` specifies side-effect-free action inspection for typed active actions. The inspection surface exposes action/effect kind, operation/run scope, expert/version provenance, normalized evidence IDs, and bounded payload metadata. Dispatch inputs and graph/KB payload contents are deliberately excluded so the operator surface does not become a raw-evidence or secret exfiltration path.

Implementation head `98b06522f343ec5da63398789f778114e4883cd9` touches only Hackpert inspection code/tests. No provider execution, canonical mutation, database internals, second scheduler, or StarIntel product work.