### PR TITLE
Hackpert: harden objective identity snapshots

### DIFF
--- a/source/hackmode-core/expert/objective.lisp
+++ b/source/hackmode-core/expert/objective.lisp
@@ -61,12 +61,23 @@ never interpreted as executable Prolog source by this layer."
 
 (defstruct (expert-objective
              (:constructor %make-expert-objective
-                 (&key id version raw-clauses raw-limits raw-granted-capabilities)))
+                 (&key id version raw-clauses raw-limits raw-granted-capabilities))
+             (:conc-name %expert-objective-))
   (id nil :read-only t)
   (version nil :read-only t)
   (raw-clauses nil :read-only t)
   (raw-limits nil :read-only t)
   (raw-granted-capabilities nil :read-only t))
+
+(defun expert-objective-id (objective)
+  "Return an independently mutable snapshot of OBJECTIVE's stable identity."
+  (check-type objective expert-objective)
+  (copy-seq (%expert-objective-id objective)))
+
+(defun expert-objective-version (objective)
+  "Return an independently mutable snapshot of OBJECTIVE's version identity."
+  (check-type objective expert-objective)
+  (copy-seq (%expert-objective-version objective)))
 
 (defun normalize-expert-objective-capabilities (capabilities)
   (unless (listp capabilities)
@@ -119,8 +130,8 @@ execution authority and encodes no fixed recon or attack phase ordering."
                              "objective clauses must be normalized clauses"))
   (validate-expert-objective-limits limits)
   (%make-expert-objective
-   :id id
-   :version version
+   :id (copy-seq id)
+   :version (copy-seq version)
    :raw-clauses (copy-list clauses)
    :raw-limits (copy-list limits)
    :raw-granted-capabilities
@@ -129,17 +140,17 @@ execution authority and encodes no fixed recon or attack phase ordering."
 (defun expert-objective-clauses (objective)
   "Return a defensive copy of OBJECTIVE clauses."
   (check-type objective expert-objective)
-  (copy-list (expert-objective-raw-clauses objective)))
+  (copy-list (%expert-objective-raw-clauses objective)))
 
 (defun expert-objective-limits (objective)
   "Return a defensive copy of OBJECTIVE limits."
   (check-type objective expert-objective)
-  (copy-list (expert-objective-raw-limits objective)))
+  (copy-list (%expert-objective-raw-limits objective)))
 
 (defun expert-objective-granted-capabilities (objective)
   "Return deterministically normalized capability grants for OBJECTIVE."
   (check-type objective expert-objective)
-  (copy-list (expert-objective-raw-granted-capabilities objective)))
+  (copy-list (%expert-objective-raw-granted-capabilities objective)))
 
 (export '(+expert-objective-clause-kinds+
           invalid-expert-objective

--- a/source/hackmode-core/tests/expert-objective.lisp
+++ b/source/hackmode-core/tests/expert-objective.lisp
@@ -62,6 +62,32 @@
       (assert-equal "http-probe"
                     (first (hackmode:expert-objective-granted-capabilities objective))
                     "returned capability list cannot mutate objective"))
+    (let* ((caller-id (copy-seq "mutable-objective"))
+           (caller-version (copy-seq "version-1"))
+           (isolated
+             (hackmode:make-expert-objective
+              :id caller-id
+              :version caller-version
+              :clauses (list goal)
+              :granted-capabilities nil)))
+      (setf (char caller-id 0) #\X
+            (char caller-version 0) #\X)
+      (assert-equal "mutable-objective"
+                    (hackmode:expert-objective-id isolated)
+                    "caller-owned ID mutation cannot rewrite objective identity")
+      (assert-equal "version-1"
+                    (hackmode:expert-objective-version isolated)
+                    "caller-owned version mutation cannot rewrite objective version")
+      (let ((returned-id (hackmode:expert-objective-id isolated))
+            (returned-version (hackmode:expert-objective-version isolated)))
+        (setf (char returned-id 0) #\Y
+              (char returned-version 0) #\Y)
+        (assert-equal "mutable-objective"
+                      (hackmode:expert-objective-id isolated)
+                      "returned ID mutation cannot rewrite objective identity")
+        (assert-equal "version-1"
+                      (hackmode:expert-objective-version isolated)
+                      "returned version mutation cannot rewrite objective version")))
     (dolist (bad `((:clause-kind
                     ,(lambda ()
                        (hackmode:make-expert-objective-clause


### PR DESCRIPTION
## Issue
Advances #29 with a bug-first regression in the objective/SPEC identity boundary.

## Bug
`expert-objective` is immutable-by-interface, but its generated `id` / `version` accessors exposed stored mutable strings directly and the constructor retained caller-owned identity strings. A caller could rewrite objective identity after construction, poisoning plan/objective matching and extension selection without any canonical mutation path.

## RED
Exact test-only head `af3821c48c4f2cddd6698c56cf756927f72671a9` reached `Load Hackmode and run ASDF tests` with all setup/dependency steps green, then `common-lisp-core` failed on the new aliasing regression.

## GREEN
Exact implementation head `1cdf5bd754e31319448a3fbd0838a2de39f3b8ff` passed `common-lisp-core`, monorepo/hygiene, and `agent-framework-boundary` on draft PR #163. This replacement PR exists only because GitHub's ready-for-review mutation failed on the recurring `fullDatabaseId` schema error; code/head are identical.

## Implementation
- objective storage uses private raw accessors;
- objective ID/version strings are snapshotted at construction;
- public ID/version accessors return independent copies;
- existing clause/limit/capability access remains behind the same public API.

No provider execution, database persistence internals, authority widening, scheduler changes, or StarIntel product work.