### PR TITLE
Database: require canonical long-term source for global KB export

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -293,10 +293,48 @@
             (push promotion promotions)))))
     (sort promotions #'string< :key #'long-term-kb-promotion-record-id)))
 
+(defun %validate-global-kb-export-source (database export)
+  "Require EXPORT to reference the exact canonical long-term promotion claim."
+  (let* ((source-id (global-kb-export-source-promotion-id export))
+         (node (tek9:fetch-node database source-id
+                                :database-name (long-term-kb-graph-name))))
+    (unless node
+      (error 'global-kb-validation-error
+             :field :source-promotion-id
+             :value source-id
+             :reason "source promotion is not persisted in canonical long-term KB"))
+    (let ((promotion (tek9-node->long-term-kb-promotion node)))
+      (unless
+          (and (string= source-id
+                        (long-term-kb-promotion-record-id promotion))
+               (string= (global-kb-export-source-operation-id export)
+                        (long-term-kb-promotion-source-operation-id promotion))
+               (string= (global-kb-export-source-assertion-id export)
+                        (long-term-kb-promotion-source-assertion-id promotion))
+               (string= (global-kb-export-source-run-id export)
+                        (long-term-kb-promotion-source-run-id promotion))
+               (string= (global-kb-export-source-expert-id export)
+                        (long-term-kb-promotion-source-expert-id promotion))
+               (string= (global-kb-export-source-expert-version export)
+                        (long-term-kb-promotion-source-expert-version promotion))
+               (equal (global-kb-export-source-evidence-ids export)
+                      (long-term-kb-promotion-source-evidence-ids promotion))
+               (equal (global-kb-export-promotion-evidence-ids export)
+                      (long-term-kb-promotion-evidence-ids promotion))
+               (equal (global-kb-export-key export)
+                      (long-term-kb-promotion-key promotion))
+               (equal (global-kb-export-value export)
+                      (long-term-kb-promotion-value promotion)))
+        (error 'global-kb-validation-error
+               :field :source-promotion-id
+               :value source-id
+               :reason "export source does not match canonical long-term promotion")))))
+
 (defun persist-global-kb-export (database export)
   "Persist one explicit immutable export through canonical Tek9 graph APIs."
   (let ((graph-name (global-kb-graph-name)))
     (tek9:with-write-transaction (database)
+      (%validate-global-kb-export-source database export)
       (persist-graph-nodes-replay-safe
        database
        (list (global-kb-root-node)

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -5,6 +5,7 @@
   :components ((:file "tests/execution-graph")
                (:file "tests/long-term-kb")
                (:file "tests/global-kb")
+               (:file "tests/global-kb-canonical-source")
                (:file "tests/replay-conflict")
                (:file "tests/kb-seed-import")
                (:file "tests/execution-outcome-kb")
@@ -18,6 +19,8 @@
              (uiop:symbol-call :hackmode-database-tests :run-tests)
              (uiop:symbol-call :hackmode-database-tests :run-long-term-kb-tests)
              (uiop:symbol-call :hackmode-database-tests :run-global-kb-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-global-kb-canonical-source-tests)
              (uiop:symbol-call :hackmode-database-tests :run-replay-conflict-tests)
              (uiop:symbol-call :hackmode-database-tests :run-kb-seed-import-tests)
              (uiop:symbol-call :hackmode-database-execution-outcome-tests

--- a/source/hackmode-database/tests/global-kb-canonical-source.lisp
+++ b/source/hackmode-database/tests/global-kb-canonical-source.lisp
@@ -1,0 +1,57 @@
+(in-package :hackmode-database-tests)
+
+(defun run-global-kb-canonical-source-tests ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-global-canonical-source-~D/"
+                        (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-global-canonical-source-test"
+                                      :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((source
+                    (make-operational-kb-assertion
+                     :assertion-id "a-global-canonical"
+                     :operation-id "op-global-canonical"
+                     :run-id "run-1"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key '(:service "https")
+                     :value '(:port 443)
+                     :evidence-ids '("result-global-canonical")
+                     :provenance '(:source "fixture")))
+                  (promotion
+                    (make-long-term-kb-promotion
+                     :promotion-id "p-global-canonical"
+                     :source-assertion source
+                     :promoted-by "operator"
+                     :promoter-version "1"
+                     :evidence-ids '("review-global-canonical")
+                     :provenance '(:reason "validated")))
+                  (export
+                    (make-global-kb-export
+                     :export-id "e-global-canonical"
+                     :source-promotion promotion
+                     :exported-by "operator"
+                     :exporter-version "1"
+                     :evidence-ids '("approval-global-canonical")
+                     :provenance '(:reason "explicit export"))))
+             (persist-operational-kb-entry database source)
+             (handler-case
+                 (progn
+                   (persist-global-kb-export database export)
+                   (error "non-canonical long-term promotion unexpectedly exported"))
+               (global-kb-validation-error () t))
+             (persist-long-term-kb-promotion database promotion)
+             (persist-global-kb-export database export)
+             (ensure (tek9:fetch-node
+                      database
+                      (global-kb-export-record-id export)
+                      :database-name (global-kb-graph-name))
+                     "canonical long-term promotion was not exportable")))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)

--- a/source/hackmode-database/tests/global-kb.lisp
+++ b/source/hackmode-database/tests/global-kb.lisp
@@ -79,26 +79,35 @@
     (unwind-protect
          (progn
            (tek9:open-database database)
-           (flet ((promotion (operation assertion promotion-id)
-                    (make-long-term-kb-promotion
-                     :promotion-id promotion-id
-                     :source-assertion
-                     (make-operational-kb-assertion
-                      :assertion-id assertion
-                      :operation-id operation
-                      :run-id "run-1"
-                      :expert-id "recon"
-                      :expert-version "1"
-                      :key (list :operation operation)
-                      :value '(:validated t)
-                      :evidence-ids (list (format nil "result-~A" operation))
-                      :provenance '(:source "fixture"))
-                     :promoted-by "operator"
-                     :promoter-version "1"
-                     :evidence-ids (list (format nil "review-~A" operation))
-                     :provenance '(:reason "reusable"))))
-             (let* ((promotion-a (promotion "op-a" "a-a" "p-a"))
-                    (promotion-b (promotion "op-b" "a-b" "p-b"))
+           (flet ((source (operation assertion)
+                    (make-operational-kb-assertion
+                     :assertion-id assertion
+                     :operation-id operation
+                     :run-id "run-1"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key (list :operation operation)
+                     :value '(:validated t)
+                     :evidence-ids (list (format nil "result-~A" operation))
+                     :provenance '(:source "fixture"))))
+             (let* ((source-a (source "op-a" "a-a"))
+                    (source-b (source "op-b" "a-b"))
+                    (promotion-a
+                      (make-long-term-kb-promotion
+                       :promotion-id "p-a"
+                       :source-assertion source-a
+                       :promoted-by "operator"
+                       :promoter-version "1"
+                       :evidence-ids '("review-op-a")
+                       :provenance '(:reason "reusable")))
+                    (promotion-b
+                      (make-long-term-kb-promotion
+                       :promotion-id "p-b"
+                       :source-assertion source-b
+                       :promoted-by "operator"
+                       :promoter-version "1"
+                       :evidence-ids '("review-op-b")
+                       :provenance '(:reason "reusable")))
                     (export-b
                       (make-global-kb-export
                        :export-id "e-b"
@@ -115,6 +124,10 @@
                        :exporter-version "1"
                        :evidence-ids '("approval-a")
                        :provenance '(:reason "shared"))))
+               (persist-operational-kb-entry database source-a)
+               (persist-operational-kb-entry database source-b)
+               (persist-long-term-kb-promotion database promotion-b)
+               (persist-long-term-kb-promotion database promotion-a)
                (persist-global-kb-export database export-b)
                (persist-global-kb-export database export-a)
                (let ((all (fetch-global-kb-exports database))


### PR DESCRIPTION
## Slice
Issue #24 database/KB lifecycle: global-KB export must prove its source long-term promotion is the exact canonical Tek9 promotion, not merely a caller-constructed in-memory object.

## TDD
RED head: `ff8d6438caf87f112dd489fcd1ef18879a13929d`
- core: RED exactly on `non-canonical long-term promotion unexpectedly exported`
- monorepo: GREEN
- agent-framework-boundary: GREEN

Implementation head: `1d9604d8b1ef316c53a95ea8850174f2d5d33817`
- core: GREEN
- monorepo: GREEN
- agent-framework-boundary: GREEN

## Typed persistence decision
`persist-global-kb-export` now resolves the referenced long-term promotion from the canonical long-term Tek9 graph and compares the exact exported claim/provenance fields before writing global state. Validation and global persistence execute under the same Tek9 write transaction.

This intentionally validates the long-term promotion as the export authority rather than re-evaluating later operational-KB retractions: promotion is the explicit immutable lifecycle boundary between operation-local and reusable knowledge.

## Boundary
- database/KB persistence only
- no Hackpert/provider/expert behavior
- no shadow KB or second database
- canonical Hackmode/Tek9 remains persistence authority
- no StarIntel product work

No reviews, comments, or unresolved review threads at exact-head gate completion.