### PR TITLE
Hackpert: expose typed action admission inspection

### DIFF
--- a/source/hackmode-core/expert/inspection.lisp
+++ b/source/hackmode-core/expert/inspection.lisp
@@ -139,6 +139,60 @@
 (defun expert-action-inspection-summary (x)
   (copy-tree (expert-action-inspection-state-raw-summary x)))
 
+(defstruct (expert-action-admission-inspection-state
+             (:constructor %make-expert-action-admission-inspection-state
+                 (&key status action rejection-kind reason denied-effect)))
+  "Pure operator-facing result of validating one typed active action."
+  (status nil :read-only t)
+  (action nil :read-only t)
+  (rejection-kind nil :read-only t)
+  (reason nil :read-only t)
+  (denied-effect nil :read-only t))
+
+(defun expert-action-admission-inspection (engine action &key operation run-id)
+  "Inspect action admission without executing or mutating anything.
+
+Accepted actions return :ACCEPTED. Expected validation failures return
+:REJECTED with a bounded rejection class. The nested action inspection retains
+only the already-redacted metadata surface and never includes raw provider,
+graph, or KB payload contents. Unexpected conditions still propagate."
+  (check-type engine expert-engine)
+  (check-type action expert-active-action)
+  (let ((inspection (expert-action-inspection action)))
+    (handler-case
+        (progn
+          (validate-expert-active-action engine action
+                                         :operation operation
+                                         :run-id run-id)
+          (%make-expert-action-admission-inspection-state
+           :status :accepted
+           :action inspection))
+      (expert-effect-denied (condition)
+        (%make-expert-action-admission-inspection-state
+         :status :rejected
+         :action inspection
+         :rejection-kind :effect-denied
+         :reason "effect denied by expert authority"
+         :denied-effect (expert-effect-denied-effect condition)))
+      (invalid-expert-action (condition)
+        (%make-expert-action-admission-inspection-state
+         :status :rejected
+         :action inspection
+         :rejection-kind :invalid-action
+         :reason (invalid-expert-action-reason condition))))))
+
+(defun expert-action-admission-inspection-status (inspection)
+  (expert-action-admission-inspection-state-status inspection))
+(defun expert-action-admission-inspection-action (inspection)
+  (expert-action-admission-inspection-state-action inspection))
+(defun expert-action-admission-inspection-rejection-kind (inspection)
+  (expert-action-admission-inspection-state-rejection-kind inspection))
+(defun expert-action-admission-inspection-reason (inspection)
+  (let ((reason (expert-action-admission-inspection-state-reason inspection)))
+    (and reason (copy-seq reason))))
+(defun expert-action-admission-inspection-denied-effect (inspection)
+  (expert-action-admission-inspection-state-denied-effect inspection))
+
 (export '(expert-run-inspection
           expert-run-inspection-operation expert-run-inspection-run-id
           expert-run-inspection-authority expert-run-inspection-strategy
@@ -152,4 +206,10 @@
           expert-action-inspection-kind expert-action-inspection-effect-kind
           expert-action-inspection-operation expert-action-inspection-run-id
           expert-action-inspection-expert-id expert-action-inspection-expert-version
-          expert-action-inspection-evidence-ids expert-action-inspection-summary))
+          expert-action-inspection-evidence-ids expert-action-inspection-summary
+          expert-action-admission-inspection
+          expert-action-admission-inspection-status
+          expert-action-admission-inspection-action
+          expert-action-admission-inspection-rejection-kind
+          expert-action-admission-inspection-reason
+          expert-action-admission-inspection-denied-effect))

--- a/source/hackmode-core/tests/expert-inspection.lisp
+++ b/source/hackmode-core/tests/expert-inspection.lisp
@@ -125,4 +125,60 @@
       (assert-equal "evidence-1"
                     (first (hackmode:expert-action-inspection-evidence-ids status))
                     "action inspection returns defensive evidence copies")))
+  (let* ((active (hackmode:make-expert-engine :mode :active))
+         (passive (hackmode:make-expert-engine :mode :passive))
+         (action
+           (hackmode:make-expert-active-action
+            :id "dispatch-admission-1"
+            :kind :dispatch
+            :operation "op-1"
+            :run-id "run-1"
+            :expert-id "recon"
+            :expert-version "3"
+            :evidence-ids '("evidence-1")
+            :payload
+            (hackmode:make-expert-dispatch-payload
+             :capability "http-probe"
+             :provider "curl"
+             :input "https://secret.example/token=admission-do-not-expose")))
+         (accepted
+           (hackmode:expert-action-admission-inspection
+            active action :operation "op-1" :run-id "run-1"))
+         (denied
+           (hackmode:expert-action-admission-inspection
+            passive action :operation "op-1" :run-id "run-1"))
+         (stale
+           (hackmode:expert-action-admission-inspection
+            active action :operation "other-op" :run-id "run-1")))
+    (assert-equal :accepted
+                  (hackmode:expert-action-admission-inspection-status accepted)
+                  "matching active action is inspectably accepted")
+    (assert-equal nil
+                  (hackmode:expert-action-admission-inspection-rejection-kind accepted)
+                  "accepted action has no rejection class")
+    (assert-equal :rejected
+                  (hackmode:expert-action-admission-inspection-status denied)
+                  "passive dispatch is inspectably rejected")
+    (assert-equal :effect-denied
+                  (hackmode:expert-action-admission-inspection-rejection-kind denied)
+                  "authority rejection is typed")
+    (assert-equal :provider-dispatch
+                  (hackmode:expert-action-admission-inspection-denied-effect denied)
+                  "authority rejection exposes only the denied effect class")
+    (assert-equal :rejected
+                  (hackmode:expert-action-admission-inspection-status stale)
+                  "cross-operation action is inspectably rejected")
+    (assert-equal :invalid-action
+                  (hackmode:expert-action-admission-inspection-rejection-kind stale)
+                  "scope rejection is typed")
+    (assert-equal t
+                  (not (null
+                        (search "does not match expected"
+                                (hackmode:expert-action-admission-inspection-reason stale))))
+                  "scope rejection retains a useful bounded reason")
+    (dolist (inspection (list accepted denied stale))
+      (assert-equal nil
+                    (search "admission-do-not-expose"
+                            (prin1-to-string inspection))
+                    "admission inspection never exposes provider input")))
   t)


### PR DESCRIPTION
Issue #27 bounded Hackpert-owned inspection slice.

RED-first contract: operator-facing inspection must distinguish accepted vs rejected active-action admission without executing providers or mutating canonical state. Rejections are typed as authority denial or invalid action/scope, expose only bounded effect/reason metadata, and must not leak raw provider input.

This intentionally extends the existing side-effect-free inspection surface only. No database internals, provider execution, second scheduler, raw Tek9 access, or StarIntel product work.

RED head: `4970d9710d2a51e05bf6eb7404fd0a6a341ed415`