### PR TITLE
HTTP: add typed transport and browser profile policy

### DIFF
--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -22,7 +22,8 @@
                (:file "tests/expert-selection-inspection")
                (:file "tests/expert-budget-inspection")
                (:file "tests/expert-direct-candidate")
-               (:file "tests/capture-provider"))
+               (:file "tests/capture-provider")
+               (:file "tests/http-transport-profile"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
@@ -45,4 +46,6 @@
              (uiop:symbol-call :hackmode-tests :run-expert-selection-inspection-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-budget-inspection-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-direct-candidate-tests)
-             (uiop:symbol-call :hackmode-tests :run-capture-provider-tests)))
+             (uiop:symbol-call :hackmode-tests :run-capture-provider-tests)
+             (uiop:symbol-call :hackmode-http-transport-profile-tests
+                               :run-http-transport-profile-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -29,6 +29,7 @@
                (:file "actor-system")
                (:file "outbox")
                (:file "outbox-actor")
+               (:file "http-transport-profile")
                (:file "providers")
                (:file "provider-actor")
                (:file "capture-provider")

--- a/source/hackmode-core/http-transport-profile.lisp
+++ b/source/hackmode-core/http-transport-profile.lisp
@@ -29,6 +29,11 @@
   backend
   capture-mode)
 
+(defparameter *sensitive-profile-header-names*
+  '("authorization" "proxy-authorization" "cookie" "set-cookie"
+    "x-api-key" "api-key" "x-auth-token" "x-access-token")
+  "Header names forbidden from persisted HTTP profile provenance.")
+
 (defun normalize-capture-mode (mode)
   (unless (member mode '(:intercept :tunnel :direct :unsupported) :test #'eq)
     (error 'provider-transport-policy-error
@@ -120,12 +125,27 @@ stable profile ID so registry/hash ordering cannot alter replay behavior."
               :reason (format nil "capture mode ~s unsupported; provider supports ~s"
                               requested supported))))))
 
