### PR TITLE
Visual evidence: project accepted records through durable outbox

### DIFF
--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -23,7 +23,8 @@
                (:file "tests/expert-budget-inspection")
                (:file "tests/expert-direct-candidate")
                (:file "tests/capture-provider")
-               (:file "tests/http-transport-profile"))
+               (:file "tests/http-transport-profile")
+               (:file "tests/visual-evidence-outbox"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
@@ -48,4 +49,6 @@
              (uiop:symbol-call :hackmode-tests :run-expert-direct-candidate-tests)
              (uiop:symbol-call :hackmode-tests :run-capture-provider-tests)
              (uiop:symbol-call :hackmode-http-transport-profile-tests
-                               :run-http-transport-profile-tests)))
+                               :run-http-transport-profile-tests)
+             (uiop:symbol-call :hackmode-visual-evidence-outbox-tests
+                               :run-visual-evidence-outbox-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -28,6 +28,7 @@
                (:file "starintel-documents")
                (:file "actor-system")
                (:file "outbox")
+               (:file "visual-evidence-outbox")
                (:file "outbox-actor")
                (:file "http-transport-profile")
                (:file "providers")

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -176,6 +176,8 @@
    :outbox-payload-id
    :enqueue-starintel-json
    :enqueue-asset-for-starintel
+   :visual-evidence->starintel-json
+   :enqueue-visual-evidence-for-starintel
    :fetch-outbox-entry
    :list-outbox-entries
    :outbox-backoff-seconds

--- a/source/hackmode-core/tests/visual-evidence-outbox.lisp
+++ b/source/hackmode-core/tests/visual-evidence-outbox.lisp
@@ -1,0 +1,103 @@
+(defpackage :hackmode-visual-evidence-outbox-tests
+  (:use :cl))
+
+(in-package :hackmode-visual-evidence-outbox-tests)
+
+(defun fresh-test-path ()
+  (merge-pathnames
+   (format nil "hackmode-visual-outbox-~a/" (tek9:make-key-id))
+   (uiop:temporary-directory)))
+
+(defun remove-test-path (path)
+  (ignore-errors
+    (uiop:delete-directory-tree path :validate t :if-does-not-exist :ignore)))
+
+(defun fixture-record ()
+  (hackmode-database:make-visual-evidence-record
+   :operation-id "op-visual"
+   :run-id "run-1"
+   :job-id "shot-1"
+   :asset-id "asset-url-1"
+   :requested-url "https://example.test/start"
+   :final-url "https://example.test/final"
+   :screenshot-evidence-ref "evidence://screens/shot-1.png"
+   :screenshot-digest "sha256:abc123"
+   :captured-at "2026-08-31T23:30:00Z"
+   :title "Example"
+   :http-status 200
+   :viewport '(:width 1440 :height 900)
+   :client-profile-id "chrome-140-linux"
+   :browser-id "chromium"
+   :browser-version "140.0"
+   :duration-ms 125
+   :body-digest "sha256:def456"
+   :technology-hints '("nginx" "h2")
+   :capture-session-id "capture-1"
+   :exchange-id "exchange-9"
+   :provenance '(:producer "browser-worker"
+                 :authorization "Bearer secret-must-not-project"
+                 :cookie "sid=secret-must-not-project")))
+
+(defun run-visual-evidence-outbox-tests ()
+  (let* ((root (fresh-test-path))
+         (db (tek9:new-database "operation" :path root))
+         (record (fixture-record)))
+    (unwind-protect
+         (progn
+           (tek9:open-database db)
+           ;; Local canonical evidence is persisted before remote projection.
+           (hackmode-database:persist-visual-evidence-record db record)
+           (assert
+            (hackmode-database:fetch-visual-evidence-record
+             db "op-visual"
+             (hackmode-database:visual-evidence-record-record-id record)))
+
+           ;; Projection is deterministic, bounded, and excludes raw secret-bearing provenance.
+           (let* ((json (hackmode:visual-evidence->starintel-json record))
+                  (json-again (hackmode:visual-evidence->starintel-json record))
+                  (wire (jsown:to-json json)))
+             (assert (string= (jsown:to-json json) (jsown:to-json json-again)))
+             (assert (string= "document" (jsown:val json "dtype")))
+             (assert (search "sha256:abc123" wire))
+             (assert (search "evidence://screens/shot-1.png" wire))
+             (assert (search "exchange-9" wire))
+             (assert (not (search "Bearer secret-must-not-project" wire)))
+             (assert (not (search "sid=secret-must-not-project" wire))))
+
+           ;; Repeated enqueue collapses onto one durable logical outbox record.
+           (multiple-value-bind (entry created-p)
+               (hackmode:enqueue-visual-evidence-for-starintel record :database db :now 1000)
+             (assert created-p)
+             (multiple-value-bind (same duplicate-created-p)
+                 (hackmode:enqueue-visual-evidence-for-starintel record :database db :now 1001)
+               (assert (not duplicate-created-p))
+               (assert (string= (hackmode:outbox-entry-id entry)
+                                (hackmode:outbox-entry-id same))))
+
+             ;; Publish/transport failure leaves local evidence intact and the projection retryable.
+             (hackmode:process-outbox-entry
+              db entry
+              (lambda (ignored)
+                (declare (ignore ignored))
+                (error 'hackmode:outbox-transport-error :message "offline"))
+              :now 1002)
+             (assert (eq :retry (hackmode:outbox-entry-state entry)))
+             (assert
+              (hackmode-database:fetch-visual-evidence-record
+               db "op-visual"
+               (hackmode-database:visual-evidence-record-record-id record)))
+
+             ;; Only an accepted response acknowledges delivery.
+             (hackmode:process-outbox-entry
+              db entry
+              (lambda (ignored)
+                (declare (ignore ignored))
+                (values 202 "accepted"))
+              :now (hackmode:outbox-entry-next-attempt-at entry))
+             (assert (eq :acknowledged (hackmode:outbox-entry-state entry)))
+             (assert (eq :ingest-accepted (hackmode:outbox-entry-ack-kind entry)))
+             (assert (= 1 (length (hackmode:list-outbox-entries db))))))
+      (when (tek9:db-is-open-p db)
+        (tek9:close-database db))
+      (remove-test-path root)))
+  t)

--- a/source/hackmode-core/visual-evidence-outbox.lisp
+++ b/source/hackmode-core/visual-evidence-outbox.lisp
@@ -1,0 +1,100 @@
+(in-package :hackmode)
+
+(defparameter +visual-evidence-starintel-id-version+
+  "hackmode-visual-evidence-starintel-v1")
+
+(defun %visual-evidence-starintel-id (record)
+  (starintel:digest-id
+   +visual-evidence-starintel-id-version+
+   (hackmode-database:visual-evidence-record-operation-id record)
+   (hackmode-database:visual-evidence-record-record-id record)))
+
+(defun %set-json-field (object key value)
+  (when value
+    (setf (jsown:val object key) value))
+  object)
+
+(defun visual-evidence->starintel-json (record &key (dataset *starintel-dataset*))
+  "Project accepted local visual evidence into a deterministic StarIntel document.
+
+Only typed visual-recon fields are projected. RECORD's free-form provenance is
+intentionally excluded so secret-bearing provider metadata remains local."
+  (let ((data (jsown:empty-object))
+        (provenance (jsown:empty-object)))
+    (%set-json-field data "asset_id"
+                     (hackmode-database:visual-evidence-record-asset-id record))
+    (%set-json-field data "requested_url"
+                     (hackmode-database:visual-evidence-record-requested-url record))
+    (%set-json-field data "final_url"
+                     (hackmode-database:visual-evidence-record-final-url record))
+    (%set-json-field data "screenshot_evidence_ref"
+                     (hackmode-database:visual-evidence-record-screenshot-evidence-ref record))
+    (%set-json-field data "screenshot_digest"
+                     (hackmode-database:visual-evidence-record-screenshot-digest record))
+    (%set-json-field data "captured_at"
+                     (hackmode-database:visual-evidence-record-captured-at record))
+    (%set-json-field data "title"
+                     (hackmode-database:visual-evidence-record-title record))
+    (%set-json-field data "http_status"
+                     (hackmode-database:visual-evidence-record-http-status record))
+    (%set-json-field data "viewport"
+                     (hackmode-database:visual-evidence-record-viewport record))
+    (%set-json-field data "client_profile_id"
+                     (hackmode-database:visual-evidence-record-client-profile-id record))
+    (%set-json-field data "browser_id"
+                     (hackmode-database:visual-evidence-record-browser-id record))
+    (%set-json-field data "browser_version"
+                     (hackmode-database:visual-evidence-record-browser-version record))
+    (%set-json-field data "duration_ms"
+                     (hackmode-database:visual-evidence-record-duration-ms record))
+    (%set-json-field data "body_digest"
+                     (hackmode-database:visual-evidence-record-body-digest record))
+    (%set-json-field data "technology_hints"
+                     (copy-list
+                      (hackmode-database:visual-evidence-record-technology-hints record)))
+    (%set-json-field data "capture_session_id"
+                     (hackmode-database:visual-evidence-record-capture-session-id record))
+    (%set-json-field data "exchange_id"
+                     (hackmode-database:visual-evidence-record-exchange-id record))
+    (%set-json-field data "failure_classification"
+                     (hackmode-database:visual-evidence-record-failure-classification record))
+
+    (%set-json-field provenance "operation"
+                     (hackmode-database:visual-evidence-record-operation-id record))
+    (%set-json-field provenance "run_id"
+                     (hackmode-database:visual-evidence-record-run-id record))
+    (%set-json-field provenance "job_id"
+                     (hackmode-database:visual-evidence-record-job-id record))
+    (%set-json-field provenance "local_record_id"
+                     (hackmode-database:visual-evidence-record-record-id record))
+    (%set-json-field provenance "producer" "hackmode-visual-recon")
+
+    (starintel:encode
+     (make-instance
+      'starintel:document
+      :id (%visual-evidence-starintel-id record)
+      :dataset dataset
+      :date-added (hackmode-database:visual-evidence-record-captured-at record)
+      :date-updated (hackmode-database:visual-evidence-record-captured-at record)
+      :title (or (hackmode-database:visual-evidence-record-title record) "")
+      :tags '("visual-recon" "cyber-evidence")
+      :related-ids
+      (remove nil
+              (list
+               (hackmode-database:visual-evidence-record-asset-id record)
+               (hackmode-database:visual-evidence-record-exchange-id record)
+               (hackmode-database:visual-evidence-record-capture-session-id record)))
+      :provenance provenance
+      :data data))))
+
+(defun enqueue-visual-evidence-for-starintel
+    (record &key (database *db*) (now (unix-now)))
+  "Durably queue RECORD for StarIntel ingest through the canonical outbox.
+
+This function does not transmit directly. Repeated projection of the same typed
+record collapses to the existing deterministic outbox entry."
+  (enqueue-starintel-json
+   database
+   (visual-evidence->starintel-json record)
+   :operation (hackmode-database:visual-evidence-record-operation-id record)
+   :now now))


### PR DESCRIPTION
Closes #143.

Implements the Hackmode-side visual-evidence projection into the existing durable StarIntel outbox. Local visual evidence remains canonical and usable offline; projection carries deterministic observation identity, screenshot ref/digest, URL/status/timing/browser/profile/capture/exchange metadata, and selected operation/run/job provenance while intentionally excluding free-form secret-bearing provider provenance.

Repeated projection is idempotent through the existing deterministic outbox ID. Transport outage remains retryable, and only an accepted 2xx response moves the existing outbox entry to `:acknowledged` / `:ingest-accepted`.

RED-first contract was committed before implementation. Exact code head: `23c34e097e3b6e9d62bed76698c33ef9b7f62af3`.

PR #160 carried the same head and passed core, monorepo, and agent-framework-boundary, but was closed because the connector's ready-for-review mutation is broken. This normal PR must receive fresh exact-head checks before merge.

No StarIntel product repository changes and no BrowserWorker direct persistence.