### PR TITLE
IPX: wire versioned mitmproxy spool addon

### DIFF
--- a/source/hackmode-core/capture-provider.lisp
+++ b/source/hackmode-core/capture-provider.lisp
@@ -5,6 +5,9 @@
   capture-session-id
   endpoint
   spool-id
+  spool-path
+  (addon-path "tools/ipx/mitmproxy-addon.py" :type string)
+  (format-version 1 :type integer)
   (program "mitmdump" :type string)
   arguments)
 
@@ -44,8 +47,12 @@
     (values (aref groups 0)
             (parse-integer (aref groups 1)))))
 
+(defun capture-addon-setting (name value)
+  (format nil "~a=~a" name value))
+
 (defun make-capture-process-specification (operation-id capture-session-id
-                                           endpoint spool-id program)
+                                           endpoint spool-id spool-path
+                                           addon-path format-version program)
   (multiple-value-bind (host port)
       (capture-endpoint-host-port endpoint)
     (make-capture-process-spec
@@ -53,9 +60,23 @@
      :capture-session-id (copy-seq capture-session-id)
      :endpoint (copy-seq endpoint)
      :spool-id (copy-seq spool-id)
+     :spool-path (copy-seq spool-path)
+     :addon-path (copy-seq addon-path)
+     :format-version format-version
      :program (copy-seq program)
      :arguments (list "--listen-host" host
-                      "--listen-port" (write-to-string port)))))
+                      "--listen-port" (write-to-string port)
+                      "-s" (copy-seq addon-path)
+                      "--set" (capture-addon-setting
+                               "hackmode_operation_id" operation-id)
+                      "--set" (capture-addon-setting
+                               "hackmode_capture_session_id" capture-session-id)
+                      "--set" (capture-addon-setting
+                               "hackmode_spool_id" spool-id)
+                      "--set" (capture-addon-setting
+                               "hackmode_spool_path" spool-path)
+                      "--set" (capture-addon-setting
+                               "hackmode_ipx_version" format-version)))))
 
 (defun default-capture-process-runner (spec)
   "Spawn mitmdump for SPEC without granting the subprocess persistence authority."
@@ -93,7 +114,9 @@
       service)))
 
 (defun start-capture-service (operation-id
-                              &key capture-session-id endpoint spool-id
+                              &key capture-session-id endpoint spool-id spool-path
+                                (addon-path "tools/ipx/mitmproxy-addon.py")
+                                (format-version 1)
                                 (program "mitmdump")
                                 (max-restarts 2)
                                 (runner #'default-capture-process-runner)
@@ -101,16 +124,21 @@
   "Start one operation-scoped mitmdump capture service and return typed state.
 
 RUNNER and STOPPER are injected process boundaries so lifecycle behavior can be
-tested without subprocesses. This service owns process supervision only; it has
-no Tek9, KB, or StarIntel mutation path."
+tested without subprocesses. The mitmdump addon writes append-only source
+evidence to SPOOL-PATH; it has no Tek9, KB, or StarIntel mutation path."
   (let* ((operation (capture-non-empty-string operation-id "operation-id"))
          (proxy-endpoint (capture-non-empty-string endpoint "endpoint"))
          (spool (capture-non-empty-string spool-id "spool-id"))
+         (spool-file (capture-non-empty-string (or spool-path spool-id)
+                                               "spool-path"))
+         (addon (capture-non-empty-string addon-path "addon-path"))
          (session (capture-non-empty-string
                    (or capture-session-id
                        (capture-session-identity operation proxy-endpoint spool))
                    "capture-session-id"))
          (program-name (capture-non-empty-string program "program")))
+    (unless (and (integerp format-version) (plusp format-version))
+      (error "format-version must be a positive integer."))
     (unless (and (integerp max-restarts) (not (minusp max-restarts)))
       (error "max-restarts must be a non-negative integer."))
     (check-type runner function)
@@ -121,13 +149,15 @@ no Tek9, KB, or StarIntel mutation path."
              :capture-session-id session
              :endpoint proxy-endpoint
              :spool-id spool
+             :version format-version
              :state :stopped
              :max-restarts max-restarts
              :runner runner
              :stopper stopper
              :process-spec
              (make-capture-process-specification
-              operation session proxy-endpoint spool program-name))))
+              operation session proxy-endpoint spool spool-file addon
+              format-version program-name))))
       (launch-capture-process service))))
 
 (defun note-capture-process-exit (service &key exit-code)

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -201,6 +201,7 @@
    :capture-process-spec-capture-session-id
    :capture-process-spec-endpoint
    :capture-process-spec-spool-id
+   :capture-process-spec-spool-path
    :capture-process-spec-program
    :capture-process-spec-arguments
    :capture-service

--- a/source/hackmode-core/tests/capture-provider.lisp
+++ b/source/hackmode-core/tests/capture-provider.lisp
@@ -19,6 +19,7 @@
                 :capture-session-id "capture-135"
                 :endpoint "http://127.0.0.1:18080"
                 :spool-id "spool-135"
+                :spool-path "/tmp/op-135.ipx.jsonl"
                 :max-restarts 1
                 :runner #'runner
                 :stopper #'stopper))
@@ -76,10 +77,19 @@
           (assert-equal "capture-135"
                         (hackmode:capture-process-spec-capture-session-id spec)
                         "process spec capture session")
+          (assert-equal "/tmp/op-135.ipx.jsonl"
+                        (hackmode:capture-process-spec-spool-path spec)
+                        "process spec spool path")
           (assert-equal '("--listen-host" "127.0.0.1"
-                          "--listen-port" "18080")
+                          "--listen-port" "18080"
+                          "-s" "tools/ipx/mitmproxy-addon.py"
+                          "--set" "hackmode_operation_id=op-135"
+                          "--set" "hackmode_capture_session_id=capture-135"
+                          "--set" "hackmode_spool_id=spool-135"
+                          "--set" "hackmode_spool_path=/tmp/op-135.ipx.jsonl"
+                          "--set" "hackmode_ipx_version=1")
                         (hackmode:capture-process-spec-arguments spec)
