### PR TITLE
Database: return typed singular global KB exports

### DIFF
--- a/source/hackmode-database/db.lisp
+++ b/source/hackmode-database/db.lisp
@@ -378,9 +378,13 @@
   export)
 
 (defun fetch-global-kb-export (database record-id)
-  "Fetch one explicit global KB export by stable record identity."
-  (tek9:fetch-node database record-id
-                   :database-name (global-kb-graph-name)))
+  "Return one typed global KB export by stable RECORD-ID, or NIL."
+  (%global-require-string :record-id record-id)
+  (let ((node (tek9:fetch-node
+               database record-id
+               :database-name (global-kb-graph-name))))
+    (when node
+      (tek9-node->global-kb-export node))))
 
 (defun fetch-global-kb-exports (database &key source-operation-id)
   "Return typed global KB exports in deterministic record-ID order."

--- a/source/hackmode-database/tests/global-kb.lisp
+++ b/source/hackmode-database/tests/global-kb.lisp
@@ -130,6 +130,18 @@
                (persist-long-term-kb-promotion database promotion-a)
                (persist-global-kb-export database export-b)
                (persist-global-kb-export database export-a)
+               (let ((fetched (fetch-global-kb-export
+                               database (global-kb-export-record-id export-a))))
+                 (ensure (typep fetched 'global-kb-export)
+                         "singular global KB fetch leaked a raw Tek9 node")
+                 (ensure (string= (global-kb-export-record-id export-a)
+                                  (global-kb-export-record-id fetched))
+                         "singular global KB fetch changed stable identity")
+                 (ensure (equal '("approval-a")
+                                (global-kb-export-evidence-ids fetched))
+                         "singular global KB fetch lost export evidence")
+                 (ensure (null (fetch-global-kb-export database "missing-export"))
+                         "singular global KB fetch should return NIL when absent"))
                (let ((all (fetch-global-kb-exports database))
                      (op-a (fetch-global-kb-exports
                             database :source-operation-id "op-a")))


### PR DESCRIPTION
## Slice
Close the remaining read-boundary asymmetry in the canonical global KB: plural reads already return typed `global-kb-export` values, while the singular fetch still leaks a raw Tek9 node.

## RED-first proof
Test-only head `bbd743cafe91c66dec69f0773bc080169f7703e8` requires `fetch-global-kb-export` to:
- return a typed `global-kb-export` for a persisted stable record ID;
- preserve stable identity and export evidence;
- return `NIL` for an absent record.

The current implementation returns `tek9:fetch-node` directly, so `core` should fail at the new typed-boundary regression before implementation.

## Ownership
Database-owned only. No Hackpert expert/orchestration files and no StarIntel product work.