### PR TITLE
Database: return typed operational KB entries from singular fetch

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -197,9 +197,20 @@
     entry))
 
 (defun fetch-operational-kb-entry (database operation-id record-id)
-  "Fetch one operational KB graph node by stable RECORD-ID."
-  (tek9:fetch-node database record-id
-                   :database-name (operational-kb-graph-name operation-id)))
+  "Return one typed operational-KB entry by stable RECORD-ID, or NIL."
+  (%kb-require-string :operation-id operation-id)
+  (%kb-require-string :record-id record-id)
+  (let ((node (tek9:fetch-node
+               database record-id
+               :database-name (operational-kb-graph-name operation-id))))
+    (when node
+      (let ((entry (tek9-node->operational-kb-entry node)))
+        (unless (string= operation-id (operational-kb-entry-operation-id entry))
+          (error 'operational-kb-validation-error
+                 :field :operation-id
+                 :value (operational-kb-entry-operation-id entry)
+                 :reason "stored entry does not match graph operation scope"))
+        entry))))
 
 (defun fetch-operational-kb-entries (database operation-id &key run-id kind)
   "Return typed operational-KB entries for one operation, including retractions."

--- a/source/hackmode-database/tests/kb-seed-import.lisp
+++ b/source/hackmode-database/tests/kb-seed-import.lisp
@@ -116,6 +116,11 @@
                      :evidence-ids '("artifact-conflict")
                      :provenance '(:source "conflict"))))
              (persist-operational-kb-entry database conflict)
+             (ensure (typep (fetch-operational-kb-entry
+                             database "op-atomic"
+                             (operational-kb-entry-record-id conflict))
+                            'operational-kb-entry)
+                     "single operational KB fetch leaked a raw Tek9 node")
              (handler-case
                  (progn
                    (apply #'persist-operational-kb-seed-values database arguments)


### PR DESCRIPTION
## Slice
Fix the singular operational-KB read boundary so callers receive the typed `operational-kb-entry` contract rather than a raw Tek9 graph node.

Tracking: #24 / #27 database-owned operational-KB boundary.

## RED
Current test-only head `4f9ff2ae415aa914a9219886fd3194c99df5d7b3` persists a canonical assertion and requires `fetch-operational-kb-entry` to return an `operational-kb-entry`. Current master leaks a raw `tek9:node`, so the new executable regression should fail in the core ASDF test gate.

## Intended GREEN
Decode and validate the fetched canonical graph node through the existing typed operational-KB decoder while preserving `NIL` for a missing stable ID and operation scoping. No Hackpert/expert/provider behavior and no shadow persistence authority.