### PR TITLE
database: require live canonical source for long-term promotion

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -213,10 +213,54 @@
             (push entry entries)))))
     (sort entries #'string< :key #'operational-kb-entry-record-id)))
 
+(defun %validate-long-term-kb-promotion-source (database promotion)
+  "Require PROMOTION to reference the exact live canonical operational assertion."
+  (let* ((operation-id
+           (long-term-kb-promotion-source-operation-id promotion))
+         (source-id
+           (long-term-kb-promotion-source-assertion-id promotion))
+         (graph-name (operational-kb-graph-name operation-id))
+         (node (tek9:fetch-node database source-id :database-name graph-name)))
+    (unless node
+      (error 'long-term-kb-validation-error
+             :field :source-assertion-id
+             :value source-id
+             :reason "source assertion is not persisted in canonical operational KB"))
+    (let ((source (tek9-node->operational-kb-entry node)))
+      (unless
+          (and (eq :assert (operational-kb-entry-kind source))
+               (string= operation-id
+                        (operational-kb-entry-operation-id source))
+               (string= (long-term-kb-promotion-source-run-id promotion)
+                        (operational-kb-entry-run-id source))
+               (string= (long-term-kb-promotion-source-expert-id promotion)
+                        (operational-kb-entry-expert-id source))
+               (string= (long-term-kb-promotion-source-expert-version promotion)
+                        (operational-kb-entry-expert-version source))
+               (equal (long-term-kb-promotion-source-evidence-ids promotion)
+                      (operational-kb-entry-evidence-ids source))
+               (equal (long-term-kb-promotion-key promotion)
+                      (operational-kb-entry-key source))
+               (equal (long-term-kb-promotion-value promotion)
+                      (operational-kb-entry-value source)))
+        (error 'long-term-kb-validation-error
+               :field :source-assertion-id
+               :value source-id
+               :reason "promotion source does not match canonical operational assertion")))
+    (when (find source-id
+                (fetch-operational-kb-entries database operation-id :kind :retract)
+                :key #'operational-kb-entry-target-assertion-id
+                :test #'string=)
+      (error 'long-term-kb-validation-error
+             :field :source-assertion-id
+             :value source-id
+             :reason "source assertion is retracted"))))
+
 (defun persist-long-term-kb-promotion (database promotion)
   "Persist one immutable evidence-backed promotion through canonical Tek9 graph APIs."
   (let ((graph-name (long-term-kb-graph-name)))
     (tek9:with-write-transaction (database)
+      (%validate-long-term-kb-promotion-source database promotion)
       (persist-graph-nodes-replay-safe
        database
        (list (long-term-kb-root-node)

--- a/source/hackmode-database/tests/long-term-kb.lisp
+++ b/source/hackmode-database/tests/long-term-kb.lisp
@@ -81,6 +81,70 @@
           (error "retraction unexpectedly promoted into long-term KB"))
       (long-term-kb-validation-error () t)))
   (let* ((path (merge-pathnames
+                (format nil "hackmode-long-term-live-source-~D/"
+                        (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-long-term-live-source-test"
+                                      :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((source
+                    (make-operational-kb-assertion
+                     :assertion-id "a-live"
+                     :operation-id "op-live"
+                     :run-id "run-1"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key '(:service "https")
+                     :value '(:port 443)
+                     :evidence-ids '("result-live")
+                     :provenance '(:source "fixture")))
+                  (promotion
+                    (make-long-term-kb-promotion
+                     :promotion-id "p-live"
+                     :source-assertion source
+                     :promoted-by "operator"
+                     :promoter-version "1"
+                     :evidence-ids '("review-live")
+                     :provenance '(:reason "validated"))))
+             (handler-case
+                 (progn
+                   (persist-long-term-kb-promotion database promotion)
+                   (error "non-canonical assertion unexpectedly promoted"))
+               (long-term-kb-validation-error () t))
+             (persist-operational-kb-entry database source)
+             (persist-long-term-kb-promotion database promotion)
+             (let ((retraction
+                     (make-operational-kb-retraction
+                      :retraction-id "r-live"
+                      :operation-id "op-live"
+                      :run-id "run-2"
+                      :expert-id "recon"
+                      :expert-version "1"
+                      :target-assertion-id
+                      (operational-kb-entry-record-id source)
+                      :evidence-ids '("result-retract")
+                      :provenance '(:source "fixture"))))
+               (persist-operational-kb-entry database retraction)
+               (handler-case
+                   (progn
+                     (persist-long-term-kb-promotion
+                      database
+                      (make-long-term-kb-promotion
+                       :promotion-id "p-retracted"
+                       :source-assertion source
+                       :promoted-by "operator"
+                       :promoter-version "1"
+                       :evidence-ids '("review-retracted")
+                       :provenance '(:reason "must reject")))
+                     (error "retracted assertion unexpectedly promoted"))
+                 (long-term-kb-validation-error () t)))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  (let* ((path (merge-pathnames
                 (format nil "hackmode-long-term-read-~D/" (random 1000000000))
                 (uiop:temporary-directory)))
          (database (tek9:new-database "hackmode-long-term-read-test" :path path)))
@@ -118,6 +182,8 @@
                        :promoter-version "1"
                        :evidence-ids '("review-a")
                        :provenance '(:reason "reusable"))))
+               (persist-operational-kb-entry database source-a)
+               (persist-operational-kb-entry database source-b)
                ;; Persist reverse lexical order so the read contract proves sorting.
                (persist-long-term-kb-promotion database promotion-b)
                (persist-long-term-kb-promotion database promotion-a)


### PR DESCRIPTION
Database/KB correctness slice for #24 / #27.

RED-first contract: long-term promotion must fail closed unless its source assertion is actually persisted in the canonical operation-scoped KB and remains effective (not retracted). This prevents callers from promoting fabricated or stale operational knowledge into reusable long-term state.

Scope is database-owned only: `source/hackmode-database/**`. No Hackpert/provider/StarIntel product changes.

Current head is the regression-only RED commit; implementation follows after exact-head CI records the expected failure.