### PR TITLE
Database: enforce visual evidence operation/run write scope

### DIFF
--- a/source/hackmode-database/tests/visual-evidence.lisp
+++ b/source/hackmode-database/tests/visual-evidence.lisp
@@ -44,7 +44,19 @@
                 :technology-hints '("nginx" "fixture")
                 :capture-session-id "capture-1"
                 :exchange-id "exchange-1"
-                :provenance '(:provider "visual-fixture/1"))))
+                :provenance '(:provider "visual-fixture/1")))
+         (second (hackmode-database:make-visual-evidence-record
+                  :operation-id "op-visual"
+                  :run-id "run-1"
+                  :job-id "shot-2"
+                  :asset-id "url:https://example.test/admin"
+                  :requested-url "https://example.test/admin"
+                  :final-url "https://example.test/admin"
+                  :screenshot-evidence-ref "evidence/screens/shot-2.png"
+                  :screenshot-digest "sha256:shot-2"
+                  :captured-at "2026-08-31T19:00:01Z"
+                  :duration-ms 10
+                  :provenance '(:provider "visual-fixture/1"))))
     (ensure (string= (hackmode-database:visual-evidence-record-record-id first)
                      (hackmode-database:visual-evidence-record-record-id same))
             "visual evidence replay changed stable identity")
@@ -63,15 +75,24 @@
              (tek9:open-database database)
              (hackmode-database:persist-visual-evidence-record database first)
              (hackmode-database:persist-visual-evidence-record database same)
+             (hackmode-database:persist-visual-evidence-record database second)
              (let ((records (hackmode-database:fetch-visual-evidence-records
                              database "op-visual" :run-id "run-1")))
-               (ensure (= 1 (length records))
+               (ensure (= 2 (length records))
                        "visual evidence replay duplicated canonical state")
+               (ensure (equal (mapcar #'hackmode-database:visual-evidence-record-record-id records)
+                              (sort (copy-list
+                                     (mapcar #'hackmode-database:visual-evidence-record-record-id records))
+                                    #'string<))
+                       "visual evidence records are not returned in deterministic ID order")
                (ensure (equal (tek9:node-props
                                (hackmode-database:visual-evidence-record->tek9-node first))
                               (tek9:node-props
                                (hackmode-database:visual-evidence-record->tek9-node
-                                (first records))))
+                                (find (hackmode-database:visual-evidence-record-record-id first)
+                                      records
+                                      :key #'hackmode-database:visual-evidence-record-record-id
+                                      :test #'string=))))
                        "visual evidence changed during Tek9 round-trip")
                (ensure (string=
                         (hackmode-database:visual-evidence-record-record-id first)
@@ -80,6 +101,21 @@
                           database "op-visual"
                           (hackmode-database:visual-evidence-record-record-id first))))
                        "singular visual evidence fetch lost stable identity"))
+             (handler-case
+                 (progn
+                   (hackmode-database:persist-visual-evidence-record
+                    database first
+                    :expected-operation-id "op-other")
+                   (error "cross-operation visual evidence write unexpectedly accepted"))
+               (hackmode-database:execution-graph-validation-error () t))
+             (handler-case
+                 (progn
+                   (hackmode-database:persist-visual-evidence-record
+                    database first
+                    :expected-operation-id "op-visual"
+                    :expected-run-id "run-other")
+                   (error "cross-run visual evidence write unexpectedly accepted"))
+               (hackmode-database:execution-graph-validation-error () t))
              (handler-case
                  (progn
                    (hackmode-database:persist-visual-evidence-record

--- a/source/hackmode-database/visual-evidence.lisp
+++ b/source/hackmode-database/visual-evidence.lisp
@@ -170,8 +170,27 @@
                :reason "stored visual evidence identity does not match typed identity"))
       record)))
 
-(defun persist-visual-evidence-record (database record)
-  "Persist RECORD replay-safely through the canonical Tek9 graph boundary."
+(defun persist-visual-evidence-record
+    (database record &key expected-operation-id expected-run-id)
+  "Persist RECORD replay-safely through the canonical Tek9 graph boundary.
+When EXPECTED-OPERATION-ID or EXPECTED-RUN-ID is supplied, reject records from
+another scope before any canonical write occurs."
+  (when expected-operation-id
+    (%require-string :expected-operation-id expected-operation-id)
+    (unless (string= expected-operation-id
+                     (visual-evidence-record-operation-id record))
+      (error 'execution-graph-validation-error
+             :field :operation-id
+             :value (visual-evidence-record-operation-id record)
+             :reason "visual evidence write does not match expected operation scope")))
+  (when expected-run-id
+    (%require-string :expected-run-id expected-run-id)
+    (unless (string= expected-run-id
+                     (visual-evidence-record-run-id record))
+      (error 'execution-graph-validation-error
+             :field :run-id
+             :value (visual-evidence-record-run-id record)
+             :reason "visual evidence write does not match expected run scope")))
   (persist-graph-node-replay-safe
    database
    (visual-evidence-record->tek9-node record)


### PR DESCRIPTION
Implements the remaining database-owned acceptance gap in #142.

RED-first head `ae84b06d257e2e2e8172eb7e67b4983074b5dbe5` adds deterministic multi-record ordering coverage and requires `persist-visual-evidence-record` to reject caller-declared cross-operation and cross-run writes through typed validation errors.

No provider/browser/Hackpert behavior is included. This stays inside canonical visual evidence persistence and preserves Tek9 authority.

Expected RED: current persistence API does not yet accept/validate the scoped-write keywords.