### PR TITLE
Hackpert: expose loop strategy transition inspection

### DIFF
--- a/source/hackmode-core/expert/transition-inspection.lisp
+++ b/source/hackmode-core/expert/transition-inspection.lisp
@@ -1,0 +1,123 @@
+(in-package :hackmode)
+
+(defstruct (expert-loop-transition-inspection-state
+             (:constructor %make-expert-loop-transition-inspection-state
+                 (&key raw-operation raw-run-id kind reason
+                       from-strategy to-strategy
+                       from-non-progress-count to-non-progress-count)))
+  "Bounded operator-facing snapshot of one reasoning-strategy transition."
+  (raw-operation nil :read-only t)
+  (raw-run-id nil :read-only t)
+  (kind nil :read-only t)
+  (reason nil :read-only t)
+  (from-strategy nil :read-only t)
+  (to-strategy nil :read-only t)
+  (from-non-progress-count 0 :read-only t)
+  (to-non-progress-count 0 :read-only t))
+
+(defun validate-expert-loop-transition-inspection (before decision after)
+  (unless (string= (expert-loop-state-operation before)
+                   (expert-loop-state-operation after))
+    (reject-expert-loop
+     after
+     "transition operation ~s does not match previous operation ~s"
+     (expert-loop-state-operation after)
+     (expert-loop-state-operation before)))
+  (unless (string= (expert-loop-state-run-id before)
+                   (expert-loop-state-run-id after))
+    (reject-expert-loop
+     after
+     "transition run ~s does not match previous run ~s"
+     (expert-loop-state-run-id after)
+     (expert-loop-state-run-id before)))
+  (unless (member (expert-loop-decision-kind decision)
+                  +expert-loop-decision-kinds+)
+    (reject-expert-loop decision
+                        "unsupported loop decision kind ~s"
+                        (expert-loop-decision-kind decision)))
+  (unless (eq (expert-loop-decision-strategy decision)
+              (expert-loop-state-strategy after))
+    (reject-expert-loop
+     after
+     "decision strategy ~s does not match next-state strategy ~s"
+     (expert-loop-decision-strategy decision)
+     (expert-loop-state-strategy after)))
+  (unless (equal (expert-loop-decision-reason decision)
+                 (expert-loop-state-last-reason after))
+    (reject-expert-loop
+     after
+     "decision reason ~s does not match next-state reason ~s"
+     (expert-loop-decision-reason decision)
+     (expert-loop-state-last-reason after)))
+  (let ((from (expert-loop-state-strategy before))
+        (to (expert-loop-state-strategy after)))
+    (ecase (expert-loop-decision-kind decision)
+      (:continue
+       (unless (eq from to)
+         (reject-expert-loop decision
+                             "continue decision cannot change strategy")))
+      (:stop
+       (unless (eq from to)
+         (reject-expert-loop decision
+                             "stop decision cannot change strategy")))
+      (:escalate
+       (unless (and (eq from :symbolic) (eq to :direct))
+         (reject-expert-loop decision
+                             "escalation must transition symbolic to direct")))
+      (:resume-symbolic
+       (unless (and (eq from :direct) (eq to :symbolic))
+         (reject-expert-loop decision
+                             "resume must transition direct to symbolic")))))
+  t)
+
+(defun expert-loop-transition-inspection (before decision after)
+  "Return a pure bounded snapshot of one validated loop strategy transition."
+  (check-type before expert-loop-state)
+  (check-type decision expert-loop-decision)
+  (check-type after expert-loop-state)
+  (validate-expert-loop-transition-inspection before decision after)
+  (%make-expert-loop-transition-inspection-state
+   :raw-operation (copy-seq (expert-loop-state-operation before))
+   :raw-run-id (copy-seq (expert-loop-state-run-id before))
+   :kind (expert-loop-decision-kind decision)
+   :reason (expert-loop-decision-reason decision)
+   :from-strategy (expert-loop-state-strategy before)
+   :to-strategy (expert-loop-state-strategy after)
+   :from-non-progress-count (expert-loop-state-non-progress-count before)
+   :to-non-progress-count (expert-loop-state-non-progress-count after)))
+
+(defun expert-loop-transition-inspection-operation (inspection)
+  (copy-seq
+   (expert-loop-transition-inspection-state-raw-operation inspection)))
+
+(defun expert-loop-transition-inspection-run-id (inspection)
+  (copy-seq
+   (expert-loop-transition-inspection-state-raw-run-id inspection)))
+
+(defun expert-loop-transition-inspection-kind (inspection)
+  (expert-loop-transition-inspection-state-kind inspection))
+
+(defun expert-loop-transition-inspection-reason (inspection)
+  (expert-loop-transition-inspection-state-reason inspection))
+
+(defun expert-loop-transition-inspection-from-strategy (inspection)
+  (expert-loop-transition-inspection-state-from-strategy inspection))
+
+(defun expert-loop-transition-inspection-to-strategy (inspection)
+  (expert-loop-transition-inspection-state-to-strategy inspection))
+
+(defun expert-loop-transition-inspection-from-non-progress-count (inspection)
+  (expert-loop-transition-inspection-state-from-non-progress-count inspection))
+
+(defun expert-loop-transition-inspection-to-non-progress-count (inspection)
+  (expert-loop-transition-inspection-state-to-non-progress-count inspection))
+
+(export '(expert-loop-transition-inspection
+          expert-loop-transition-inspection-operation
+          expert-loop-transition-inspection-run-id
+          expert-loop-transition-inspection-kind
+          expert-loop-transition-inspection-reason
+          expert-loop-transition-inspection-from-strategy
+          expert-loop-transition-inspection-to-strategy
+          expert-loop-transition-inspection-from-non-progress-count
+          expert-loop-transition-inspection-to-non-progress-count))

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -15,6 +15,7 @@
                (:file "tests/expert-selection")
                (:file "tests/expert-budget")
                (:file "tests/expert-inspection")
