### PR TITLE
Database: persist capture source rotation lineage

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -46,7 +46,8 @@
     (%require-string :run-id run-id))
   (when (and kind
              (not (member kind '(:tool-call :tool-result :http-exchange
-                                  :capture-checkpoint :capture-quarantine)
+                                  :capture-checkpoint :capture-quarantine
+                                  :capture-source-rotation)
                           :test #'eq)))
     (error 'execution-graph-validation-error
            :field :kind :value kind :reason "unsupported execution record filter"))
@@ -103,6 +104,20 @@
    #'<
    :key (lambda (record)
           (getf (execution-record-payload record) :offset))))
+
+(defun fetch-capture-source-rotations
+    (database operation-id capture-session-id)
+  "Return typed source-rotation lineage in predecessor durable-offset order."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (sort
+   (fetch-operation-execution-records
+    database operation-id
+    :run-id capture-session-id
+    :kind :capture-source-rotation)
+   #'<
+   :key (lambda (record)
+          (getf (execution-record-payload record) :previous-final-offset))))
 
 (defun persist-operational-kb-entry (database entry)
   "Persist one replay-safe operational KB assertion or retraction through Tek9."

--- a/source/hackmode-database/execution-graph.lisp
+++ b/source/hackmode-database/execution-graph.lisp
@@ -111,6 +111,24 @@
   (%require-string :framing-version (getf payload :framing-version))
   payload)
 
+(defun %validate-capture-source-rotation-payload (payload)
+  (unless (listp payload)
+    (error 'execution-graph-validation-error
+           :field :payload :value payload
+           :reason "expected capture source rotation property list"))
+  (let ((previous-source-id
+          (%require-string :previous-source-id (getf payload :previous-source-id)))
+        (next-source-id
+          (%require-string :next-source-id (getf payload :next-source-id))))
+    (when (string= previous-source-id next-source-id)
+      (error 'execution-graph-validation-error
+             :field :next-source-id :value next-source-id
+             :reason "capture rotation successor must differ from predecessor")))
+  (%require-non-negative-integer
+   :previous-final-offset (getf payload :previous-final-offset))
+  (%require-string :framing-version (getf payload :framing-version))
+  payload)
+
 (defun %key-part (value)
   (let ((string (princ-to-string value)))
     (format nil "~D:~A" (length string) string)))
@@ -233,6 +251,29 @@
      :payload payload
      :provenance provenance)))
 
+(defun make-capture-source-rotation-record
+    (&key operation-id capture-session-id previous-source-id next-source-id
+          previous-final-offset framing-version provenance)
+  "Construct immutable lineage for one capture source rotation."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-provenance provenance)
+  (let ((payload (list :previous-source-id previous-source-id
+                       :next-source-id next-source-id
+                       :previous-final-offset previous-final-offset
+                       :framing-version framing-version)))
+    (%validate-capture-source-rotation-payload payload)
+    (%make-execution-record
+     :kind :capture-source-rotation
+     :operation-id operation-id
+     :run-id capture-session-id
+     :call-id next-source-id
+     :record-id (%record-id "capture-source-rotation"
+                            operation-id capture-session-id
+                            previous-source-id next-source-id)
+     :payload payload
+     :provenance provenance)))
+
 (defun validate-tool-result-link (call result)
   (unless (eq :tool-call (execution-record-kind call))
     (error 'execution-graph-validation-error
@@ -276,7 +317,8 @@
          (payload (getf props :payload))
          (provenance (getf props :provenance)))
     (unless (member kind '(:tool-call :tool-result :http-exchange
-                           :capture-checkpoint :capture-quarantine)
+                           :capture-checkpoint :capture-quarantine
+                           :capture-source-rotation)
                     :test #'eq)
       (error 'execution-graph-validation-error
              :field :kind :value kind :reason "unsupported stored execution record kind"))
@@ -297,6 +339,8 @@
       (%validate-capture-checkpoint-payload payload))
     (when (eq kind :capture-quarantine)
       (%validate-capture-quarantine-payload payload))
+    (when (eq kind :capture-source-rotation)
+      (%validate-capture-source-rotation-payload payload))
     (%make-execution-record
      :kind kind
      :operation-id operation-id

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -11,7 +11,8 @@
                (:file "tests/effective-operational-kb")
                (:file "tests/http-exchange-graph")
                (:file "tests/capture-checkpoint")
-               (:file "tests/capture-quarantine"))
+               (:file "tests/capture-quarantine")
+               (:file "tests/capture-source-rotation"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
@@ -28,4 +29,6 @@
              (uiop:symbol-call :hackmode-database-tests
                                :run-capture-checkpoint-tests)
              (uiop:symbol-call :hackmode-database-tests
-                               :run-capture-quarantine-tests)))
+                               :run-capture-quarantine-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-capture-source-rotation-tests)))

--- a/source/hackmode-database/package.lisp
+++ b/source/hackmode-database/package.lisp
@@ -29,6 +29,7 @@
    #:make-http-exchange-record
    #:make-capture-checkpoint-record
    #:make-capture-quarantine-record
+   #:make-capture-source-rotation-record
    #:validate-tool-result-link
    #:execution-graph-name
    #:execution-record->tek9-node
@@ -39,6 +40,7 @@
    #:fetch-operation-execution-records
    #:fetch-latest-capture-checkpoint
    #:fetch-capture-quarantine-records
