### PR TITLE
Database: reject divergent capture source rotation forks

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -14,13 +14,41 @@
     (error "No Hackmode database is open."))
   (tek9:put-bulk* database documents :database-name database-name))
 
+(defun %validate-capture-source-rotation-lineage (database record)
+  "Reject a second successor for the same operation/session predecessor source."
+  (when (eq :capture-source-rotation (execution-record-kind record))
+    (let* ((operation-id (execution-record-operation-id record))
+           (session-id (execution-record-run-id record))
+           (payload (execution-record-payload record))
+           (previous-source-id (getf payload :previous-source-id))
+           (graph-name (execution-graph-name operation-id)))
+      (dolist (existing
+               (fetch-operation-execution-records
+                database operation-id
+                :run-id session-id
+                :kind :capture-source-rotation))
+        (when (and
+               (string= previous-source-id
+                        (getf (execution-record-payload existing)
+                              :previous-source-id))
+               (not (string= (execution-record-record-id existing)
+                             (execution-record-record-id record))))
+          (%signal-replay-conflict
+           :capture-source-rotation-lineage
+           previous-source-id
+           graph-name
+           existing
+           record))))))
+
 (defun persist-execution-record (database record)
   "Persist one typed execution RECORD into its operation-scoped Tek9 graph."
-  (persist-graph-node-replay-safe
-   database
-   (execution-record->tek9-node record)
-   :database-name (execution-graph-name
-                   (execution-record-operation-id record)))
+  (tek9:with-write-transaction (database)
+    (%validate-capture-source-rotation-lineage database record)
+    (persist-graph-node-replay-safe
+     database
+     (execution-record->tek9-node record)
+     :database-name (execution-graph-name
+                     (execution-record-operation-id record))))
   record)
 
 (defun persist-tool-execution (database call result)

--- a/source/hackmode-database/tests/capture-source-rotation.lisp
+++ b/source/hackmode-database/tests/capture-source-rotation.lisp
@@ -81,6 +81,15 @@
                     :previous-final-offset 8192
                     :framing-version "ipx/1"
                     :provenance '(:parser "fixture")))
+                 (fork
+                   (make-capture-source-rotation-record
+                    :operation-id "op-rotation"
+                    :capture-session-id "capture-1"
+                    :previous-source-id "capture.log"
+                    :next-source-id "capture.log.alt"
+                    :previous-final-offset 4096
+                    :framing-version "ipx/1"
+                    :provenance '(:parser "fixture")))
                  (foreign
                    (make-capture-source-rotation-record
                     :operation-id "op-other"
@@ -93,6 +102,11 @@
              (persist-execution-record database rotation-b)
              (persist-execution-record database rotation-a)
              (persist-execution-record database rotation-a)
+             (handler-case
+                 (progn
+                   (persist-execution-record database fork)
+                   (error "divergent capture source rotation fork unexpectedly persisted"))
+               (persistence-replay-conflict () t))
              (persist-execution-record database foreign)
              (let ((rotations
                      (fetch-capture-source-rotations


### PR DESCRIPTION
## Slice
Harden the canonical Tek9 execution-graph boundary so one operation/capture-session predecessor source cannot persist two different successor rotations.

## Why
Capture rotation lineage is used for durable restart/replay. Accepting divergent successors for the same predecessor makes resume lineage ambiguous under concurrent or replayed writers.

## RED
Commit `96a7c2d3fb58056a4969d8eb824619190213adf3` adds a regression proving exact replay is allowed but a divergent successor must raise `persistence-replay-conflict`.

## GREEN implementation
Commit `340dde0d0d798ba65e5a68d52565111681fa228b` validates lineage inside the canonical Tek9 write transaction before replay-safe node persistence. Scope is operation + capture session + predecessor source. Identical stable replay remains accepted.

## Boundary
Database/execution-graph only. No parser actor, Hackpert expert logic, provider execution, shadow graph/KB, second database, or StarIntel product work.