### PR TITLE
Database: enforce redacted HTTP header evidence

### DIFF
--- a/source/hackmode-database/hackmode-database.asd
+++ b/source/hackmode-database/hackmode-database.asd
@@ -8,6 +8,7 @@
   :depends-on (#:tek9)
   :components ((:file "package")
                (:file "execution-graph")
+               (:file "http-exchange-headers")
                (:file "operational-kb")
                (:file "execution-outcome-kb")
                (:file "kb-seed-import")

--- a/source/hackmode-database/http-exchange-headers.lisp
+++ b/source/hackmode-database/http-exchange-headers.lisp
@@ -1,0 +1,120 @@
+(in-package :hackmode-database)
+
+(defconstant +http-exchange-max-header-count+ 64)
+(defconstant +http-exchange-max-header-name-length+ 128)
+(defconstant +http-exchange-max-header-value-length+ 4096)
+
+(defparameter +http-exchange-sensitive-header-names+
+  '("authorization"
+    "proxy-authorization"
+    "cookie"
+    "set-cookie"
+    "x-api-key"
+    "x-auth-token"
+    "api-key"))
+
+(defun %proper-list-p (value)
+  (or (null value)
+      (ignore-errors (integerp (list-length value)))))
+
+(defun %sensitive-http-header-name-p (name)
+  (member name +http-exchange-sensitive-header-names+
+          :test #'string-equal))
+
+(defun %sanitize-http-headers (field headers)
+  (unless (%proper-list-p headers)
+    (error 'execution-graph-validation-error
+           :field field :value headers
+           :reason "expected a proper list of HTTP header pairs"))
+  (when (> (length headers) +http-exchange-max-header-count+)
+    (error 'execution-graph-validation-error
+           :field field :value headers
+           :reason "too many HTTP headers"))
+  (loop for entry in headers
+        collect
+        (progn
+          (unless (and (consp entry)
+                       (stringp (car entry))
+                       (stringp (cdr entry)))
+            (error 'execution-graph-validation-error
+                   :field field :value entry
+                   :reason "expected (header-name . header-value) string pair"))
+          (let ((name (car entry))
+                (value (cdr entry)))
+            (unless (%non-empty-string-p name)
+              (error 'execution-graph-validation-error
+                     :field field :value entry
+                     :reason "HTTP header name must be non-empty"))
+            (when (> (length name) +http-exchange-max-header-name-length+)
+              (error 'execution-graph-validation-error
+                     :field field :value name
+                     :reason "HTTP header name exceeds canonical bound"))
+            (when (> (length value) +http-exchange-max-header-value-length+)
+              (error 'execution-graph-validation-error
+                     :field field :value name
+                     :reason "HTTP header value exceeds canonical bound"))
+            (when (%sensitive-http-header-name-p name)
+              (error 'execution-graph-validation-error
+                     :field field :value name
+                     :reason "secret-bearing HTTP header is not canonical graph evidence"))
+            (cons (copy-seq name) (copy-seq value))))))
+
+(defun %validate-http-exchange-payload (payload)
+  (unless (listp payload)
+    (error 'execution-graph-validation-error
+           :field :payload :value payload
+           :reason "expected HTTP exchange property list"))
+  (%require-string :method (getf payload :method))
+  (let ((scheme (getf payload :scheme)))
+    (%require-string :scheme scheme)
+    (unless (member scheme '("http" "https") :test #'string-equal)
+      (error 'execution-graph-validation-error
+             :field :scheme :value scheme
+             :reason "expected http or https scheme")))
+  (%require-string :host (getf payload :host))
+  (%require-http-port (getf payload :port))
+  (%require-string :path (getf payload :path))
+  (%require-http-status (getf payload :response-status))
+  (%sanitize-http-headers :request-headers (getf payload :request-headers))
+  (%sanitize-http-headers :response-headers (getf payload :response-headers))
+  (%require-optional-string :request-body-digest (getf payload :request-body-digest))
+  (%require-optional-string :response-body-digest (getf payload :response-body-digest))
+  (%require-string :raw-evidence-ref (getf payload :raw-evidence-ref))
+  (%require-string :observed-at (getf payload :observed-at))
+  (%require-duration-ms (getf payload :duration-ms))
+  payload)
+
+(defun make-http-exchange-record
+    (&key operation-id capture-session-id exchange-id method scheme host port path
+          response-status request-headers response-headers request-body-digest
+          response-body-digest raw-evidence-ref observed-at duration-ms provenance)
+  "Construct one immutable, sanitized HTTP exchange evidence record."
+  (%require-string :operation-id operation-id)
+  (%require-string :capture-session-id capture-session-id)
+  (%require-string :exchange-id exchange-id)
+  (%require-provenance provenance)
+  (let ((payload (list :method method
+                       :scheme scheme
+                       :host host
+                       :port port
+                       :path path
+                       :response-status response-status
+                       :request-headers
+                       (%sanitize-http-headers :request-headers request-headers)
+                       :response-headers
+                       (%sanitize-http-headers :response-headers response-headers)
+                       :request-body-digest request-body-digest
+                       :response-body-digest response-body-digest
+                       :raw-evidence-ref raw-evidence-ref
+                       :observed-at observed-at
+                       :duration-ms duration-ms)))
+    (%validate-http-exchange-payload payload)
+    (%make-execution-record
+     :kind :http-exchange
+     :operation-id operation-id
+     :run-id capture-session-id
+     :call-id exchange-id
+     :record-id (%record-id "http-exchange"
+                            operation-id capture-session-id exchange-id)
+     :payload payload
+     :provenance provenance)))

--- a/source/hackmode-database/tests/http-exchange-graph.lisp
+++ b/source/hackmode-database/tests/http-exchange-graph.lisp
@@ -11,6 +11,10 @@
                  :port 443
                  :path "/login?next=%2F"
                  :response-status 302
+                 :request-headers '(("accept" . "text/html")
+                                    ("user-agent" . "HackmodeFixture/1"))
+                 :response-headers '(("content-type" . "text/html; charset=utf-8")
+                                     ("server" . "fixture"))
                  :request-body-digest "sha256:req"
                  :response-body-digest "sha256:resp"
                  :raw-evidence-ref "capture-1:120-418"
@@ -27,6 +31,10 @@
                 :port 443
                 :path "/login?next=%2F"
                 :response-status 302
+                :request-headers '(("accept" . "text/html")
+                                   ("user-agent" . "HackmodeFixture/1"))
+                :response-headers '(("content-type" . "text/html; charset=utf-8")
+                                    ("server" . "fixture"))
                 :request-body-digest "sha256:req"
                 :response-body-digest "sha256:resp"
                 :raw-evidence-ref "capture-1:120-418"
