### PR TITLE
Hackpert: defend direct candidate accessors

### DIFF
--- a/source/hackmode-core/expert/direct-candidate.lisp
+++ b/source/hackmode-core/expert/direct-candidate.lisp
@@ -25,12 +25,38 @@
 
 (defstruct (expert-direct-candidate
              (:constructor %make-expert-direct-candidate
-                 (&key operation run-id kind payload provenance)))
+                 (&key operation run-id kind payload provenance))
+             (:conc-name %expert-direct-candidate-))
   operation
   run-id
   kind
   payload
   provenance)
+
+(defun expert-direct-candidate-operation (candidate)
+  "Return an independently mutable snapshot of CANDIDATE's operation scope."
+  (check-type candidate expert-direct-candidate)
+  (copy-seq (%expert-direct-candidate-operation candidate)))
+
+(defun expert-direct-candidate-run-id (candidate)
+  "Return an independently mutable snapshot of CANDIDATE's run scope."
+  (check-type candidate expert-direct-candidate)
+  (copy-seq (%expert-direct-candidate-run-id candidate)))
+
+(defun expert-direct-candidate-kind (candidate)
+  "Return CANDIDATE's immutable typed kind."
+  (check-type candidate expert-direct-candidate)
+  (%expert-direct-candidate-kind candidate))
+
+(defun expert-direct-candidate-payload (candidate)
+  "Return a defensive snapshot of CANDIDATE's symbolic payload."
+  (check-type candidate expert-direct-candidate)
+  (expert-direct-copy-value (%expert-direct-candidate-payload candidate)))
+
+(defun expert-direct-candidate-provenance (candidate)
+  "Return a defensive snapshot of CANDIDATE's generation provenance."
+  (check-type candidate expert-direct-candidate)
+  (expert-direct-copy-value (%expert-direct-candidate-provenance candidate)))
 
 (defun make-expert-direct-candidate (&key operation run-id kind payload provenance)
   "Normalize direct-mode progress into a typed, operation-scoped candidate.
@@ -58,18 +84,18 @@ Hackmode boundaries."
 
 (defun validate-expert-direct-candidate-scope (state candidate)
   (unless (string= (expert-loop-state-operation state)
-                   (expert-direct-candidate-operation candidate))
+                   (%expert-direct-candidate-operation candidate))
     (reject-expert-direct-candidate
      candidate
      "candidate operation ~s does not match loop operation ~s"
-     (expert-direct-candidate-operation candidate)
+     (%expert-direct-candidate-operation candidate)
      (expert-loop-state-operation state)))
   (unless (string= (expert-loop-state-run-id state)
-                   (expert-direct-candidate-run-id candidate))
+                   (%expert-direct-candidate-run-id candidate))
     (reject-expert-direct-candidate
      candidate
      "candidate run ~s does not match loop run ~s"
-     (expert-direct-candidate-run-id candidate)
+     (%expert-direct-candidate-run-id candidate)
      (expert-loop-state-run-id state)))
   candidate)
 

--- a/source/hackmode-core/tests/expert-direct-candidate.lisp
+++ b/source/hackmode-core/tests/expert-direct-candidate.lisp
@@ -52,6 +52,28 @@
                   (getf (hackmode:expert-direct-candidate-payload candidate)
                         :predicate)
                   "candidate owns a defensive payload snapshot")
+    (let ((operation (hackmode:expert-direct-candidate-operation candidate))
+          (run-id (hackmode:expert-direct-candidate-run-id candidate))
+          (exposed-payload (hackmode:expert-direct-candidate-payload candidate))
+          (provenance (hackmode:expert-direct-candidate-provenance candidate)))
+      (setf (char operation 0) #\X)
+      (setf (char run-id 0) #\X)
+      (setf (char (getf exposed-payload :predicate) 0) #\X)
+      (setf (char (getf provenance :source) 0) #\X)
+      (assert-equal "op-a"
+                    (hackmode:expert-direct-candidate-operation candidate)
+                    "candidate operation accessor returns a defensive string")
+      (assert-equal "run-1"
+                    (hackmode:expert-direct-candidate-run-id candidate)
+                    "candidate run accessor returns a defensive string")
+      (assert-equal "root-proven"
+                    (getf (hackmode:expert-direct-candidate-payload candidate)
+                          :predicate)
+                    "candidate payload accessor returns a defensive snapshot")
+      (assert-equal "direct"
+                    (getf (hackmode:expert-direct-candidate-provenance candidate)
+                          :source)
+                    "candidate provenance accessor returns a defensive snapshot"))
     (handler-case
         (progn
           (hackmode:expert-loop-resume-with-direct-candidate


### PR DESCRIPTION
Bug-first Hackpert slice for #29/#27.

RED proved that the typed direct-candidate boundary copied constructor inputs but leaked its stored mutable operation/run strings and payload/provenance trees through generated defstruct accessors. The fix gives the struct private raw accessors and preserves the public API as defensive snapshot accessors; internal scope validation reads the private immutable snapshot directly.

No provider execution, canonical mutation, persistence/database authority, second scheduler, or StarIntel product work is added.

This PR replaces draft #125 on the identical implementation head because GitHub's ready-for-review mutation failed on the recurring `fullDatabaseId` connector bug.