+               (:file "tests/expert-transition-inspection")
                (:file "tests/expert-selection-inspection"))
   :perform (test-op (op system)
              (declare (ignore op system))
@@ -31,4 +32,5 @@
              (uiop:symbol-call :hackmode-tests :run-expert-selection-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-budget-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-inspection-tests)
+             (uiop:symbol-call :hackmode-tests :run-expert-transition-inspection-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-selection-inspection-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -47,6 +47,7 @@
                              (:file "budget")
                              (:file "budget-loop")
                              (:file "inspection")
+                             (:file "transition-inspection")
                              (:file "selection-inspection")))
                (:file "functions")
                (:file "exploits")

--- a/source/hackmode-core/tests/expert-transition-inspection.lisp
+++ b/source/hackmode-core/tests/expert-transition-inspection.lisp
@@ -1,0 +1,108 @@
+(in-package :hackmode-tests)
+
+(defun run-expert-transition-inspection-tests ()
+  (let* ((before
+           (hackmode:make-expert-loop-state
+            :operation "op-1"
+            :run-id "run-1"
+            :strategy :symbolic
+            :non-progress-count 1
+            :last-reason :symbolic-non-progress))
+         (decision
+           (hackmode:make-expert-loop-decision
+            :kind :escalate
+            :reason :symbolic-stall
+            :strategy :direct))
+         (after
+           (hackmode:make-expert-loop-state
+            :operation "op-1"
+            :run-id "run-1"
+            :strategy :direct
+            :non-progress-count 2
+            :last-reason :symbolic-stall))
+         (inspection
+           (hackmode:expert-loop-transition-inspection before decision after)))
+    (assert-equal "op-1"
+                  (hackmode:expert-loop-transition-inspection-operation inspection)
+                  "transition inspection retains operation scope")
+    (assert-equal "run-1"
+                  (hackmode:expert-loop-transition-inspection-run-id inspection)
+                  "transition inspection retains run scope")
+    (assert-equal :escalate
+                  (hackmode:expert-loop-transition-inspection-kind inspection)
+                  "transition inspection exposes the loop decision")
+    (assert-equal :symbolic-stall
+                  (hackmode:expert-loop-transition-inspection-reason inspection)
+                  "transition inspection exposes the decision reason")
+    (assert-equal :symbolic
+                  (hackmode:expert-loop-transition-inspection-from-strategy inspection)
+                  "transition inspection exposes the previous strategy")
+    (assert-equal :direct
+                  (hackmode:expert-loop-transition-inspection-to-strategy inspection)
+                  "transition inspection exposes the next strategy")
+    (assert-equal 1
+                  (hackmode:expert-loop-transition-inspection-from-non-progress-count
+                   inspection)
+                  "transition inspection exposes previous stall count")
+    (assert-equal 2
+                  (hackmode:expert-loop-transition-inspection-to-non-progress-count
+                   inspection)
+                  "transition inspection exposes next stall count")
+    (let ((operation
+            (hackmode:expert-loop-transition-inspection-operation inspection))
+          (run-id
+            (hackmode:expert-loop-transition-inspection-run-id inspection)))
+      (setf (char operation 0) #\X
+            (char run-id 0) #\X)
+      (assert-equal "op-1"
+                    (hackmode:expert-loop-transition-inspection-operation inspection)
+                    "transition inspection returns a defensive operation copy")
+      (assert-equal "run-1"
+                    (hackmode:expert-loop-transition-inspection-run-id inspection)
+                    "transition inspection returns a defensive run-id copy")))
+  (let* ((before
+           (hackmode:make-expert-loop-state
+            :operation "op-1" :run-id "run-1" :strategy :direct))
+         (decision
+           (hackmode:make-expert-loop-decision
+            :kind :resume-symbolic :reason :direct-progress :strategy :symbolic))
+         (after
+           (hackmode:make-expert-loop-state
+            :operation "op-1" :run-id "run-1" :strategy :symbolic
+            :last-reason :direct-progress))
+         (inspection
+           (hackmode:expert-loop-transition-inspection before decision after)))
+    (assert-equal :resume-symbolic
+                  (hackmode:expert-loop-transition-inspection-kind inspection)
+                  "direct progress is inspectable as a return to symbolic")
+    (assert-equal :direct
+                  (hackmode:expert-loop-transition-inspection-from-strategy inspection)
+                  "resume transition starts in direct strategy")
+    (assert-equal :symbolic
+                  (hackmode:expert-loop-transition-inspection-to-strategy inspection)
+                  "resume transition returns to symbolic strategy"))
+  (let* ((before
+           (hackmode:make-expert-loop-state
+            :operation "op-1" :run-id "run-1" :strategy :symbolic))
+         (decision
+           (hackmode:make-expert-loop-decision
+            :kind :escalate :reason :symbolic-stall :strategy :direct))
+         (wrong-scope
+           (hackmode:make-expert-loop-state
+            :operation "other-op" :run-id "run-1" :strategy :direct
+            :last-reason :symbolic-stall))
+         (wrong-strategy
+           (hackmode:make-expert-loop-state
+            :operation "op-1" :run-id "run-1" :strategy :symbolic
+            :last-reason :symbolic-stall)))
+    (assert-signals 'hackmode:invalid-expert-loop
+                    (lambda ()
+                      (hackmode:expert-loop-transition-inspection
+                       before decision wrong-scope))
+                    "transition inspection rejects cross-operation state")
+    (assert-signals 'hackmode:invalid-expert-loop
+                    (lambda ()
+                      (hackmode:expert-loop-transition-inspection
+                       before decision wrong-strategy))
+                    "transition inspection rejects decision/state disagreement"))
+  t)

--- a/source/hackmode-core/tests/expert-transition-inspection.lisp
+++ b/source/hackmode-core/tests/expert-transition-inspection.lisp
@@ -9,7 +9,7 @@
             :non-progress-count 1
             :last-reason :symbolic-non-progress))
          (decision
-           (hackmode:make-expert-loop-decision
+           (hackmode::make-expert-loop-decision
             :kind :escalate
             :reason :symbolic-stall
             :strategy :direct))
@@ -64,7 +64,7 @@
            (hackmode:make-expert-loop-state
             :operation "op-1" :run-id "run-1" :strategy :direct))
          (decision
-           (hackmode:make-expert-loop-decision
+           (hackmode::make-expert-loop-decision
             :kind :resume-symbolic :reason :direct-progress :strategy :symbolic))
          (after
            (hackmode:make-expert-loop-state
@@ -85,7 +85,7 @@
            (hackmode:make-expert-loop-state
             :operation "op-1" :run-id "run-1" :strategy :symbolic))
          (decision
-           (hackmode:make-expert-loop-decision
+           (hackmode::make-expert-loop-decision
             :kind :escalate :reason :symbolic-stall :strategy :direct))
          (wrong-scope
            (hackmode:make-expert-loop-state

--- a/source/hackmode-core/tests/expert-transition-inspection.lisp
+++ b/source/hackmode-core/tests/expert-transition-inspection.lisp
@@ -1,5 +1,10 @@
 (in-package :hackmode-tests)
 
+(defun expert-transition-signals-invalid-p (thunk)
+  (handler-case
+      (progn (funcall thunk) nil)
+    (hackmode:invalid-expert-loop () t)))
+
 (defun run-expert-transition-inspection-tests ()
   (let* ((before
            (hackmode:make-expert-loop-state
@@ -41,12 +46,10 @@
                   (hackmode:expert-loop-transition-inspection-to-strategy inspection)
                   "transition inspection exposes the next strategy")
     (assert-equal 1
-                  (hackmode:expert-loop-transition-inspection-from-non-progress-count
-                   inspection)
+                  (hackmode:expert-loop-transition-inspection-from-non-progress-count inspection)
                   "transition inspection exposes previous stall count")
     (assert-equal 2
-                  (hackmode:expert-loop-transition-inspection-to-non-progress-count
-                   inspection)
+                  (hackmode:expert-loop-transition-inspection-to-non-progress-count inspection)
                   "transition inspection exposes next stall count")
     (let ((operation
             (hackmode:expert-loop-transition-inspection-operation inspection))
@@ -95,14 +98,16 @@
            (hackmode:make-expert-loop-state
             :operation "op-1" :run-id "run-1" :strategy :symbolic
             :last-reason :symbolic-stall)))
-    (assert-signals 'hackmode:invalid-expert-loop
-                    (lambda ()
-                      (hackmode:expert-loop-transition-inspection
-                       before decision wrong-scope))
-                    "transition inspection rejects cross-operation state")
-    (assert-signals 'hackmode:invalid-expert-loop
-                    (lambda ()
-                      (hackmode:expert-loop-transition-inspection
-                       before decision wrong-strategy))
-                    "transition inspection rejects decision/state disagreement"))
+    (assert-equal t
+                  (expert-transition-signals-invalid-p
+                   (lambda ()
+                     (hackmode:expert-loop-transition-inspection
+                      before decision wrong-scope)))
+                  "transition inspection rejects cross-operation state")
+    (assert-equal t
+                  (expert-transition-signals-invalid-p
+                   (lambda ()
+                     (hackmode:expert-loop-transition-inspection
+                      before decision wrong-strategy)))
+                  "transition inspection rejects decision/state disagreement"))
   t)


### PR DESCRIPTION
## Slice
#29 / #27 Hackpert-owned operator inspection: expose one bounded, side-effect-free transition record for symbolic/direct loop decisions so LISH/UI consumers can explain `symbolic -> direct -> symbolic` without inferring it from mutable controller state.

## RED contract
The regression requires operation/run scope, decision kind/reason, previous/next reasoning strategy, and previous/next non-progress counts. It also requires defensive string copies and fail-closed rejection when the before/after scope or decision/next-state strategy disagree.

This draft intentionally wires the regression before implementation.

## Boundary
Inspection only. No provider execution, canonical mutation, persistence/database internals, model executor, second scheduler, raw Prolog execution, or StarIntel product work.