-                        "mitmdump listen arguments"))))
+                        "mitmdump IPX addon arguments"))))
 
     (let ((exhaust-launches 0))
       (flet ((runner (spec)

--- a/tools/ipx/mitmproxy-addon.py
+++ b/tools/ipx/mitmproxy-addon.py
@@ -1,0 +1,111 @@
+"""Lossless operation-scoped HTTP evidence writer for mitmproxy.
+
+This addon has one job: append versioned source-evidence records to the configured
+IPX spool. It intentionally has no database, KB, or remote-ingest authority.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from typing import Any
+
+from mitmproxy import ctx, http
+
+SCHEMA = "hackmode-ipx-http"
+
+
+def _b64(value: bytes | None) -> str:
+    return base64.b64encode(value or b"").decode("ascii")
+
+
+def _raw_headers(headers: http.Headers) -> list[list[str]]:
+    return [[_b64(name), _b64(value)] for name, value in headers.fields]
+
+
+def _connection_metadata(flow: http.HTTPFlow) -> dict[str, Any]:
+    server = flow.server_conn
+    client = flow.client_conn
+    return {
+        "client_peername": list(client.peername) if client.peername else None,
+        "server_address": list(server.address) if server.address else None,
+        "server_sni": server.sni,
+        "server_alpn": server.alpn.decode("ascii", "backslashreplace") if server.alpn else None,
+        "server_cipher": server.cipher,
+        "tls_version": server.tls_version,
+    }
+
+
+class IPXSpoolAddon:
+    def load(self, loader: Any) -> None:
+        loader.add_option("hackmode_operation_id", str, "", "Hackmode operation identity")
+        loader.add_option("hackmode_capture_session_id", str, "", "Hackmode capture session identity")
+        loader.add_option("hackmode_spool_id", str, "", "Hackmode spool identity")
+        loader.add_option("hackmode_spool_path", str, "", "Append-only IPX spool path")
+        loader.add_option("hackmode_ipx_version", int, 1, "IPX record format version")
+
+    def running(self) -> None:
+        required = {
+            "hackmode_operation_id": ctx.options.hackmode_operation_id,
+            "hackmode_capture_session_id": ctx.options.hackmode_capture_session_id,
+            "hackmode_spool_id": ctx.options.hackmode_spool_id,
+            "hackmode_spool_path": ctx.options.hackmode_spool_path,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise RuntimeError(f"Missing required IPX options: {', '.join(missing)}")
+        parent = os.path.dirname(os.path.abspath(ctx.options.hackmode_spool_path))
+        os.makedirs(parent, exist_ok=True)
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        request = flow.request
+        response = flow.response
+        if response is None:
+            return
+
+        session = ctx.options.hackmode_capture_session_id
+        exchange_id = hashlib.sha256(f"{session}\0{flow.id}".encode("utf-8")).hexdigest()
+        record = {
+            "schema": SCHEMA,
+            "version": ctx.options.hackmode_ipx_version,
+            "operation_id": ctx.options.hackmode_operation_id,
+            "capture_session_id": session,
+            "spool_id": ctx.options.hackmode_spool_id,
+            "exchange_id": exchange_id,
+            "correlation_id": flow.id,
+            "timestamp_start": flow.timestamp_start,
+            "timestamp_end": flow.timestamp_end,
+            "request": {
+                "method": request.method,
+                "scheme": request.scheme,
+                "host": request.host,
+                "port": request.port,
+                "path": request.path,
+                "http_version": request.http_version,
+                "headers_raw_b64": _raw_headers(request.headers),
+                "body_raw_b64": _b64(request.raw_content),
+            },
+            "response": {
+                "status_code": response.status_code,
+                "reason": response.reason,
+                "http_version": response.http_version,
+                "headers_raw_b64": _raw_headers(response.headers),
+                "body_raw_b64": _b64(response.raw_content),
+            },
+            "connection": _connection_metadata(flow),
+            "provider": {
+                "name": "mitmproxy",
+                "addon_schema": SCHEMA,
+                "addon_version": 1,
+            },
+        }
+        encoded = (json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+        path = ctx.options.hackmode_spool_path
+        with open(path, "ab", buffering=0) as spool:
+            spool.write(encoded)
+            os.fsync(spool.fileno())
+
+
+addons = [IPXSpoolAddon()]


### PR DESCRIPTION
Implements the first provider/runtime slice of #136 on top of #135.

RED-first contract: supervised capture must pass an explicit append-only IPX spool path plus stable operation/session/spool identity and record version into mitmdump. RED head `fbe7aec92b5a81d7f2c923ea2bba09f7ff5e670f` failed `common-lisp-core`; monorepo and the product-tree boundary were green.

Implementation adds the versioned mitmproxy addon and capture-process wiring. The addon writes one append-only JSONL source-evidence record per completed HTTP exchange, preserves exact observed header/body bytes as base64, includes stable operation/session/spool/correlation provenance and connection metadata, flushes each record durably, and has no Tek9, KB, Hackpert, or StarIntel write path.

Newest repository lossless-evidence invariants override stale redaction wording in #136. Derived projections may be bounded later, but this source spool does not destroy secret-bearing evidence.

Exact implementation head `989f7b114f42775d598b64d1abb2c670b1a1b102` is GREEN: core, monorepo, and agent-framework-boundary all completed successfully. No review submissions or unresolved review threads are present. Ready to merge once draft state is cleared.