### PR TITLE
Hackpert: re-evaluate objective on each loop step

### DIFF
--- a/source/hackmode-core/expert/selection.lisp
+++ b/source/hackmode-core/expert/selection.lisp
@@ -187,6 +187,50 @@ an explicit admission/rejection reason. No provider or mutation effect occurs."
             :reason (if selected :selected :no-applicable-extension)
             :raw-candidates candidates))))))
 
+(defun expert-objective-loop-step
+    (state plan policy registry objective
+     &key authority available-capabilities clause-satisfied-p
+       progress-p failure-p budget-exhausted-p policy-denied-p explicit-stop-p)
+  "Re-evaluate one objective iteration before deriving the next loop decision.
+
+Returns four values: the fresh objective evaluation, extension selection, loop
+decision, and next loop state. The current loop reasoning strategy is used for
+extension admission, while AUTHORITY remains an independent caller-supplied
+constraint. This function is pure control-plane composition: it executes no
+provider, persists no state, and grants no effects."
+  (check-type state expert-loop-state)
+  (check-type plan expert-plan)
+  (check-type policy expert-loop-policy)
+  (check-type registry expert-extension-registry)
+  (check-type objective expert-objective)
+  (unless (string= (expert-plan-objective-id plan)
+                   (expert-objective-id objective))
+    (reject-expert-loop
+     objective
+     "plan objective ~s does not match objective ~s"
+     (expert-plan-objective-id plan)
+     (expert-objective-id objective)))
+  (multiple-value-bind (evaluation selection)
+      (expert-select-extension
+       registry objective
+       :authority authority
+       :strategy (expert-loop-state-strategy state)
+       :available-capabilities available-capabilities
+       :clause-satisfied-p clause-satisfied-p)
+    (multiple-value-bind (decision next-state)
+        (expert-loop-next-decision
+         state plan policy
+         :goal-satisfied-p
+         (eq :satisfied (expert-objective-evaluation-status evaluation))
+         :budget-exhausted-p budget-exhausted-p
+         :policy-denied-p policy-denied-p
+         :viable-extension-p
+         (not (null (expert-extension-selection-selected-id selection)))
+         :explicit-stop-p explicit-stop-p
+         :progress-p progress-p
+         :failure-p failure-p)
+      (values evaluation selection decision next-state))))
+
 (export '(+expert-objective-evaluation-statuses+
           +expert-extension-candidate-reasons+
           expert-objective-evaluation
@@ -209,4 +253,5 @@ an explicit admission/rejection reason. No provider or mutation effect occurs."
           expert-extension-selection-selected-version
           expert-extension-selection-reason
           expert-extension-selection-candidates
-          expert-select-extension))
+          expert-select-extension
+          expert-objective-loop-step))

--- a/source/hackmode-core/tests/expert-selection.lisp
+++ b/source/hackmode-core/tests/expert-selection.lisp
@@ -120,4 +120,84 @@
       (assert-equal :objective-satisfied
                     (hackmode:expert-extension-selection-reason selection)
                     "satisfied objective explains stop selection"))
+    (let* ((work
+             (hackmode:make-expert-playbook-step
+              :id "work"
+              :success-next "done"
+              :failure-next "work"))
+           (done
+             (hackmode:make-expert-playbook-step
+              :id "done"
+              :terminal :succeeded))
+           (playbook
+             (hackmode:make-expert-playbook
+              :id "objective-loop"
+              :version "1"
+              :entry-step "work"
+              :steps (list work done)
+              :stop-conditions
+              (list
+               (hackmode:make-expert-stop-condition :kind :goal-satisfied)
+               (hackmode:make-expert-stop-condition :kind :no-viable-extension))))
+           (plan
+             (hackmode:instantiate-expert-plan
+              playbook
+              :id "objective-plan"
+              :operation "op-a"
+              :run-id "run-a"
+              :objective-id "root-objective"))
+           (policy (hackmode:make-expert-loop-policy :non-progress-threshold 2))
+           (state
+             (hackmode:make-expert-loop-state
+              :operation "op-a"
+              :run-id "run-a"
+              :strategy :symbolic))
+           (satisfied '("foothold")))
+      (flet ((satisfied-p (clause)
+               (member (hackmode:expert-objective-clause-predicate clause)
+                       satisfied
+                       :test #'string=)))
+        (multiple-value-bind (evaluation selection decision next-state)
+            (hackmode:expert-objective-loop-step
+             state plan policy registry objective
+             :authority :active
+             :available-capabilities '("shell-command" "http-probe")
+             :clause-satisfied-p #'satisfied-p
+             :progress-p t)
+          (assert-equal :in-progress
+                        (hackmode:expert-objective-evaluation-status evaluation)
+                        "loop step evaluates current evidence")
+          (assert-equal "recon-path"
+                        (hackmode:expert-extension-selection-selected-id selection)
+                        "loop step selects from current applicable extensions")
+          (assert-equal :continue
+                        (hackmode:expert-loop-decision-kind decision)
+                        "unsatisfied objective continues after progress")
+          (setf satisfied
+                '("foothold" "final_identity" "authenticated_execution"))
+          (multiple-value-bind (second-evaluation second-selection second-decision
+                                second-state)
+              (hackmode:expert-objective-loop-step
+               next-state plan policy registry objective
+               :authority :active
+               :available-capabilities '("shell-command" "http-probe")
+               :clause-satisfied-p #'satisfied-p
+               :progress-p t)
+            (assert-equal :satisfied
+                          (hackmode:expert-objective-evaluation-status
+                           second-evaluation)
+                          "next loop step re-evaluates newly available evidence")
+            (assert-equal :objective-satisfied
+                          (hackmode:expert-extension-selection-reason
+                           second-selection)
+                          "satisfied objective bypasses extension execution")
+            (assert-equal :stop
+                          (hackmode:expert-loop-decision-kind second-decision)
+                          "newly satisfied objective stops on the next iteration")
+            (assert-equal :goal-satisfied
+                          (hackmode:expert-loop-decision-reason second-decision)
+                          "objective satisfaction supplies the typed stop reason")
+            (assert-equal "op-a"
+                          (hackmode:expert-loop-state-operation second-state)
+                          "loop step preserves operation scope")))))
     t))


### PR DESCRIPTION
## Slice
Advance #29/#27 with one pure Hackpert control-plane boundary that re-evaluates objective evidence and extension applicability on every loop iteration before deriving the next symbolic/direct decision.

This does not execute providers, mutate canonical state, own persistence, or add another scheduler/executor. Authority remains orthogonal to reasoning strategy and effects still cross the existing canonical Hackmode boundary.

## RED
Test-only head `4d12338f76f6b33d8d8143058e8c530445b00a71` failed core exactly because `HACKMODE:EXPERT-OBJECTIVE-LOOP-STEP` did not exist. Monorepo and agent-framework-boundary passed.

## GREEN
Implementation head `d0ff9b626391e6ada768d45c066a54f9765b84c5` passes fresh core, monorepo, and agent-framework-boundary. The loop step validates plan/objective identity, re-runs objective evaluation and extension admission using the current reasoning strategy, derives goal/no-extension stop signals from fresh results, and delegates the final transition to the existing generic loop.

No database-owned files or StarIntel product code are touched.

Issue: #29