### PR TITLE
capture: replay canonical IPX HTTP spool

### DIFF
--- a/source/hackmode-core/capture-replay.lisp
+++ b/source/hackmode-core/capture-replay.lisp
@@ -1,0 +1,216 @@
+(in-package :hackmode)
+
+(defstruct ipx-replay-result
+  operation-id
+  capture-session-id
+  source-id
+  (start-offset 0 :type integer)
+  (end-offset 0 :type integer)
+  (committed-count 0 :type integer)
+  (quarantine-count 0 :type integer)
+  (truncated-p nil :type boolean))
+
+(defun ipx-require-string (value label)
+  (unless (and (stringp value) (plusp (length value)))
+    (error "~a must be a non-empty string." label))
+  value)
+
+(defun ipx-json-value (object key)
+  (or (jsown:val-safe object key)
+      (error "Missing IPX field ~a." key)))
+
+(defun ipx-require-real (value label)
+  (unless (realp value)
+    (error "~a must be a real number." label))
+  value)
+
+(defun ipx-octets->ascii (octets)
+  (map 'string #'code-char octets))
+
+(defun ipx-read-frame (stream)
+  "Read one newline-delimited frame and return OCTETS, COMPLETE-P, START, END."
+  (let ((start (file-position stream))
+        (octets (make-array 256
+                            :element-type '(unsigned-byte 8)
+                            :adjustable t
+                            :fill-pointer 0)))
+    (loop
+      for octet = (read-byte stream nil :eof)
+      do (cond
+           ((eq octet :eof)
+            (return (values octets nil start (file-position stream))))
+           ((= octet 10)
+            (return (values octets t start (file-position stream))))
+           (t
+            (vector-push-extend octet octets))))))
+
+(defun ipx-evidence-reference (pathname source-id start end)
+  (format nil "ipx://~a?path=~a#bytes=~d-~d"
+          source-id (namestring pathname) start end))
+
+(defun ipx-frame-provenance (pathname source-id start end)
+  (list :parser "hackmode-ipx-http/1"
+        :source-id source-id
+        :source-path (namestring pathname)
+        :offset start
+        :length (- end start)))
+
+(defun ipx-quarantine-at-offset-p
+    (database operation-id capture-session-id source-id offset)
+  (find offset
+        (hackmode-database:fetch-capture-quarantine-records
+         database operation-id capture-session-id source-id)
+        :key (lambda (record)
+               (getf (hackmode-database:execution-record-payload record) :offset))
+        :test #'=))
+
+(defun ipx-persist-quarantine
+    (database pathname operation-id capture-session-id source-id start end reason)
+  (unless (ipx-quarantine-at-offset-p
+           database operation-id capture-session-id source-id start)
+    (let ((record
+            (hackmode-database:make-capture-quarantine-record
+             :operation-id operation-id
+             :capture-session-id capture-session-id
+             :source-id source-id
+             :offset start
+             :length (- end start)
+             :reason reason
+             :raw-evidence-ref
+             (ipx-evidence-reference pathname source-id start end)
+             :framing-version "hackmode-ipx-http/1"
+             :provenance
+             (ipx-frame-provenance pathname source-id start end))))
+      (hackmode-database:persist-execution-record database record)
+      record)))
+
+(defun ipx-validate-identity
+    (object operation-id capture-session-id source-id)
+  (unless (string= "hackmode-ipx-http" (ipx-json-value object "schema"))
+    (error "Unsupported IPX schema."))
+  (unless (= 1 (ipx-json-value object "version"))
+    (error "Unsupported IPX version."))
+  (unless (string= operation-id (ipx-json-value object "operation_id"))
+    (error "IPX operation identity mismatch."))
+  (unless (string= capture-session-id
+                   (ipx-json-value object "capture_session_id"))
+    (error "IPX capture-session identity mismatch."))
+  (unless (string= source-id (ipx-json-value object "spool_id"))
+    (error "IPX source identity mismatch."))
+  object)
+
+(defun ipx-object->http-exchange
+    (object pathname operation-id capture-session-id source-id start end)
+  (ipx-validate-identity object operation-id capture-session-id source-id)
+  (let* ((request (ipx-json-value object "request"))
+         (response (ipx-json-value object "response"))
+         (timestamp-start
+           (ipx-require-real (ipx-json-value object "timestamp_start")
+                             "timestamp_start"))
+         (timestamp-end
+           (ipx-require-real (ipx-json-value object "timestamp_end")
+                             "timestamp_end")))
+    (when (< timestamp-end timestamp-start)
+      (error "IPX timestamp_end precedes timestamp_start."))
+    (hackmode-database:make-http-exchange-record
+     :operation-id operation-id
+     :capture-session-id capture-session-id
+     :exchange-id (ipx-json-value object "exchange_id")
+     :method (ipx-json-value request "method")
+     :scheme (ipx-json-value request "scheme")
+     :host (ipx-json-value request "host")
+     :port (ipx-json-value request "port")
+     :path (ipx-json-value request "path")
+     :response-status (ipx-json-value response "status_code")
+     :raw-evidence-ref (ipx-evidence-reference pathname source-id start end)
+     :observed-at (unix-seconds->starintel-timestring (floor timestamp-start))
+     :duration-ms (round (* 1000 (- timestamp-end timestamp-start)))
+     :provenance (ipx-frame-provenance pathname source-id start end))))
+
+(defun ipx-persist-checkpoint
+    (database operation-id capture-session-id source-id offset last-record-id pathname)
+  (hackmode-database:persist-execution-record
+   database
+   (hackmode-database:make-capture-checkpoint-record
+    :operation-id operation-id
+    :capture-session-id capture-session-id
+    :source-id source-id
+    :offset offset
+    :last-record-id last-record-id
+    :framing-version "hackmode-ipx-http/1"
+    :provenance (list :parser "hackmode-ipx-http/1"
+                      :source-id source-id
+                      :source-path (namestring pathname)))))
+
+(defun replay-ipx-http-spool
+    (database pathname &key operation-id capture-session-id source-id)
+  "Replay complete HTTP frames from PATHNAME into the canonical operation graph.
+
+Checkpoint offsets are byte offsets. Complete malformed frames are quarantined and
+advanced past. An unterminated final frame is quarantined without advancing the
+checkpoint so a later replay can consume it after the writer completes the frame."
+  (ipx-require-string operation-id "operation-id")
+  (ipx-require-string capture-session-id "capture-session-id")
+  (ipx-require-string source-id "source-id")
+  (let* ((path (pathname pathname))
+         (checkpoint
+           (hackmode-database:fetch-latest-capture-checkpoint
+            database operation-id capture-session-id source-id))
+         (start-offset
+           (if checkpoint
+               (getf (hackmode-database:execution-record-payload checkpoint)
+                     :offset)
+               0))
+         (committed-count 0)
+         (quarantine-count 0)
+         (truncated-p nil)
+         (end-offset start-offset))
+    (with-open-file (stream path
+                            :direction :input
+                            :element-type '(unsigned-byte 8))
+      (file-position stream start-offset)
+      (loop
+        (multiple-value-bind (octets complete-p frame-start frame-end)
+            (ipx-read-frame stream)
+          (setf end-offset frame-end)
+          (when (and (zerop (length octets)) (not complete-p))
+            (return))
+          (unless complete-p
+            (setf truncated-p t)
+            (when (ipx-persist-quarantine
+                   database path operation-id capture-session-id source-id
+                   frame-start frame-end "truncated IPX frame")
+              (incf quarantine-count))
+            (return))
+          (handler-case
+              (let* ((object (jsown:parse (ipx-octets->ascii octets)))
+                     (exchange
+                       (ipx-object->http-exchange
+                        object path operation-id capture-session-id source-id
+                        frame-start frame-end)))
+                (hackmode-database:persist-execution-record database exchange)
+                (ipx-persist-checkpoint
+                 database operation-id capture-session-id source-id frame-end
+                 (hackmode-database:execution-record-record-id exchange) path)
+                (incf committed-count))
+            (error (condition)
+              (let ((quarantine
+                      (ipx-persist-quarantine
+                       database path operation-id capture-session-id source-id
+                       frame-start frame-end (princ-to-string condition))))
+                (when quarantine
+                  (incf quarantine-count))
+                (ipx-persist-checkpoint
+                 database operation-id capture-session-id source-id frame-end
+                 (and quarantine
+                      (hackmode-database:execution-record-record-id quarantine))
+                 path)))))))
+    (make-ipx-replay-result
+     :operation-id operation-id
+     :capture-session-id capture-session-id
+     :source-id source-id
+     :start-offset start-offset
+     :end-offset end-offset
+     :committed-count committed-count
+     :quarantine-count quarantine-count
+     :truncated-p truncated-p)))

--- a/source/hackmode-core/capture-replay.lisp
+++ b/source/hackmode-core/capture-replay.lisp
@@ -127,6 +127,18 @@
      :duration-ms (round (* 1000 (- timestamp-end timestamp-start)))
      :provenance (ipx-frame-provenance pathname source-id start end))))
 
