### PR TITLE
Database: reject non-assertion operational KB retraction targets

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -147,6 +147,26 @@
    :key (lambda (record)
           (getf (execution-record-payload record) :previous-final-offset))))
 
+(defun %validate-operational-kb-retraction-target (database entry graph-name)
+  "Require ENTRY to retract a canonical assertion in the same operation graph."
+  (let* ((target-id (operational-kb-entry-target-assertion-id entry))
+         (node (tek9:fetch-node database target-id :database-name graph-name)))
+    (unless node
+      (error 'operational-kb-validation-error
+             :field :target-assertion-id
+             :value target-id
+             :reason "target assertion does not exist"))
+    (let ((target (tek9-node->operational-kb-entry node)))
+      (unless (and (eq :assert (operational-kb-entry-kind target))
+                   (string= target-id
+                            (operational-kb-entry-record-id target))
+                   (string= (operational-kb-entry-operation-id entry)
+                            (operational-kb-entry-operation-id target)))
+        (error 'operational-kb-validation-error
+               :field :target-assertion-id
+               :value target-id
+               :reason "target is not the canonical operation assertion")))))
+
 (defun persist-operational-kb-entry (database entry)
   "Persist one replay-safe operational KB assertion or retraction through Tek9."
   (let ((graph-name (operational-kb-graph-name
@@ -165,13 +185,7 @@
           (operational-kb-membership-edge entry)
           :database-name graph-name))
         (:retract
-         (unless (tek9:fetch-node database
-                                  (operational-kb-entry-target-assertion-id entry)
-                                  :database-name graph-name)
-           (error 'operational-kb-validation-error
-                  :field :target-assertion-id
-                  :value (operational-kb-entry-target-assertion-id entry)
-                  :reason "target assertion does not exist"))
+         (%validate-operational-kb-retraction-target database entry graph-name)
          (persist-graph-node-replay-safe
           database
           (operational-kb-entry->tek9-node entry)

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -13,7 +13,8 @@
                (:file "tests/http-exchange-graph")
                (:file "tests/capture-checkpoint")
                (:file "tests/capture-quarantine")
-               (:file "tests/capture-source-rotation"))
+               (:file "tests/capture-source-rotation")
+               (:file "tests/operational-kb-retraction-target"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
@@ -34,4 +35,6 @@
              (uiop:symbol-call :hackmode-database-tests
                                :run-capture-quarantine-tests)
              (uiop:symbol-call :hackmode-database-tests
-                               :run-capture-source-rotation-tests)))
+                               :run-capture-source-rotation-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-operational-kb-retraction-target-tests)))

--- a/source/hackmode-database/tests/operational-kb-retraction-target.lisp
+++ b/source/hackmode-database/tests/operational-kb-retraction-target.lisp
@@ -1,0 +1,55 @@
+(in-package :hackmode-database-tests)
+
+(defun run-operational-kb-retraction-target-tests ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-kb-retraction-target-~D/"
+                        (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-kb-retraction-target-test"
+                                      :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((operation-id "op-retraction-target")
+                  (assertion
+                    (make-operational-kb-assertion
+                     :assertion-id "claim-1"
+                     :operation-id operation-id
+                     :run-id "run-1"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key '(:hypothesis "wildcard-dns")
+                     :value '(:confidence 80)
+                     :evidence-ids '("evidence-1")
+                     :provenance '(:source "database-test")))
+                  (target-id (operational-kb-entry-record-id assertion))
+                  (graph-name (operational-kb-graph-name operation-id))
+                  (retraction
+                    (make-operational-kb-retraction
+                     :retraction-id "retract-1"
+                     :operation-id operation-id
+                     :run-id "run-2"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :target-assertion-id target-id
+                     :evidence-ids '("evidence-2")
+                     :provenance '(:source "database-test"))))
+             ;; Simulate canonical graph corruption or a legacy/non-canonical writer:
+             ;; an assertion-shaped stable ID exists, but the stored node is not an assertion.
+             (tek9:put-node
+              database
+              (make-instance 'tek9:node
+                             :id target-id
+                             :props (list :kind :operational-kb-root
+                                          :operation-id operation-id))
+              :database-name graph-name)
+             (handler-case
+                 (progn
+                   (persist-operational-kb-entry database retraction)
+                   (error "retraction unexpectedly targeted a non-assertion node"))
+               (operational-kb-validation-error () t))))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)


### PR DESCRIPTION
Database-owned #24 hardening slice.

RED-first regression: a retraction must not be accepted merely because an assertion-shaped stable ID exists in the operation KB graph. The persisted target must be a canonical typed `:assert` entry for the same operation.

This PR is intentionally opened at the RED test-only head first so core CI can prove the defect before implementation. No Hackpert/provider/StarIntel product behavior is in scope.