@@ -42,6 +50,16 @@
             "capture session identity was not retained")
     (ensure (string= "exchange-1" (hackmode-database:execution-record-call-id first))
             "exchange correlation identity was not retained")
+    (ensure (equal '(("accept" . "text/html")
+                     ("user-agent" . "HackmodeFixture/1"))
+                   (getf (hackmode-database:execution-record-payload first)
+                         :request-headers))
+            "bounded request headers were not retained")
+    (ensure (equal '(("content-type" . "text/html; charset=utf-8")
+                     ("server" . "fixture"))
+                   (getf (hackmode-database:execution-record-payload first)
+                         :response-headers))
+            "bounded response headers were not retained")
     (let* ((path (merge-pathnames
                   (format nil "hackmode-http-exchange-~D/" (random 1000000000))
                   (uiop:temporary-directory)))
@@ -81,5 +99,24 @@
            :duration-ms 1
            :provenance '(:parser "ipx-http/1"))
           (error "invalid HTTP port unexpectedly accepted"))
+      (hackmode-database:execution-graph-validation-error () t))
+    (handler-case
+        (progn
+          (hackmode-database:make-http-exchange-record
+           :operation-id "op-http"
+           :capture-session-id "capture-1"
+           :exchange-id "secret-header"
+           :method "GET"
+           :scheme "https"
+           :host "example.com"
+           :port 443
+           :path "/"
+           :response-status 200
+           :request-headers '(("authorization" . "Bearer secret"))
+           :raw-evidence-ref "capture-1:10-20"
+           :observed-at "2026-08-30T18:55:00Z"
+           :duration-ms 1
+           :provenance '(:parser "ipx-http/1"))
+          (error "secret-bearing HTTP header unexpectedly accepted"))
       (hackmode-database:execution-graph-validation-error () t)))
   t)


### PR DESCRIPTION
## Slice
Database-owned #26 storage contract for bounded/redacted HTTP header evidence.

Current canonical `:http-exchange` records persist method/URL/status/body digests/raw evidence reference/timing, but the #26 contract also requires bounded/redacted headers. Capture/ZAP/mitmproxy process work remains outside this PR.

## RED-first contract
Exact test head `706efb1ca5729042f3dccf81577a7979c273f983` requires:
- sanitized request/response header pairs to survive the typed execution-record + Tek9 round trip;
- secret-bearing headers such as `Authorization` to fail closed at the canonical persistence constructor rather than entering graph evidence.

The current constructor has no request/response header keywords, so core is expected to fail at the new regression before implementation.

## Intended GREEN
Smallest database-only change in `source/hackmode-database/execution-graph.lisp`:
- accept bounded sanitized header alists;
- reject malformed/oversized entries and sensitive header names;
- preserve deterministic replay identity and existing Tek9 graph authority;
- no raw bodies, provider process logic, ZAP semantics, mitmproxy addon, Hackpert reasoning, or StarIntel product work.

Relates to #26 and hands a provider-neutral storage target to #133 consumers.