+(defun ipx-decode-http-exchange
+    (octets pathname operation-id capture-session-id source-id start end)
+  "Decode one framed record. Return EXCHANGE and NIL, or NIL and the decode error."
+  (handler-case
+      (values
+       (ipx-object->http-exchange
+        (jsown:parse (ipx-octets->ascii octets))
+        pathname operation-id capture-session-id source-id start end)
+       nil)
+    (error (condition)
+      (values nil condition))))
+
 (defun ipx-persist-checkpoint
     (database operation-id capture-session-id source-id offset last-record-id pathname)
   (hackmode-database:persist-execution-record
@@ -182,29 +194,28 @@ checkpoint so a later replay can consume it after the writer completes the frame
                    frame-start frame-end "truncated IPX frame")
               (incf quarantine-count))
             (return))
-          (handler-case
-              (let* ((object (jsown:parse (ipx-octets->ascii octets)))
-                     (exchange
-                       (ipx-object->http-exchange
-                        object path operation-id capture-session-id source-id
-                        frame-start frame-end)))
-                (hackmode-database:persist-execution-record database exchange)
-                (ipx-persist-checkpoint
-                 database operation-id capture-session-id source-id frame-end
-                 (hackmode-database:execution-record-record-id exchange) path)
-                (incf committed-count))
-            (error (condition)
-              (let ((quarantine
-                      (ipx-persist-quarantine
-                       database path operation-id capture-session-id source-id
-                       frame-start frame-end (princ-to-string condition))))
-                (when quarantine
-                  (incf quarantine-count))
-                (ipx-persist-checkpoint
-                 database operation-id capture-session-id source-id frame-end
-                 (and quarantine
-                      (hackmode-database:execution-record-record-id quarantine))
-                 path)))))))
+          (multiple-value-bind (exchange decode-error)
+              (ipx-decode-http-exchange
+               octets path operation-id capture-session-id source-id
+               frame-start frame-end)
+            (if decode-error
+                (let ((quarantine
+                        (ipx-persist-quarantine
+                         database path operation-id capture-session-id source-id
+                         frame-start frame-end (princ-to-string decode-error))))
+                  (when quarantine
+                    (incf quarantine-count))
+                  (ipx-persist-checkpoint
+                   database operation-id capture-session-id source-id frame-end
+                   (and quarantine
+                        (hackmode-database:execution-record-record-id quarantine))
+                   path))
+                (progn
+                  (hackmode-database:persist-execution-record database exchange)
+                  (ipx-persist-checkpoint
+                   database operation-id capture-session-id source-id frame-end
+                   (hackmode-database:execution-record-record-id exchange) path)
+                  (incf committed-count)))))))
     (make-ipx-replay-result
      :operation-id operation-id
      :capture-session-id capture-session-id

--- a/source/hackmode-core/hackmode-tests.asd
+++ b/source/hackmode-core/hackmode-tests.asd
@@ -25,6 +25,7 @@
                (:file "tests/expert-budget-inspection")
                (:file "tests/expert-direct-candidate")
                (:file "tests/capture-provider")
+               (:file "tests/ipx-replay")
                (:file "tests/http-transport-profile")
                (:file "tests/visual-evidence-outbox")
                (:file "tests/http-requester"))
