### PR TITLE
test: prove missing ingest-by-state runtime contract

### DIFF
--- a/source/hackmode-core/tests/investigation-views.lisp
+++ b/source/hackmode-core/tests/investigation-views.lisp
@@ -85,7 +85,24 @@
                              "assets/by-type rebuild equivalence")
                (assert-equal before-tag
                              (hackmode:investigation-view-rows db :by-tag)
-                             "assets/by-tag rebuild equivalence"))))
+                             "assets/by-tag rebuild equivalence")))
+
+           ;; RED contract for #15: use only the public outbox enqueue path, then
+           ;; require the not-yet-implemented ingest-state investigation query.
+           (multiple-value-bind (entry created-p)
+               (hackmode:enqueue-starintel-json
+                db
+                (jsown:new-js
+                  ("_id" "view-red-doc")
+                  ("dtype" "url"))
+                :operation "op-views"
+                :now 30)
+             (declare (ignore entry))
+             (assert created-p () "Outbox RED fixture must be durably created."))
+           (assert-equal 1
+                         (length
+                          (hackmode::investigation-view-outbox-ids db :queued))
+                         "ingest/by-state queued selection must exist"))
       (when (tek9:db-is-open-p db)
         (tek9:close-database db))
       (remove-test-path root)))


### PR DESCRIPTION
Corrected RED oracle for #15 only.

Exact head `58b3fb93960e183034a9eedc9ce652564bf6fef3` uses Hackmode's public `enqueue-starintel-json` path to create canonical durable outbox state, then calls the intentionally not-yet-defined `hackmode::investigation-view-outbox-ids` runtime function. The double-colon avoids a package-export reader failure, forcing the test into the missing runtime contract.

Observed RED: monorepo and agent-framework-boundary passed; Common Lisp core reached `Load Hackmode and run ASDF tests` after all setup/dependency steps succeeded, then failed. No production files or dependency pins are changed on this head.

Clean RED is established; production remains in #169. Closing this proof-only PR without merge.