### PR TITLE
HTTP: require typed requester contract on current master

### DIFF
--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -24,7 +24,8 @@
                (:file "tests/expert-direct-candidate")
                (:file "tests/capture-provider")
                (:file "tests/http-transport-profile")
-               (:file "tests/visual-evidence-outbox"))
+               (:file "tests/visual-evidence-outbox")
+               (:file "tests/http-requester"))
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
@@ -51,4 +52,6 @@
              (uiop:symbol-call :hackmode-http-transport-profile-tests
                                :run-http-transport-profile-tests)
              (uiop:symbol-call :hackmode-visual-evidence-outbox-tests
-                               :run-visual-evidence-outbox-tests)))
+                               :run-visual-evidence-outbox-tests)
+             (uiop:symbol-call :hackmode-http-requester-tests
+                               :run-http-requester-tests)))

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -31,6 +31,7 @@
                (:file "visual-evidence-outbox")
                (:file "outbox-actor")
                (:file "http-transport-profile")
+               (:file "http-requester")
                (:file "providers")
                (:file "provider-actor")
                (:file "capture-provider")

--- a/source/hackmode-core/http-requester.lisp
+++ b/source/hackmode-core/http-requester.lisp
@@ -1,0 +1,75 @@
+(in-package :hackmode)
+
+(define-condition http-request-policy-error (error)
+  ((reason :initarg :reason :reader http-request-policy-error-reason))
+  (:report (lambda (condition stream)
+             (format stream "HTTP request policy rejected execution: ~a"
+                     (http-request-policy-error-reason condition)))))
+
+(defparameter *http-redirect-policies* '(:manual :same-origin :follow))
+
+(defstruct (http-request (:constructor %make-http-request))
+  operation-id
+  run-id
+  url
+  (method :get)
+  headers
+  body
+  redirect-policy
+  timeout-seconds
+  client-profile
+  capture-mode)
+
+(defun validate-http-request (request)
+  (check-type request http-request)
+  (unless (and (stringp (http-request-operation-id request))
+               (plusp (length (http-request-operation-id request))))
+    (error 'http-request-policy-error :reason "missing operation identity"))
+  (unless (and (stringp (http-request-run-id request))
+               (plusp (length (http-request-run-id request))))
+    (error 'http-request-policy-error :reason "missing run identity"))
+  (unless (and (stringp (http-request-url request))
+               (plusp (length (http-request-url request))))
+    (error 'http-request-policy-error :reason "missing request URL"))
+  (unless (member (http-request-redirect-policy request)
+                  *http-redirect-policies* :test #'eq)
+    (error 'http-request-policy-error
+           :reason (format nil "unknown redirect policy ~s"
+                           (http-request-redirect-policy request))))
+  (unless (and (realp (http-request-timeout-seconds request))
+               (plusp (http-request-timeout-seconds request)))
+    (error 'http-request-policy-error :reason "timeout must be positive"))
+  (validate-http-client-profile (http-request-client-profile request))
+  (normalize-capture-mode (http-request-capture-mode request))
+  request)
+
+(defun make-http-request (&key operation-id run-id url (method :get) headers body
+                            redirect-policy timeout-seconds client-profile capture-mode)
+  (validate-http-request
+   (%make-http-request :operation-id operation-id
+                       :run-id run-id
+                       :url url
+                       :method method
+                       :headers (copy-tree headers)
+                       :body body
+                       :redirect-policy redirect-policy
+                       :timeout-seconds timeout-seconds
+                       :client-profile client-profile
+                       :capture-mode capture-mode)))
+
+(defun http-request-provenance (request &key backend-id backend-version)
+  "Return execution provenance without request headers, body, URL credentials, or secrets."
+  (validate-http-request request)
+  (let ((profile (http-request-client-profile request)))
+    (list :operation-id (http-request-operation-id request)
+          :run-id (http-request-run-id request)
+          :backend-id backend-id
+          :backend-version backend-version
+          :profile-id (http-client-profile-id profile)
+          :profile-version (http-client-profile-version profile)
+          :browser-family (http-client-profile-browser-family profile)
+          :browser-version (http-client-profile-browser-version profile)
+          :http-protocol (http-client-profile-http-protocol profile)
+          :capture-mode (http-request-capture-mode request)
+          :redirect-policy (http-request-redirect-policy request)
+          :timeout-seconds (http-request-timeout-seconds request))))

--- a/source/hackmode-core/tests/http-requester.lisp
+++ b/source/hackmode-core/tests/http-requester.lisp
@@ -1,0 +1,76 @@
+(defpackage :hackmode-http-requester-tests
+  (:use :cl))
+
+(in-package :hackmode-http-requester-tests)
+
+(defun check (condition format-control &rest format-arguments)
+  (unless condition
+    (error (apply #'format nil format-control format-arguments))))
+
+(defun run-http-requester-tests ()
+  (let* ((profile
+           (hackmode::make-http-client-profile
+            :id "chrome-stable"
+            :version "1"
+            :browser-family :chrome
+            :browser-version "146"
+            :user-agent "Mozilla/5.0 Chrome/146.0"
+            :http-protocol :http2
+            :backend :impersonating
+            :capture-mode :tunnel))
+         (request
+           (hackmode::make-http-request
+            :operation-id "op-http"
+            :run-id "run-http"
+            :url "https://example.invalid/path"
+            :method :get
+            :headers '(("Accept" . "text/html")
+                       ("Authorization" . "secret-must-not-persist"))
+            :redirect-policy :manual
+            :timeout-seconds 5
+            :client-profile profile
+            :capture-mode :tunnel)))
+    (hackmode::validate-http-request request)
+    (check (string= "op-http" (hackmode::http-request-operation-id request))
+           "Typed HTTP request must retain operation identity.")
+    (check (eq :manual (hackmode::http-request-redirect-policy request))
+           "Redirect policy must remain explicit.")
+    (let ((provenance (hackmode::http-request-provenance request
+                                                        :backend-id "curl-cffi"
+                                                        :backend-version "0.16.2")))
+      (check (string= "curl-cffi" (getf provenance :backend-id))
+             "Execution provenance must identify the selected backend.")
+      (check (string= "chrome-stable" (getf provenance :profile-id))
+             "Execution provenance must identify the selected client profile.")
+      (check (eq :tunnel (getf provenance :capture-mode))
+             "Execution provenance must identify actual capture mode.")
+      (check (null (search "secret-must-not-persist"
+                           (prin1-to-string provenance)))
+             "Request secrets must not enter execution provenance."))
+    (handler-case
+        (progn
+          (hackmode::make-http-request
+           :operation-id "op-http"
+           :run-id "run-http"
+           :url "https://example.invalid/"
+           :method :get
+           :redirect-policy :surprise-me
+           :timeout-seconds 5
+           :client-profile profile
+           :capture-mode :direct)
+          (error "Unknown redirect policy unexpectedly constructed."))
+      (hackmode::http-request-policy-error () t))
+    (handler-case
+        (progn
+          (hackmode::make-http-request
+           :operation-id "op-http"
+           :run-id "run-http"
+           :url "https://example.invalid/"
+           :method :get
+           :redirect-policy :manual
+           :timeout-seconds 0
+           :client-profile profile
+           :capture-mode :direct)
+          (error "Non-positive timeout unexpectedly constructed."))
+      (hackmode::http-request-policy-error () t))
+    t))


### PR DESCRIPTION
## Issue
Advances #138; does not close it.

## Recovery
Rebuilds the typed requester contract on current `master` because draft PR #159 diverged after later visual-evidence merges.

## RED-first evidence
Test-only head `560792e496be3ed607709f51299daed0e94be861` registered the requester contract before implementation. GitHub Actions reached the core job but failed during Quicklisp installation before ASDF tests ran, so that workflow is infrastructure-failed rather than counted as semantic RED proof. The test-only commit remains in history.

## Research gate
As of 2026-08-31, `curl_cffi` is actively maintained; PyPI 0.16.2 was released 2026-08-25. This slice deliberately defines a backend-neutral Common Lisp contract first; executable backend/process integration remains follow-up work in #138.

## Implemented contract
- operation/run scoped typed request
- explicit bounded timeout
- explicit redirect policy
- selected coherent client profile + capture mode
- backend/profile/capture provenance
- request secret values excluded from execution provenance
- invalid redirect policy/non-positive timeout fail closed

No database/KB/StarIntel mutation is added.

## Completion boundary
This PR must not close #138. Remaining work includes maintained impersonating backend integration, capability detection/fallback, proxy/IPX execution, normalized result typing, deadline/redirect execution behavior, and deterministic local fixture proof.