### PR TITLE
Hackpert: defend transition reason inspection strings

### DIFF
--- a/source/hackmode-core/expert/transition-inspection.lisp
+++ b/source/hackmode-core/expert/transition-inspection.lisp
@@ -1,5 +1,10 @@
 (in-package :hackmode)
 
+(defun copy-expert-loop-transition-reason (reason)
+  (if (stringp reason)
+      (copy-seq reason)
+      reason))
+
 (defstruct (expert-loop-transition-inspection-state
              (:constructor %make-expert-loop-transition-inspection-state
                  (&key raw-operation raw-run-id kind reason
@@ -80,7 +85,8 @@
    :raw-operation (copy-seq (expert-loop-state-operation before))
    :raw-run-id (copy-seq (expert-loop-state-run-id before))
    :kind (expert-loop-decision-kind decision)
-   :reason (expert-loop-decision-reason decision)
+   :reason (copy-expert-loop-transition-reason
+            (expert-loop-decision-reason decision))
    :from-strategy (expert-loop-state-strategy before)
    :to-strategy (expert-loop-state-strategy after)
    :from-non-progress-count (expert-loop-state-non-progress-count before)
@@ -98,7 +104,8 @@
   (expert-loop-transition-inspection-state-kind inspection))
 
 (defun expert-loop-transition-inspection-reason (inspection)
-  (expert-loop-transition-inspection-state-reason inspection))
+  (copy-expert-loop-transition-reason
+   (expert-loop-transition-inspection-state-reason inspection)))
 
 (defun expert-loop-transition-inspection-from-strategy (inspection)
   (expert-loop-transition-inspection-state-from-strategy inspection))

--- a/source/hackmode-core/tests/expert-transition-inspection.lisp
+++ b/source/hackmode-core/tests/expert-transition-inspection.lisp
@@ -63,6 +63,29 @@
       (assert-equal "run-1"
                     (hackmode:expert-loop-transition-inspection-run-id inspection)
                     "transition inspection returns a defensive run-id copy")))
+  (let* ((reason (copy-seq "symbolic stall"))
+         (before
+           (hackmode:make-expert-loop-state
+            :operation "op-1" :run-id "run-string" :strategy :symbolic))
+         (decision
+           (hackmode::make-expert-loop-decision
+            :kind :escalate :reason reason :strategy :direct))
+         (after
+           (hackmode:make-expert-loop-state
+            :operation "op-1" :run-id "run-string" :strategy :direct
+            :last-reason reason))
+         (inspection
+           (hackmode:expert-loop-transition-inspection before decision after)))
+    (setf (char reason 0) #\X)
+    (assert-equal "symbolic stall"
+                  (hackmode:expert-loop-transition-inspection-reason inspection)
+                  "transition inspection snapshots mutable source reason strings")
+    (let ((returned
+            (hackmode:expert-loop-transition-inspection-reason inspection)))
+      (setf (char returned 0) #\X)
+      (assert-equal "symbolic stall"
+                    (hackmode:expert-loop-transition-inspection-reason inspection)
+                    "transition inspection returns a defensive reason copy")))
   (let* ((before
            (hackmode:make-expert-loop-state
             :operation "op-1" :run-id "run-1" :strategy :direct))


### PR DESCRIPTION
## Slice
Bug-first Hackpert operator-inspection hardening for #29/#27.

`expert-loop-transition-inspection` already defensively copies operation/run scope, but a mutable string decision reason was still stored and returned by alias. That let source or caller mutation rewrite a supposedly side-effect-free historical transition snapshot.

RED contract commit: `74900d58537ea798de9a1bbce28863c5c6449222` — core failed on the new aliasing regression while monorepo and boundary passed.

GREEN implementation head: `e01da8f61ec2913ba86bdc91e3786a40ae879d40` — core, monorepo, and agent-framework-boundary all passed at exact head.

This non-draft PR replaces draft #117 at the identical green head because GitHub's ready-for-review GraphQL mutation failed on the connector's recurring `fullDatabaseId` field bug.

Scope is confined to Hackpert transition inspection/tests; no database persistence internals, provider execution, or StarIntel product work.