### PR TITLE
Core: repair find-apis arity regression

### DIFF
--- a/source/hackmode-core/functions.lisp
+++ b/source/hackmode-core/functions.lisp
@@ -53,4 +53,6 @@
 (defun find-apis (url-objects &optional (common-api-urls *api-common-patterns*))
   "find api urls in a list of url-objects based on the given pattern.
    adds 'api' tag to each url-object if it matches the pattern."
-  (mapcar (lambda (url-object) (find-api pattern url-object common-api-urls)) url-objects))
+  (mapcar (lambda (url-object)
+            (find-api url-object common-api-urls))
+          url-objects))

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -3,6 +3,7 @@
   :depends-on (#:hackmode #:hackmode-database)
   :serial t
   :components ((:file "tests/core-state")
+               (:file "tests/functions")
                (:file "tests/expert")
                (:file "tests/expert-orchestration")
                (:file "tests/expert-state-snapshot")
@@ -17,6 +18,7 @@
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
+             (uiop:symbol-call :hackmode-tests :run-functions-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-orchestration-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-state-snapshot-tests)

--- a/source/hackmode-core/tests/functions.lisp
+++ b/source/hackmode-core/tests/functions.lisp
@@ -1,0 +1,16 @@
+(in-package :hackmode-tests)
+
+(defun run-find-apis-test ()
+  (let* ((api (hackmode:parse-url "https://example.test/api/v1/users"))
+         (plain (hackmode:parse-url "https://example.test/about"))
+         (matches (hackmode:find-apis (list api plain) '("/api/"))))
+    (assert-equal (list api nil) matches "API classification results")
+    (assert (member "api" (hackmode:doc-tags api) :test #'string=) ()
+            "Matching URL must receive the api tag.")
+    (assert (not (member "api" (hackmode:doc-tags plain) :test #'string=)) ()
+            "Non-matching URL must not receive the api tag.")))
+
+(defun run-functions-tests ()
+  (run-find-apis-test)
+  (format t "Hackmode function tests passed.~%")
+  t)


### PR DESCRIPTION
## Bug-first blocker
Exact-head core CI for #101 exposed an existing clean-compile regression in `functions.lisp`: `find-apis` calls `find-api` with three arguments even though `find-api` accepts a URL object plus one optional pattern list. The same call also references an unbound `pattern` variable.

## RED
Focused collection regression proves `find-apis` classifies each URL using the caller-supplied pattern set while leaving non-matches untagged. Pre-fix exact-head core failed during clean compilation on the invalid `find-api` call.

## GREEN candidate
Head `3c96ed3eb04b2be1485ba8d3928976d3d4364db5` passed core, monorepo, and agent-framework-boundary as draft #102. This non-draft PR reuses the identical head because GitHub's ready-for-review mutation failed on the connector `fullDatabaseId` schema bug.

## Boundary
Minimal core correctness repair only. No database internals, provider/effect widening, expert authority changes, scheduler changes, or StarIntel product work.