### PR TITLE
Investigation: materialize operation asset views

### DIFF
--- a/source/hackmode-core/assets.lisp
+++ b/source/hackmode-core/assets.lisp
@@ -175,14 +175,15 @@ older recon/client integrations while they migrate to the generic event stream."
   (bind-asset-operation asset)
   (setf (doc-id asset) (asset-deterministic-id asset :parent-id parent-id))
   (put-doc asset :database database)
+  (maintain-investigation-asset-views database asset)
   asset)
 
 (defun discover-asset (asset &key (database *db*) parent-id (publish t))
   "Persist ASSET exactly once, then publish a :DISCOVERED event.
 
 Returns two values: the canonical stored asset and true only when this call
-created it. Persistence happens before event publication, so subscribers never
-observe an asset that is absent from the local operation store."
+created it. Persistence happens before view maintenance and event publication,
+so subscribers never observe an asset absent from canonical local state."
   (unless (and database (tek9:db-is-open-p database))
     (error "DISCOVER-ASSET requires an open local operation database."))
   (normalize-asset asset)
@@ -193,6 +194,7 @@ observe an asset that is absent from the local operation store."
         (values existing nil)
         (progn
           (put-doc asset :database database)
+          (maintain-investigation-asset-views database asset)
           (when publish
             (publish-asset-event :discovered asset))
           (values asset t)))))
