### PR TITLE
Hackpert: defend loop reason strings from caller mutation

### DIFF
--- a/source/hackmode-core/expert/loop.lisp
+++ b/source/hackmode-core/expert/loop.lisp
@@ -19,6 +19,11 @@
          :value value
          :reason (apply #'format nil control arguments)))
 
+(defun expert-loop-copy-reason (reason)
+  (if (stringp reason)
+      (copy-seq reason)
+      reason))
+
 (defstruct (expert-loop-policy
              (:constructor %make-expert-loop-policy (&key non-progress-threshold)))
   (non-progress-threshold 2 :type integer))
@@ -59,8 +64,9 @@
   (%expert-loop-state-non-progress-count state))
 
 (defun expert-loop-state-last-reason (state)
+  "Return a defensive snapshot when STATE's last reason is mutable text."
   (check-type state expert-loop-state)
-  (%expert-loop-state-last-reason state))
+  (expert-loop-copy-reason (%expert-loop-state-last-reason state)))
 
 (defun make-expert-loop-state (&key operation run-id (strategy :symbolic)
                                     (non-progress-count 0) last-reason)
@@ -78,7 +84,7 @@
    :run-id (copy-seq run-id)
    :strategy strategy
    :non-progress-count non-progress-count
-   :last-reason last-reason))
+   :last-reason (expert-loop-copy-reason last-reason)))
 
 (defstruct (expert-loop-decision
              (:constructor make-expert-loop-decision (&key kind reason strategy)))
@@ -95,7 +101,7 @@
    (if (null non-progress-count)
        (%expert-loop-state-non-progress-count state)
        non-progress-count)
-   :last-reason last-reason))
+   :last-reason (expert-loop-copy-reason last-reason)))
 
 (defun expert-loop-stop-reason (plan &key goal-satisfied-p budget-exhausted-p
                                           policy-denied-p (viable-extension-p t)

--- a/source/hackmode-core/tests/expert-loop-scope-copy.lisp
+++ b/source/hackmode-core/tests/expert-loop-scope-copy.lisp
@@ -3,28 +3,39 @@
 (defun run-expert-loop-scope-copy-tests ()
   (let* ((operation (copy-seq "op-a"))
          (run-id (copy-seq "run-1"))
+         (last-reason (copy-seq "symbolic-stall"))
          (state
            (hackmode:make-expert-loop-state
             :operation operation
             :run-id run-id
-            :strategy :symbolic)))
+            :strategy :symbolic
+            :last-reason last-reason)))
     (setf (char operation 0) #\X
-          (char run-id 0) #\X)
+          (char run-id 0) #\X
+          (char last-reason 0) #\X)
     (assert-equal "op-a"
                   (hackmode:expert-loop-state-operation state)
                   "loop state owns an operation-scope snapshot")
     (assert-equal "run-1"
                   (hackmode:expert-loop-state-run-id state)
                   "loop state owns a run-scope snapshot")
+    (assert-equal "symbolic-stall"
+                  (hackmode:expert-loop-state-last-reason state)
+                  "loop state owns a mutable last-reason snapshot")
     (let ((exposed-operation (hackmode:expert-loop-state-operation state))
-          (exposed-run-id (hackmode:expert-loop-state-run-id state)))
+          (exposed-run-id (hackmode:expert-loop-state-run-id state))
+          (exposed-last-reason (hackmode:expert-loop-state-last-reason state)))
       (setf (char exposed-operation 0) #\Y
-            (char exposed-run-id 0) #\Y)
+            (char exposed-run-id 0) #\Y
+            (char exposed-last-reason 0) #\Y)
       (assert-equal "op-a"
                     (hackmode:expert-loop-state-operation state)
                     "operation accessor does not expose mutable scope storage")
       (assert-equal "run-1"
                     (hackmode:expert-loop-state-run-id state)
-                    "run accessor does not expose mutable scope storage"))
+                    "run accessor does not expose mutable scope storage")
+      (assert-equal "symbolic-stall"
+                    (hackmode:expert-loop-state-last-reason state)
+                    "last-reason accessor does not expose mutable state storage"))
     (format t "Hackmode expert loop scope-copy tests passed.~%")
     t))


### PR DESCRIPTION
## Slice
Bug-first hardening for #29: `expert-loop-state` owns mutable `last-reason` metadata just like its operation/run scope strings, and operator access must not expose the stored string.

## RED-first proof
Test-only head `eeb953068ea0d3897714fe082bca77d364f423f4` mutates both the caller-owned source string and the accessor-returned string. Current `master` stores/returns `last-reason` directly, so `common-lisp-core` should fail at the new regression before implementation.

## Ownership
Hackpert loop state/tests only. No database internals and no StarIntel product work.