+(defun profile-header-name (entry)
+  (etypecase entry
+    (cons (car entry))
+    (string entry)))
+
+(defun sensitive-profile-header-p (entry)
+  (member (string-downcase (string (profile-header-name entry)))
+          *sensitive-profile-header-names*
+          :test #'string=))
+
+(defun safe-profile-headers (headers)
+  "Copy static profile headers while dropping credential-bearing names."
+  (loop for entry in headers
+        unless (sensitive-profile-header-p entry)
+          collect (copy-tree entry)))
+
 (defun http-client-profile-provenance (profile)
   "Return the safe immutable profile snapshot suitable for execution evidence.
 
-Only typed profile metadata is projected. Runtime headers carrying credentials,
-cookies, authorization values, API keys, or other request secrets are never an
-input to this function and therefore cannot leak into the snapshot."
+Credential-bearing header names are filtered even if a caller accidentally puts
+one into the static profile. Runtime request headers are not accepted here."
   (validate-http-client-profile profile)
   (list :profile-id (http-client-profile-id profile)
         :profile-version (http-client-profile-version profile)
@@ -135,8 +155,10 @@ input to this function and therefore cannot leak into the snapshot."
         :accept (http-client-profile-accept profile)
         :accept-language (http-client-profile-accept-language profile)
         :accept-encoding (http-client-profile-accept-encoding profile)
-        :fetch-headers (copy-tree (http-client-profile-fetch-headers profile))
-        :client-hints (copy-tree (http-client-profile-client-hints profile))
+        :fetch-headers (safe-profile-headers
+                        (http-client-profile-fetch-headers profile))
+        :client-hints (safe-profile-headers
+                       (http-client-profile-client-hints profile))
         :http-protocol (http-client-profile-http-protocol profile)
         :backend (http-client-profile-backend profile)
         :capture-mode (http-client-profile-capture-mode profile)))

--- a/source/hackmode-core/http-transport-profile.lisp
+++ b/source/hackmode-core/http-transport-profile.lisp
@@ -1,0 +1,142 @@
+(in-package :hackmode)
+
+(define-condition provider-transport-policy-error (error)
+  ((reason :initarg :reason :reader provider-transport-policy-error-reason))
+  (:report (lambda (condition stream)
+             (format stream "Provider transport policy rejected execution: ~a"
+                     (provider-transport-policy-error-reason condition)))))
+
+(defstruct provider-transport-support
+  (http-proxy-p nil :type boolean)
+  (https-proxy-p nil :type boolean)
+  (socks-p nil :type boolean)
+  (browser-cdp-p nil :type boolean)
+  (direct-only-p nil :type boolean)
+  (capture-modes '(:unsupported) :type list))
+
+(defstruct http-client-profile
+  id
+  version
+  browser-family
+  browser-version
+  user-agent
+  accept
+  accept-language
+  accept-encoding
+  fetch-headers
+  client-hints
+  http-protocol
+  backend
+  capture-mode)
+
+(defun normalize-capture-mode (mode)
+  (unless (member mode '(:intercept :tunnel :direct :unsupported) :test #'eq)
+    (error 'provider-transport-policy-error
+           :reason (format nil "unknown capture mode ~s" mode)))
+  mode)
+
+(defun validate-provider-transport-support (support)
+  (check-type support provider-transport-support)
+  (let ((modes (provider-transport-support-capture-modes support)))
+    (unless modes
+      (error 'provider-transport-policy-error
+             :reason "provider declares no capture modes"))
+    (dolist (mode modes)
+      (normalize-capture-mode mode))
+    (when (and (provider-transport-support-direct-only-p support)
+               (or (provider-transport-support-http-proxy-p support)
+                   (provider-transport-support-https-proxy-p support)
+                   (provider-transport-support-socks-p support)
+                   (provider-transport-support-browser-cdp-p support)))
+      (error 'provider-transport-policy-error
+             :reason "direct-only provider also declares mediated transport"))
+    support))
+
+(defun http-client-profile-coherent-p (profile)
+  "Return true when PROFILE is internally coherent enough for reproducible use.
+
+This intentionally validates semantic consistency rather than pretending a
+User-Agent string can model TLS/browser fingerprint behavior. Provider backends
+remain responsible for implementing the declared backend/profile faithfully."
+  (and (typep profile 'http-client-profile)
+       (stringp (http-client-profile-id profile))
+       (plusp (length (http-client-profile-id profile)))
+       (stringp (http-client-profile-version profile))
+       (plusp (length (http-client-profile-version profile)))
+       (member (http-client-profile-http-protocol profile)
+               '(:http1 :http2 :http3 :backend-default)
+               :test #'eq)
+       (member (http-client-profile-capture-mode profile)
+               '(:intercept :tunnel :direct)
+               :test #'eq)
+       (or (not (eq :browser (http-client-profile-backend profile)))
+           (and (http-client-profile-browser-family profile)
+                (stringp (http-client-profile-browser-version profile))
+                (stringp (http-client-profile-user-agent profile))))))
+
+(defun validate-http-client-profile (profile)
+  (unless (http-client-profile-coherent-p profile)
+    (error 'provider-transport-policy-error
+           :reason (format nil "incoherent HTTP client profile ~s"
+                           (and (typep profile 'http-client-profile)
+                                (http-client-profile-id profile)))))
+  profile)
+
+(defun select-http-client-profile (profiles &key profile-id)
+  "Select one reproducible profile.
+
+Explicit PROFILE-ID is authoritative. Without it, choose lexicographically by
+stable profile ID so registry/hash ordering cannot alter replay behavior."
+  (let ((validated (mapcar #'validate-http-client-profile profiles)))
+    (or (when profile-id
+          (find profile-id validated
+                :key #'http-client-profile-id
+                :test #'string=))
+        (when (null profile-id)
+          (first (sort (copy-list validated) #'string<
+                       :key #'http-client-profile-id)))
+        (error 'provider-transport-policy-error
+               :reason (format nil "unknown HTTP client profile ~s" profile-id)))))
+
+(defun resolve-provider-capture-mode (support requested-mode
+                                      &key capture-required-p)
+  "Resolve REQUESTED-MODE against typed SUPPORT without silent downgrade."
+  (validate-provider-transport-support support)
+  (let* ((requested (normalize-capture-mode requested-mode))
+         (supported (provider-transport-support-capture-modes support)))
+    (cond
+      ((member requested supported :test #'eq)
+       requested)
+      (capture-required-p
+       (error 'provider-transport-policy-error
+              :reason (format nil "required capture mode ~s unsupported; provider supports ~s"
+                              requested supported)))
+      ((member :direct supported :test #'eq)
+       :direct)
+      ((member :unsupported supported :test #'eq)
+       :unsupported)
+      (t
+       (error 'provider-transport-policy-error
+              :reason (format nil "capture mode ~s unsupported; provider supports ~s"
+                              requested supported))))))
+
+(defun http-client-profile-provenance (profile)
+  "Return the safe immutable profile snapshot suitable for execution evidence.
+
+Only typed profile metadata is projected. Runtime headers carrying credentials,
+cookies, authorization values, API keys, or other request secrets are never an
+input to this function and therefore cannot leak into the snapshot."
+  (validate-http-client-profile profile)
+  (list :profile-id (http-client-profile-id profile)
+        :profile-version (http-client-profile-version profile)
+        :browser-family (http-client-profile-browser-family profile)
+        :browser-version (http-client-profile-browser-version profile)
+        :user-agent (http-client-profile-user-agent profile)
+        :accept (http-client-profile-accept profile)
+        :accept-language (http-client-profile-accept-language profile)
+        :accept-encoding (http-client-profile-accept-encoding profile)
+        :fetch-headers (copy-tree (http-client-profile-fetch-headers profile))
+        :client-hints (copy-tree (http-client-profile-client-hints profile))
+        :http-protocol (http-client-profile-http-protocol profile)
+        :backend (http-client-profile-backend profile)
+        :capture-mode (http-client-profile-capture-mode profile)))

--- a/source/hackmode-core/tests/http-transport-profile.lisp
+++ b/source/hackmode-core/tests/http-transport-profile.lisp
@@ -1,0 +1,62 @@
+(defpackage :hackmode-http-transport-profile-tests
+  (:use :cl))
+
+(in-package :hackmode-http-transport-profile-tests)
+
+(defun check (condition format-control &rest format-arguments)
+  (unless condition
+    (error (apply #'format nil format-control format-arguments))))
+
+(defun run-http-transport-profile-tests ()
+  (let* ((profile-a
+           (hackmode::make-http-client-profile
+            :id "firefox-linux"
+            :version "1"
+            :browser-family :firefox
+            :browser-version "142"
+            :user-agent "Mozilla/5.0 Firefox/142.0"
+            :accept "text/html,application/xhtml+xml"
+            :accept-language "en-US,en;q=0.5"
+            :accept-encoding "gzip, deflate, br"
+            :http-protocol :http2
+            :backend :browser
+            :capture-mode :intercept))
+         (profile-b
+           (hackmode::select-http-client-profile
+            (list profile-a)
+            :profile-id "firefox-linux"))
+         (http-support
+           (hackmode::make-provider-transport-support
+            :http-proxy-p t
+            :https-proxy-p t
+            :capture-modes '(:intercept :tunnel :direct)))
+         (dns-support
+           (hackmode::make-provider-transport-support
+            :direct-only-p t
+            :capture-modes '(:unsupported))))
+    (check (eq profile-a profile-b)
+           "Explicit profile selection must be deterministic.")
+    (check (hackmode::http-client-profile-coherent-p profile-a)
+           "Fixture browser profile must be coherent.")
+    (check (eq :intercept
+               (hackmode::resolve-provider-capture-mode
+                http-support :intercept :capture-required-p t))
+           "HTTP provider must accept supported required capture mode.")
+    (handler-case
+        (progn
+          (hackmode::resolve-provider-capture-mode
+           dns-support :intercept :capture-required-p t)
+          (error "Required capture unexpectedly downgraded for direct-only provider."))
+      (hackmode::provider-transport-policy-error () t))
+    (check (eq :unsupported
+               (hackmode::resolve-provider-capture-mode
+                dns-support :unsupported :capture-required-p nil))
+           "Protocol-inapplicable provider must remain explicitly unsupported.")
+    (let ((snapshot (hackmode::http-client-profile-provenance profile-a)))
+      (check (string= "firefox-linux" (getf snapshot :profile-id))
+             "Profile provenance must retain stable profile identity.")
+      (check (eq :browser (getf snapshot :backend))
+             "Profile provenance must retain backend identity.")
+      (check (eq :intercept (getf snapshot :capture-mode))
+             "Profile provenance must retain actual capture mode."))
+    t))

--- a/source/hackmode-core/tests/http-transport-profile.lisp
+++ b/source/hackmode-core/tests/http-transport-profile.lisp
@@ -18,9 +18,22 @@
             :accept "text/html,application/xhtml+xml"
             :accept-language "en-US,en;q=0.5"
             :accept-encoding "gzip, deflate, br"
+            :fetch-headers '(("Sec-Fetch-Site" . "none")
+                             ("Authorization" . "secret-must-not-persist"))
+            :client-hints '(("Sec-CH-UA-Mobile" . "?0"))
             :http-protocol :http2
             :backend :browser
             :capture-mode :intercept))
+         (profile-z
+           (hackmode::make-http-client-profile
+            :id "z-profile"
+            :version "1"
+            :browser-family :firefox
+            :browser-version "142"
+            :user-agent "Mozilla/5.0 Firefox/142.0"
+            :http-protocol :http2
+            :backend :browser
+            :capture-mode :direct))
          (profile-b
            (hackmode::select-http-client-profile
             (list profile-a)
@@ -36,6 +49,10 @@
             :capture-modes '(:unsupported))))
     (check (eq profile-a profile-b)
            "Explicit profile selection must be deterministic.")
+    (check (eq profile-a
+               (hackmode::select-http-client-profile
+                (list profile-z profile-a)))
+           "Default profile selection must not depend on registry ordering.")
     (check (hackmode::http-client-profile-coherent-p profile-a)
            "Fixture browser profile must be coherent.")
     (check (eq :intercept
@@ -52,11 +69,16 @@
                (hackmode::resolve-provider-capture-mode
                 dns-support :unsupported :capture-required-p nil))
            "Protocol-inapplicable provider must remain explicitly unsupported.")
-    (let ((snapshot (hackmode::http-client-profile-provenance profile-a)))
+    (let* ((snapshot (hackmode::http-client-profile-provenance profile-a))
+           (headers (getf snapshot :fetch-headers)))
       (check (string= "firefox-linux" (getf snapshot :profile-id))
              "Profile provenance must retain stable profile identity.")
       (check (eq :browser (getf snapshot :backend))
              "Profile provenance must retain backend identity.")
       (check (eq :intercept (getf snapshot :capture-mode))
-             "Profile provenance must retain actual capture mode."))
+             "Profile provenance must retain actual capture mode.")
+      (check (assoc "Sec-Fetch-Site" headers :test #'string=)
+             "Safe static fetch metadata must remain in provenance.")
+      (check (null (assoc "Authorization" headers :test #'string-equal))
+             "Credential-bearing headers must not enter profile provenance."))
     t))


### PR DESCRIPTION
Closes #137.

RED-first provider/runtime slice for typed transport support and reproducible coherent HTTP/browser client profiles.

RED evidence: exact head `9851c439f18e602a434e1b6c2a75a25a24de30b7` recorded `core` failure while `monorepo` and `agent-framework-boundary` were green, proving the missing transport/profile policy boundary before implementation.

Implementation adds typed provider transport support, explicit capture-mode resolution without silent downgrade, deterministic profile selection, coherence validation, and safe profile provenance that excludes runtime request secrets. The core system loads this policy before provider registration.

Fence: provider/runtime policy only; no database internals, no Hackpert selection policy, no StarIntel product work.