@@ -216,23 +218,27 @@ events are never published for unpersisted results."
 (defun query-assets (&key (database *db*) type predicate)
   "Return operation-local assets matching TYPE and PREDICATE.
 
-This first protocol slice intentionally uses Tek9's existing snapshot iterator.
-Indexes/views can be added without changing callers once query volume requires
-it."
+Typed queries use Hackmode's materialized `assets/by-type' investigation view.
+Unconstrained queries retain the generic snapshot iterator."
   (unless (and database (tek9:db-is-open-p database))
     (error "QUERY-ASSETS requires an open local operation database."))
-  (let ((wanted (and type (string-downcase (string type))))
-        assets)
-    (tek9:map-database
-     database
-     :map-fn
-     (lambda (key document)
-       (declare (ignore key))
-       (let* ((value (tek9:doc-value document))
-              (kind (and (typep value 'meta)
-                         (ignore-errors (asset-kind value)))))
-         (when (and kind
-                    (or (null wanted) (string= wanted kind))
-                    (or (null predicate) (funcall predicate value)))
-           (push value assets)))))
-    (nreverse assets)))
+  (let ((wanted (and type (string-downcase (string type)))))
+    (if wanted
+        (loop for id in (investigation-view-asset-ids database :by-type wanted)
+              for asset = (tek9:fetch* database id)
+              when (and (typep asset 'meta)
+                        (or (null predicate) (funcall predicate asset)))
+                collect asset)
+        (let (assets)
+          (tek9:map-database
+           database
+           :map-fn
+           (lambda (key document)
+             (declare (ignore key))
+             (let* ((value (tek9:doc-value document))
+                    (kind (and (typep value 'meta)
+                               (ignore-errors (asset-kind value)))))
+               (when (and kind
+                          (or (null predicate) (funcall predicate value)))
+                 (push value assets)))))
+          (nreverse assets)))))

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -3,6 +3,7 @@
   :depends-on (#:hackmode #:hackmode-database)
   :serial t
   :components ((:file "tests/core-state")
+               (:file "tests/investigation-views")
                (:file "tests/functions")
                (:file "tests/expert")
                (:file "tests/expert-orchestration")
@@ -29,6 +30,7 @@
   :perform (test-op (op system)
              (declare (ignore op system))
              (uiop:symbol-call :hackmode-tests :run-tests)
+             (uiop:symbol-call :hackmode-tests :run-investigation-view-tests)
              (uiop:symbol-call :hackmode-tests :run-functions-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-orchestration-tests)

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -25,6 +25,7 @@
                (:file "database")
                (:file "operations")
                (:file "assets")
+               (:file "investigation-views")
                (:file "starintel-documents")
                (:file "actor-system")
                (:file "outbox")

--- a/source/hackmode-core/investigation-views.lisp
+++ b/source/hackmode-core/investigation-views.lisp
@@ -57,21 +57,25 @@
 (defun ensure-investigation-views (database &key rebuild)
   "Register Hackmode-owned asset investigation views in DATABASE.
 
-When REBUILD is true, rebuild both views from canonical operation documents.
-The view definitions stay in Hackmode; Tek9 remains the generic view engine."
+A newly registered view is rebuilt immediately so operation databases created
+before this feature do not return false-empty results. REBUILD forces both views
+to be rebuilt from canonical operation documents."
   (unless (and database (tek9:db-is-open-p database))
     (error "Investigation views require an open operation database."))
   (labels ((ensure-view (name constructor)
-             (or (gethash name (tek9:db-views database))
-                 (tek9:add-view database (funcall constructor)))))
-    (let ((by-type (ensure-view +assets-by-type-view-name+
-                                #'make-assets-by-type-view))
-          (by-tag (ensure-view +assets-by-tag-view-name+
-                               #'make-assets-by-tag-view)))
-      (when rebuild
-        (tek9:apply-view-to-database database by-type)
-        (tek9:apply-view-to-database database by-tag))
-      (values by-type by-tag))))
+             (let ((existing (gethash name (tek9:db-views database))))
+               (if existing
+                   (values existing nil)
+                   (values (tek9:add-view database (funcall constructor)) t)))))
+    (multiple-value-bind (by-type by-type-created-p)
+        (ensure-view +assets-by-type-view-name+ #'make-assets-by-type-view)
+      (multiple-value-bind (by-tag by-tag-created-p)
+          (ensure-view +assets-by-tag-view-name+ #'make-assets-by-tag-view)
+        (when (or rebuild by-type-created-p)
+          (tek9:apply-view-to-database database by-type))
+        (when (or rebuild by-tag-created-p)
+          (tek9:apply-view-to-database database by-tag))
+        (values by-type by-tag)))))
 
 (defun rebuild-investigation-views (database)
   "Rebuild every currently supported Hackmode investigation view."

--- a/source/hackmode-core/investigation-views.lisp
+++ b/source/hackmode-core/investigation-views.lisp
@@ -1,5 +1,10 @@
 (in-package :hackmode)
 
+(export '(ensure-investigation-views
+          rebuild-investigation-views
+          investigation-view-rows
+          investigation-view-asset-ids))
+
 (defparameter +assets-by-type-view-name+ "assets/by-type")
 (defparameter +assets-by-tag-view-name+ "assets/by-tag")
 

--- a/source/hackmode-core/investigation-views.lisp
+++ b/source/hackmode-core/investigation-views.lisp
@@ -1,0 +1,115 @@
+(in-package :hackmode)
+
+(defparameter +assets-by-type-view-name+ "assets/by-type")
+(defparameter +assets-by-tag-view-name+ "assets/by-tag")
+
+(defun investigation-view-selector (kind)
+  (ecase kind
+    (:by-type +assets-by-type-view-name+)
+    (:by-tag +assets-by-tag-view-name+)))
+
+(defun investigation-view-key-prefix (selector)
+  (let ((value (string-downcase (string selector))))
+    (format nil "~d:~a:" (length value) value)))
+
+(defun investigation-view-key (selector document-id)
+  (concatenate 'string
+               (investigation-view-key-prefix selector)
+               document-id))
+
+(defun investigation-view-prefix-p (prefix key)
+  (and (<= (length prefix) (length key))
+       (string= prefix key :end2 (length prefix))))
+
+(defun make-assets-by-type-view ()
+  (tek9:new-view
+   +assets-by-type-view-name+
+   (lambda (document)
+     (let* ((asset (tek9:doc-value document))
+            (kind (and (typep asset 'meta)
+                       (ignore-errors (asset-kind asset))))
+            (id (and (typep asset 'meta) (doc-id asset))))
+       (if (and kind (stringp id) (plusp (length id)))
+           (list (cons (investigation-view-key kind id) id))
+           nil)))))
+
+(defun make-assets-by-tag-view ()
+  (tek9:new-view
+   +assets-by-tag-view-name+
+   (lambda (document)
+     (let* ((asset (tek9:doc-value document))
+            (kind (and (typep asset 'meta)
+                       (ignore-errors (asset-kind asset))))
+            (id (and (typep asset 'meta) (doc-id asset))))
+       (when (and kind (stringp id) (plusp (length id)))
+         (loop for tag in (remove-duplicates
+                           (mapcar (lambda (value)
+                                     (string-downcase (string value)))
+                                   (doc-tags asset))
+                           :test #'string=)
+               collect (cons (investigation-view-key tag id) id)))))))
+
+(defun ensure-investigation-views (database &key rebuild)
+  "Register Hackmode-owned asset investigation views in DATABASE.
+
+When REBUILD is true, rebuild both views from canonical operation documents.
+The view definitions stay in Hackmode; Tek9 remains the generic view engine."
+  (unless (and database (tek9:db-is-open-p database))
+    (error "Investigation views require an open operation database."))
+  (labels ((ensure-view (name constructor)
+             (or (gethash name (tek9:db-views database))
+                 (tek9:add-view database (funcall constructor)))))
+    (let ((by-type (ensure-view +assets-by-type-view-name+
+                                #'make-assets-by-type-view))
+          (by-tag (ensure-view +assets-by-tag-view-name+
+                               #'make-assets-by-tag-view)))
+      (when rebuild
+        (tek9:apply-view-to-database database by-type)
+        (tek9:apply-view-to-database database by-tag))
+      (values by-type by-tag))))
+
+(defun rebuild-investigation-views (database)
+  "Rebuild every currently supported Hackmode investigation view."
+  (ensure-investigation-views database :rebuild t)
+  database)
+
+(defun maintain-investigation-asset-views (database asset)
+  "Incrementally project persisted ASSET into registered investigation views."
+  (multiple-value-bind (by-type by-tag)
+      (ensure-investigation-views database)
+    (let ((id (doc-id asset)))
+      (tek9:apply-view database by-type (list id))
+      (tek9:apply-view database by-tag (list id))))
+  asset)
+
+(defun investigation-view-object (database kind)
+  (ensure-investigation-views database)
+  (or (gethash (investigation-view-selector kind) (tek9:db-views database))
+      (error "Investigation view ~s is not registered." kind)))
+
+(defun investigation-view-rows (database kind &key selector limit)
+  "Return public decoded rows from investigation view KIND.
+
+SELECTOR narrows :BY-TYPE or :BY-TAG using the deterministic materialized key
+prefix. No Hackmode caller depends on Tek9's LMDB representation."
+  (let* ((view (investigation-view-object database kind))
+         (prefix (and selector (investigation-view-key-prefix selector)))
+         (rows (if prefix
+                   (tek9:view-rows database view
+                                   :start prefix
+                                   :end (concatenate 'string prefix
+                                                     (string #\Rubout))
+                                   :limit limit)
+                   (tek9:view-rows database view :limit limit))))
+    (if prefix
+        (remove-if-not (lambda (row)
+                         (investigation-view-prefix-p prefix (car row)))
+                       rows)
+        rows)))
+
+(defun investigation-view-asset-ids (database kind selector &key limit)
+  "Return stable asset IDs selected through materialized investigation view KIND."
+  (mapcar #'cdr
+          (investigation-view-rows database kind
+                                   :selector selector
+                                   :limit limit)))

--- a/source/hackmode-core/tests/investigation-views.lisp
+++ b/source/hackmode-core/tests/investigation-views.lisp
@@ -1,0 +1,92 @@
+(in-package :hackmode-tests)
+
+(defun run-investigation-view-tests ()
+  (let* ((root (fresh-test-path "hackmode-investigation-views"))
+         (db (tek9:new-database "investigation-views" :path root)))
+    (unwind-protect
+         (progn
+           (tek9:open-database db)
+           (hackmode:ensure-investigation-views db)
+
+           (multiple-value-bind (first created-p)
+               (hackmode:discover-asset
+                (make-instance 'hackmode:domain
+                               :record "alpha.example"
+                               :record-type "A"
+                               :operation "op-views"
+                               :tags '("external" "api"))
+                :database db
+                :publish nil)
+             (declare (ignore first))
+             (assert created-p () "First asset discovery must create the asset."))
+
+           (hackmode:discover-asset
+            (make-instance 'hackmode:domain
+                           :record "beta.example"
+                           :record-type "A"
+                           :operation "op-views"
+                           :tags '("external"))
+            :database db
+            :publish nil)
+
+           (hackmode:discover-asset
+            (make-instance 'hackmode:url
+                           :scheme "https"
+                           :host "alpha.example"
+                           :port 443
+                           :path "/api"
+                           :operation "op-views"
+                           :tags '("api"))
+            :database db
+            :publish nil)
+
+           (let ((domain-ids
+                   (hackmode:investigation-view-asset-ids
+                    db :by-type "domain"))
+                 (api-ids
+                   (hackmode:investigation-view-asset-ids
+                    db :by-tag "api"))
+                 (external-ids
+                   (hackmode:investigation-view-asset-ids
+                    db :by-tag "external")))
+             (assert-equal 2 (length domain-ids) "assets/by-type domain count")
+             (assert-equal 2 (length api-ids) "assets/by-tag api count")
+             (assert-equal 2 (length external-ids) "assets/by-tag external count")
+             (assert-equal domain-ids
+                           (sort (copy-list domain-ids) #'string<)
+                           "stable domain row order")
+
+             ;; Re-discovery is idempotent and must not create a second view row.
+             (multiple-value-bind (repeat repeat-created-p)
+                 (hackmode:discover-asset
+                  (make-instance 'hackmode:domain
+                                 :record "alpha.example"
+                                 :record-type "A"
+                                 :operation "op-views"
+                                 :tags '("external" "api"))
+                  :database db
+                  :publish nil)
+               (declare (ignore repeat))
+               (assert (not repeat-created-p) ()
+                       "Repeated discovery must remain idempotent."))
+             (assert-equal domain-ids
+                           (hackmode:investigation-view-asset-ids
+                            db :by-type "domain")
+                           "repeated discovery view identity")
+
+             ;; A full rebuild must be equivalent to the incrementally maintained rows.
+             (let ((before-type
+                     (hackmode:investigation-view-rows db :by-type))
+                   (before-tag
+                     (hackmode:investigation-view-rows db :by-tag)))
+               (hackmode:rebuild-investigation-views db)
+               (assert-equal before-type
+                             (hackmode:investigation-view-rows db :by-type)
+                             "assets/by-type rebuild equivalence")
+               (assert-equal before-tag
+                             (hackmode:investigation-view-rows db :by-tag)
+                             "assets/by-tag rebuild equivalence"))))
+      (when (tek9:db-is-open-p db)
+        (tek9:close-database db))
+      (remove-test-path root)))
+  t)


### PR DESCRIPTION
Advances #15 with the first bounded materialized-view slice.

RED-first evidence: exact head `872639d130feeddcee3a6328f66795f3e4f297c9` reached the repository-native Common Lisp test step and failed because the new `HACKMODE:ENSURE-INVESTIGATION-VIEWS` contract did not exist.

Implementation head on open: `d23073e6df8bc8f060e84877d510d5569e12df93`.

This slice:
- defines Hackmode-owned `assets/by-type` and `assets/by-tag` materialized views using Tek9's public view API;
- incrementally maintains them only after canonical asset persistence;
- rebuilds newly registered views from existing operation documents to avoid false-empty legacy state;
- exposes stable public view reads without raw LMDB access;
- routes typed `query-assets` through `assets/by-type` instead of full operation scans;
- proves idempotent discovery, stable ordering, and full rebuild equivalence.

The prior draft #165 passed all three gates at this exact head but could not be transitioned because the connector's draft→ready mutation requests nonexistent GitHub GraphQL field `Repository.fullDatabaseId`. This normal PR intentionally reruns fresh PR-triggered checks before merge.

`ingest/by-state` is not faked here: Hackmode's durable outbox lives in a named Tek9 DB while current view application reads the primary DB. Generic named-source view support is tracked upstream as lost-rob0t/tek9#15. Keep Hackmode #15 open after this slice for that and later investigation views.