### PR TITLE
Hackpert: freeze expert extension identity strings

### DIFF
--- a/source/hackmode-core/expert/extension.lisp
+++ b/source/hackmode-core/expert/extension.lisp
@@ -43,13 +43,24 @@
 (defstruct (expert-extension
              (:constructor %make-expert-extension
                  (&key id version raw-objective-predicates
-                       raw-required-capabilities authority raw-strategies)))
+                       raw-required-capabilities authority raw-strategies))
+             (:conc-name %expert-extension-))
   (id nil :read-only t)
   (version nil :read-only t)
   (raw-objective-predicates nil :read-only t)
   (raw-required-capabilities nil :read-only t)
   (authority :passive :read-only t)
   (raw-strategies nil :read-only t))
+
+(defun expert-extension-id (extension)
+  "Return an independently mutable snapshot of EXTENSION's stable identity."
+  (check-type extension expert-extension)
+  (copy-seq (%expert-extension-id extension)))
+
+(defun expert-extension-version (extension)
+  "Return an independently mutable snapshot of EXTENSION's version identity."
+  (check-type extension expert-extension)
+  (copy-seq (%expert-extension-version extension)))
 
 (defun make-expert-extension (&key id version objective-predicates
                                    required-capabilities authority strategies)
@@ -71,8 +82,8 @@ minimum engine authority required for selection."
                              "unsupported authority requirement ~s"
                              authority))
   (%make-expert-extension
-   :id id
-   :version version
+   :id (copy-seq id)
+   :version (copy-seq version)
    :raw-objective-predicates
    (normalize-expert-extension-strings objective-predicates
                                        "objective predicates")
@@ -84,15 +95,19 @@ minimum engine authority required for selection."
 
 (defun expert-extension-objective-predicates (extension)
   (check-type extension expert-extension)
-  (copy-list (expert-extension-raw-objective-predicates extension)))
+  (copy-list (%expert-extension-raw-objective-predicates extension)))
 
 (defun expert-extension-required-capabilities (extension)
   (check-type extension expert-extension)
-  (copy-list (expert-extension-raw-required-capabilities extension)))
+  (copy-list (%expert-extension-raw-required-capabilities extension)))
+
+(defun expert-extension-authority (extension)
+  (check-type extension expert-extension)
+  (%expert-extension-authority extension))
 
 (defun expert-extension-strategies (extension)
   (check-type extension expert-extension)
-  (copy-list (expert-extension-raw-strategies extension)))
+  (copy-list (%expert-extension-raw-strategies extension)))
 
 (defstruct (expert-extension-registry
              (:constructor %make-expert-extension-registry (&key raw-extensions)))

--- a/source/hackmode-core/tests/expert-extension.lisp
+++ b/source/hackmode-core/tests/expert-extension.lisp
@@ -70,6 +70,34 @@
                     (hackmode:expert-extension-id
                      (first (hackmode:list-expert-extensions registry)))
                     "registry accessor is defensive"))
+    (let* ((id (copy-seq "stable-extension"))
+           (version (copy-seq "v1"))
+           (extension
+             (hackmode:make-expert-extension
+              :id id
+              :version version
+              :objective-predicates '("foothold")
+              :required-capabilities nil
+              :authority :passive
+              :strategies '(:symbolic))))
+      (setf (char id 0) #\X
+            (char version 0) #\X)
+      (assert-equal "stable-extension"
+                    (hackmode:expert-extension-id extension)
+                    "extension snapshots caller-owned ID strings")
+      (assert-equal "v1"
+                    (hackmode:expert-extension-version extension)
+                    "extension snapshots caller-owned version strings")
+      (let ((returned-id (hackmode:expert-extension-id extension))
+            (returned-version (hackmode:expert-extension-version extension)))
+        (setf (char returned-id 0) #\Y
+              (char returned-version 0) #\Y)
+        (assert-equal "stable-extension"
+                      (hackmode:expert-extension-id extension)
+                      "extension ID accessor returns a defensive snapshot")
+        (assert-equal "v1"
+                      (hackmode:expert-extension-version extension)
+                      "extension version accessor returns a defensive snapshot")))
     (handler-case
         (progn
           (hackmode:register-expert-extension registry recon)


### PR DESCRIPTION
## Issue

Advances #29 with a bug-first immutability regression for registered expert-extension identity.

## RED

Test-only head `c396578d7d81015f6f40b4ab35d438b06f727241` recorded the intended failure in `common-lisp-core`: caller mutation rewrote `"stable-extension"` to `"Xtable-extension"`. Monorepo and agent-framework-boundary were green on the same head.

## GREEN

Exact implementation head `ba0e4ae664705c7c108b30d5132e73e44854625c` is green in `common-lisp-core`, `monorepo`, and `agent-framework-boundary`. It snapshots extension ID/version strings at construction and exposes defensive public identity accessors using the same private-slot pattern as `expert-objective`.

Replaces draft #167 on the identical head because GitHub's ready-for-review GraphQL mutation fails on the nonexistent `Repository.fullDatabaseId` field.

## Authority fence

No provider execution, canonical mutation, database persistence internals, scheduler, raw Prolog execution, or StarIntel product work is involved.