+   #:fetch-capture-source-rotations
    #:operational-kb-validation-error
    #:operational-kb-entry
    #:operational-kb-entry-kind

--- a/source/hackmode-database/tests/capture-source-rotation.lisp
+++ b/source/hackmode-database/tests/capture-source-rotation.lisp
@@ -1,0 +1,119 @@
+(in-package :hackmode-database-tests)
+
+(defun run-capture-source-rotation-tests ()
+  (let* ((first
+           (make-capture-source-rotation-record
+            :operation-id "op-rotation"
+            :capture-session-id "capture-1"
+            :previous-source-id "capture.log"
+            :next-source-id "capture.log.1"
+            :previous-final-offset 4096
+            :framing-version "ipx/1"
+            :provenance '(:parser "fixture" :version "1")))
+         (same
+           (make-capture-source-rotation-record
+            :operation-id "op-rotation"
+            :capture-session-id "capture-1"
+            :previous-source-id "capture.log"
+            :next-source-id "capture.log.1"
+            :previous-final-offset 4096
+            :framing-version "ipx/1"
+            :provenance '(:parser "fixture" :version "1"))))
+    (ensure (eq :capture-source-rotation (execution-record-kind first))
+            "capture source rotation has wrong execution kind")
+    (ensure (string= "capture-1" (execution-record-run-id first))
+            "capture source rotation lost capture-session identity")
+    (ensure (string= "capture.log.1" (execution-record-call-id first))
+            "capture source rotation lost successor source identity")
+    (ensure (string= (execution-record-record-id first)
+                     (execution-record-record-id same))
+            "identical capture source rotation replay changed identity")
+    (ensure (equal '(:previous-source-id "capture.log"
+                     :next-source-id "capture.log.1"
+                     :previous-final-offset 4096
+                     :framing-version "ipx/1")
+                   (execution-record-payload first))
+            "capture source rotation payload drifted")
+    (let ((roundtrip
+            (tek9-node->execution-record
+             (execution-record->tek9-node first))))
+      (ensure (eq :capture-source-rotation (execution-record-kind roundtrip))
+              "capture source rotation round-trip lost kind")
+      (ensure (equal (execution-record-payload first)
+                     (execution-record-payload roundtrip))
+              "capture source rotation round-trip lost lineage payload"))
+    (handler-case
+        (progn
+          (make-capture-source-rotation-record
+           :operation-id "op-rotation"
+           :capture-session-id "capture-1"
+           :previous-source-id "capture.log"
+           :next-source-id "capture.log"
+           :previous-final-offset 4096
+           :framing-version "ipx/1"
+           :provenance '(:parser "fixture"))
+          (error "self-rotation unexpectedly accepted"))
+      (execution-graph-validation-error () t)))
+
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-capture-rotation-~D/"
+                        (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-capture-rotation-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let ((rotation-a
+                   (make-capture-source-rotation-record
+                    :operation-id "op-rotation"
+                    :capture-session-id "capture-1"
+                    :previous-source-id "capture.log"
+                    :next-source-id "capture.log.1"
+                    :previous-final-offset 4096
+                    :framing-version "ipx/1"
+                    :provenance '(:parser "fixture")))
+                 (rotation-b
+                   (make-capture-source-rotation-record
+                    :operation-id "op-rotation"
+                    :capture-session-id "capture-1"
+                    :previous-source-id "capture.log.1"
+                    :next-source-id "capture.log.2"
+                    :previous-final-offset 8192
+                    :framing-version "ipx/1"
+                    :provenance '(:parser "fixture")))
+                 (foreign
+                   (make-capture-source-rotation-record
+                    :operation-id "op-other"
+                    :capture-session-id "capture-1"
+                    :previous-source-id "other.log"
+                    :next-source-id "other.log.1"
+                    :previous-final-offset 1024
+                    :framing-version "ipx/1"
+                    :provenance '(:parser "fixture"))))
+             (persist-execution-record database rotation-b)
+             (persist-execution-record database rotation-a)
+             (persist-execution-record database rotation-a)
+             (persist-execution-record database foreign)
+             (let ((rotations
+                     (fetch-capture-source-rotations
+                      database "op-rotation" "capture-1")))
+               (ensure (= 2 (length rotations))
+                       "capture source rotation replay duplicated lineage")
+               (ensure (equal '(4096 8192)
+                              (mapcar
+                               (lambda (record)
+                                 (getf (execution-record-payload record)
+                                       :previous-final-offset))
+                               rotations))
+                       "capture source rotations are not returned in durable offset order")
+               (ensure (every
+                        (lambda (record)
+                          (string= "op-rotation"
+                                   (execution-record-operation-id record)))
+                        rotations)
+                       "capture source rotation query leaked another operation"))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)


### PR DESCRIPTION
## Slice
Issue #26 database-owned persistence slice: preserve capture-source rotation lineage inside the existing operation-scoped execution graph.

## RED contract
The regression requires a typed immutable rotation record carrying capture session, predecessor/successor source identity, predecessor final durable offset, framing version, and provenance. Identical replay must keep stable identity, self-rotation must fail closed, reads must stay operation/capture scoped, and returned lineage must be durable-offset ordered.

This PR is intentionally opened with the regression wired before implementation so exact-head CI can prove RED first.

## Boundary
No parser/proxy implementation, Hackpert behavior, provider execution, StarIntel product work, shadow graph, second KB, or second database.