### PR TITLE
db: return typed singular long-term KB promotions

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -300,9 +300,13 @@
   promotion)
 
 (defun fetch-long-term-kb-promotion (database record-id)
-  "Fetch one long-term KB promotion by its stable record identity."
-  (tek9:fetch-node database record-id
-                   :database-name (long-term-kb-graph-name)))
+  "Return one typed long-term KB promotion by stable RECORD-ID, or NIL."
+  (%long-term-require-string :record-id record-id)
+  (let ((node (tek9:fetch-node
+               database record-id
+               :database-name (long-term-kb-graph-name))))
+    (when node
+      (tek9-node->long-term-kb-promotion node))))
 
 (defun fetch-long-term-kb-promotions (database &key source-operation-id)
   "Return typed long-term KB promotions in deterministic record-ID order."

--- a/source/hackmode-database/hackmode-database-tests.asd
+++ b/source/hackmode-database/hackmode-database-tests.asd
@@ -4,6 +4,7 @@
   :serial t
   :components ((:file "tests/execution-graph")
                (:file "tests/long-term-kb")
+               (:file "tests/long-term-kb-singular-fetch")
                (:file "tests/global-kb")
                (:file "tests/global-kb-canonical-source")
                (:file "tests/replay-conflict")
@@ -19,6 +20,8 @@
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-database-tests :run-tests)
              (uiop:symbol-call :hackmode-database-tests :run-long-term-kb-tests)
+             (uiop:symbol-call :hackmode-database-tests
+                               :run-long-term-kb-singular-fetch-tests)
              (uiop:symbol-call :hackmode-database-tests :run-global-kb-tests)
              (uiop:symbol-call :hackmode-database-tests
                                :run-global-kb-canonical-source-tests)

--- a/source/hackmode-database/tests/long-term-kb-singular-fetch.lisp
+++ b/source/hackmode-database/tests/long-term-kb-singular-fetch.lisp
@@ -1,0 +1,51 @@
+(in-package :hackmode-database-tests)
+
+(defun run-long-term-kb-singular-fetch-tests ()
+  (let* ((path (merge-pathnames
+                (format nil "hackmode-long-term-singular-~D/" (random 1000000000))
+                (uiop:temporary-directory)))
+         (database (tek9:new-database "hackmode-long-term-singular-test" :path path)))
+    (unwind-protect
+         (progn
+           (tek9:open-database database)
+           (let* ((source
+                    (make-operational-kb-assertion
+                     :assertion-id "a-singular"
+                     :operation-id "op-singular"
+                     :run-id "run-1"
+                     :expert-id "recon"
+                     :expert-version "1"
+                     :key '(:service "https")
+                     :value '(:port 443)
+                     :evidence-ids '("result-singular")
+                     :provenance '(:source "fixture")))
+                  (promotion
+                    (make-long-term-kb-promotion
+                     :promotion-id "p-singular"
+                     :source-assertion source
+                     :promoted-by "operator"
+                     :promoter-version "1"
+                     :evidence-ids '("review-singular")
+                     :provenance '(:reason "validated"))))
+             (persist-operational-kb-entry database source)
+             (persist-long-term-kb-promotion database promotion)
+             (let ((fetched
+                     (fetch-long-term-kb-promotion
+                      database
+                      (long-term-kb-promotion-record-id promotion))))
+               (ensure (typep fetched 'long-term-kb-promotion)
+                       "singular long-term KB fetch leaked a raw Tek9 node")
+               (ensure (string=
+                        (long-term-kb-promotion-record-id promotion)
+                        (long-term-kb-promotion-record-id fetched))
+                       "singular long-term KB fetch changed promotion identity")
+               (ensure (equal '("result-singular")
+                              (long-term-kb-promotion-source-evidence-ids fetched))
+                       "singular long-term KB fetch lost source evidence"))
+             (ensure (null (fetch-long-term-kb-promotion database "missing-promotion"))
+                     "missing singular long-term KB fetch did not return NIL")))
+      (when (tek9:db-is-open-p database)
+        (tek9:close-database database))
+      (when (probe-file path)
+        (uiop:delete-directory-tree path :validate t))))
+  t)


### PR DESCRIPTION
Database/KB RED→GREEN slice for #24.

RED established that `fetch-long-term-kb-promotions` returned typed `long-term-kb-promotion` values while singular `fetch-long-term-kb-promotion` leaked a raw Tek9 node. The regression requires the singular read to preserve typed promotion identity/evidence and return NIL for a missing stable ID.

GREEN changes only the canonical database read boundary: validate the stable record ID, fetch from the canonical long-term KB graph, and deserialize a present node with `tek9-node->long-term-kb-promotion`.

The branch has been reconciled forward onto current `master` after sibling Hackpert #126; no sibling-owned files are changed.

No provider/Hackpert behavior and no StarIntel product work.