@@ -53,6 +54,7 @@
              (uiop:symbol-call :hackmode-tests :run-expert-budget-inspection-tests)
              (uiop:symbol-call :hackmode-tests :run-expert-direct-candidate-tests)
              (uiop:symbol-call :hackmode-tests :run-capture-provider-tests)
+             (uiop:symbol-call :hackmode-tests :run-ipx-replay-tests)
              (uiop:symbol-call :hackmode-http-transport-profile-tests
                                :run-http-transport-profile-tests)
              (uiop:symbol-call :hackmode-visual-evidence-outbox-tests

--- a/source/hackmode-core/hackmode.asd
+++ b/source/hackmode-core/hackmode.asd
@@ -36,6 +36,7 @@
                (:file "providers")
                (:file "provider-actor")
                (:file "capture-provider")
+               (:file "capture-replay")
                (:file "expert")
                (:module "expert-actions"
                 :pathname "expert/"

--- a/source/hackmode-core/package.lisp
+++ b/source/hackmode-core/package.lisp
@@ -221,6 +221,17 @@
    :start-capture-service
    :note-capture-process-exit
    :stop-capture-service
+   ;; Capture replay
+   :ipx-replay-result
+   :ipx-replay-result-operation-id
+   :ipx-replay-result-capture-session-id
+   :ipx-replay-result-source-id
+   :ipx-replay-result-start-offset
+   :ipx-replay-result-end-offset
+   :ipx-replay-result-committed-count
+   :ipx-replay-result-quarantine-count
+   :ipx-replay-result-truncated-p
+   :replay-ipx-http-spool
    ;; Optional Prolog expert layer
    :*expert-program*
    :expert-unavailable

--- a/source/hackmode-core/tests/ipx-replay.lisp
+++ b/source/hackmode-core/tests/ipx-replay.lisp
@@ -1,0 +1,111 @@
+(in-package :hackmode-tests)
+
+(defun write-ascii-file (pathname content &key append)
+  (with-open-file (stream pathname
+                          :direction :output
+                          :if-does-not-exist :create
+                          :if-exists (if append :append :supersede)
+                          :external-format :utf-8)
+    (write-string content stream)))
+
+(defun run-ipx-replay-tests ()
+  (let* ((root (fresh-test-path "hackmode-ipx-replay"))
+         (spool (merge-pathnames "capture.ipx.jsonl" root))
+         (db (tek9:new-database "ipx-replay" :path root))
+         (valid-line
+           "{\"schema\":\"hackmode-ipx-http\",\"version\":1,\"operation_id\":\"op-ipx\",\"capture_session_id\":\"cap-1\",\"spool_id\":\"spool-1\",\"exchange_id\":\"exchange-1\",\"timestamp_start\":1000.0,\"timestamp_end\":1000.125,\"request\":{\"method\":\"GET\",\"scheme\":\"https\",\"host\":\"example.test\",\"port\":443,\"path\":\"/api?x=1\",\"http_version\":\"HTTP/2\",\"headers_raw_b64\":[],\"body_raw_b64\":\"\"},\"response\":{\"status_code\":200,\"reason\":\"OK\",\"http_version\":\"HTTP/2\",\"headers_raw_b64\":[],\"body_raw_b64\":\"\"},\"connection\":{},\"provider\":{\"name\":\"mitmproxy\",\"addon_schema\":\"hackmode-ipx-http\",\"addon_version\":1}}\n"))
+    (unwind-protect
+         (progn
+           (uiop:ensure-all-directories-exist (list root))
+           (tek9:open-database db)
+           (write-ascii-file spool valid-line)
+           (let ((first
+                   (hackmode:replay-ipx-http-spool
+                    db spool
+                    :operation-id "op-ipx"
+                    :capture-session-id "cap-1"
+                    :source-id "spool-1")))
+             (assert-equal 1
+                           (hackmode:ipx-replay-result-committed-count first)
+                           "first replay committed count")
+             (assert-equal 0
+                           (hackmode:ipx-replay-result-quarantine-count first)
+                           "first replay quarantine count")
+             (assert (not (hackmode:ipx-replay-result-truncated-p first)) ()
+                     "Complete frame must not be marked truncated."))
+           (let ((exchanges
+                   (hackmode-database:fetch-operation-execution-records
+                    db "op-ipx" :run-id "cap-1" :kind :http-exchange)))
+             (assert-equal 1 (length exchanges) "one canonical HTTP exchange")
+             (let* ((exchange (first exchanges))
+                    (payload (hackmode-database:execution-record-payload exchange)))
+               (assert-equal "GET" (getf payload :method) "HTTP method")
+               (assert-equal "https" (getf payload :scheme) "HTTP scheme")
+               (assert-equal "example.test" (getf payload :host) "HTTP host")
+               (assert-equal 443 (getf payload :port) "HTTP port")
+               (assert-equal "/api?x=1" (getf payload :path) "HTTP path")
+               (assert-equal 200 (getf payload :response-status) "HTTP status")
+               (assert-equal 125 (getf payload :duration-ms) "HTTP duration")
+               (assert (search "spool-1" (getf payload :raw-evidence-ref)) ()
+                       "HTTP exchange must retain a raw spool evidence reference.")))
+           (let ((again
+                   (hackmode:replay-ipx-http-spool
+                    db spool
+                    :operation-id "op-ipx"
+                    :capture-session-id "cap-1"
+                    :source-id "spool-1")))
+             (assert-equal 0
+                           (hackmode:ipx-replay-result-committed-count again)
+                           "checkpointed replay does not duplicate exchange")
+             (assert-equal 1
+                           (length
+                            (hackmode-database:fetch-operation-execution-records
+                             db "op-ipx" :run-id "cap-1" :kind :http-exchange))
+                           "replay-safe exchange count"))
+
+           (write-ascii-file spool "{not-json}\n" :append t)
+           (let ((malformed
+                   (hackmode:replay-ipx-http-spool
+                    db spool
+                    :operation-id "op-ipx"
+                    :capture-session-id "cap-1"
+                    :source-id "spool-1")))
+             (assert-equal 1
+                           (hackmode:ipx-replay-result-quarantine-count malformed)
+                           "malformed complete frame quarantined")
+             (assert-equal 1
+                           (length
+                            (hackmode-database:fetch-capture-quarantine-records
+                             db "op-ipx" "cap-1" "spool-1"))
+                           "one durable malformed-frame quarantine"))
+
+           (let* ((checkpoint-before
+                    (hackmode-database:fetch-latest-capture-checkpoint
+                     db "op-ipx" "cap-1" "spool-1"))
+                  (offset-before
+                    (getf (hackmode-database:execution-record-payload checkpoint-before)
+                          :offset)))
+             (write-ascii-file spool "{" :append t)
+             (let ((truncated
+                     (hackmode:replay-ipx-http-spool
+                      db spool
+                      :operation-id "op-ipx"
+                      :capture-session-id "cap-1"
+                      :source-id "spool-1")))
+               (assert (hackmode:ipx-replay-result-truncated-p truncated) ()
+                       "Unterminated final frame must be classified as truncated.")
+               (assert-equal 1
+                             (hackmode:ipx-replay-result-quarantine-count truncated)
+                             "truncated frame quarantined"))
+             (let* ((checkpoint-after
+                      (hackmode-database:fetch-latest-capture-checkpoint
+                       db "op-ipx" "cap-1" "spool-1"))
+                    (offset-after
+                      (getf (hackmode-database:execution-record-payload checkpoint-after)
+                            :offset)))
+               (assert-equal offset-before offset-after
+                             "truncated frame does not advance checkpoint"))))
+      (when (tek9:db-is-open-p db)
+        (tek9:close-database db))
+      (remove-test-path root)))
+  t)

--- a/source/hackmode-core/tests/ipx-replay.lisp
+++ b/source/hackmode-core/tests/ipx-replay.lisp
@@ -13,7 +13,9 @@
          (spool (merge-pathnames "capture.ipx.jsonl" root))
          (db (tek9:new-database "ipx-replay" :path root))
          (valid-line
-           "{\"schema\":\"hackmode-ipx-http\",\"version\":1,\"operation_id\":\"op-ipx\",\"capture_session_id\":\"cap-1\",\"spool_id\":\"spool-1\",\"exchange_id\":\"exchange-1\",\"timestamp_start\":1000.0,\"timestamp_end\":1000.125,\"request\":{\"method\":\"GET\",\"scheme\":\"https\",\"host\":\"example.test\",\"port\":443,\"path\":\"/api?x=1\",\"http_version\":\"HTTP/2\",\"headers_raw_b64\":[],\"body_raw_b64\":\"\"},\"response\":{\"status_code\":200,\"reason\":\"OK\",\"http_version\":\"HTTP/2\",\"headers_raw_b64\":[],\"body_raw_b64\":\"\"},\"connection\":{},\"provider\":{\"name\":\"mitmproxy\",\"addon_schema\":\"hackmode-ipx-http\",\"addon_version\":1}}\n"))
+           (format nil
+                   "~a~%"
+                   "{\"schema\":\"hackmode-ipx-http\",\"version\":1,\"operation_id\":\"op-ipx\",\"capture_session_id\":\"cap-1\",\"spool_id\":\"spool-1\",\"exchange_id\":\"exchange-1\",\"timestamp_start\":1000.0,\"timestamp_end\":1000.125,\"request\":{\"method\":\"GET\",\"scheme\":\"https\",\"host\":\"example.test\",\"port\":443,\"path\":\"/api?x=1\",\"http_version\":\"HTTP/2\",\"headers_raw_b64\":[],\"body_raw_b64\":\"\"},\"response\":{\"status_code\":200,\"reason\":\"OK\",\"http_version\":\"HTTP/2\",\"headers_raw_b64\":[],\"body_raw_b64\":\"\"},\"connection\":{},\"provider\":{\"name\":\"mitmproxy\",\"addon_schema\":\"hackmode-ipx-http\",\"addon_version\":1}}")))
     (unwind-protect
          (progn
            (uiop:ensure-all-directories-exist (list root))
@@ -63,7 +65,7 @@
                              db "op-ipx" :run-id "cap-1" :kind :http-exchange))
                            "replay-safe exchange count"))
 
-           (write-ascii-file spool "{not-json}\n" :append t)
+           (write-ascii-file spool (format nil "{not-json}~%") :append t)
            (let ((malformed
                    (hackmode:replay-ipx-http-spool
                     db spool


### PR DESCRIPTION
Advances #26.

RED: test-only head `a438518b59adb7c437f6f84c22e65631a5baa4c1` reached the repository-native Common Lisp gate after dependency setup and failed because `HACKMODE:REPLAY-IPX-HTTP-SPOOL` did not exist.

GREEN: exact head `898b5f85d35947cec9debd3b05f597a119cc130a` adds the canonical IPX HTTP spool replay boundary. It reads binary byte offsets, validates operation/capture-session/source identity, persists typed `:http-exchange` records through the existing execution graph, resumes from the canonical checkpoint, quarantines malformed complete frames and advances past them, and quarantines truncated final frames without advancing the checkpoint so they can be retried after completion. Persistence errors propagate instead of being misclassified as source corruption.

The source spool remains the lossless evidence authority. This change introduces no second operation store, graph, KB, capture authority, or scheduler.

Exact-head CI: Common Lisp core ✅, hygiene ✅, agent-framework boundary ✅.