### PR TITLE
cli: add hm commands, expert shell, and Nix entrypoints

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,32 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
 
-      - name: Check flake, Lish, and CLI smoke tests
+      - name: Show public flake outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix flake show --all-systems
+
+      - name: Build public packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix build . .#hm .#expert --no-link --print-build-logs
+
+      - name: Run public apps
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix run . -- --help
+          nix run .#hm -- --help
+
+      - name: Exercise development shell
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix develop -c hm --help
+
+      - name: Run flake checks
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,31 @@
+name: nix
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    name: nix-flake-check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - name: Checkout Hackmode
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
+
+      - name: Check flake, Lish, and CLI smoke tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          nix flake check --print-build-logs

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,31 @@
-##
-# Hackmode
-#
-# @file
-# @version 0.1
-
 LISP ?= sbcl
+PREFIX ?= /usr/local
 
-all: test
+.PHONY: all build test install clean
 
-run:
-	$(LISP) --load run.lisp
+all: build
 
-build:
-	$(LISP)	--non-interactive \
+build: hm hm-expert
+
+hm: hackmode-user.asd hackmode.lisp
+	$(LISP) --non-interactive \
 		--load hackmode-user.asd \
 		--eval '(ql:quickload :hackmode-user)' \
-		--load 'hackmode.lisp' \
-		--eval "(sb-ext:save-lisp-and-die \"hm\" :toplevel 'hackmode-user::main :executable t :compression t)"
-install:
-	cp hm /usr/local/bin
+		--eval "(sb-ext:save-lisp-and-die \"hm\" :toplevel 'hackmode-user:main :executable t :compression t)"
+
+hm-expert: hm
+	printf '%s\n' '#!/bin/sh' 'exec "$$(dirname "$$0")/hm" expert "$$@"' > $@
+	chmod +x $@
+
+test:
+	$(LISP) --non-interactive \
+		--load hackmode-user.asd \
+		--eval '(ql:quickload :hackmode-user)' \
+		--eval '(assert (find-package :lish))'
+
+install: build
+	install -Dm755 hm $(DESTDIR)$(PREFIX)/bin/hm
+	install -Dm755 hm-expert $(DESTDIR)$(PREFIX)/bin/hm-expert
 
 clean:
-	rm -f hm
+	rm -f hm hm-expert

--- a/README.org
+++ b/README.org
@@ -63,18 +63,51 @@ sudo pacman -S sbcl git
 #+end_src
 
 *** NixOS
-The public flake exposes both the command CLI and the interactive expert shell.
+The public flake intentionally exposes a small stable package/app surface for both the command CLI and the interactive expert shell.
+
+#+begin_example
+packages.<system>.default
+packages.<system>.hm
+packages.<system>.expert
+apps.<system>.default
+apps.<system>.hm
+apps.<system>.expert
+checks.<system>.*
+devShells.<system>.default
+#+end_example
+
+Inspect it directly:
+
+#+begin_src shell
+nix flake show github:lost-rob0t/hackmode
+#+end_src
+
+Build each public package output:
+
+#+begin_src shell
+nix build github:lost-rob0t/hackmode
+nix build github:lost-rob0t/hackmode#hm
+nix build github:lost-rob0t/hackmode#expert
+#+end_src
+
+Run the apps without installing them:
 
 #+begin_src shell
 nix run github:lost-rob0t/hackmode -- --help
+nix run github:lost-rob0t/hackmode#hm -- --help
 nix run github:lost-rob0t/hackmode#expert
 #+end_src
 
 For a development checkout:
 
 #+begin_src shell
+nix flake show
+nix flake check
 nix develop
+nix develop -c hm --help
 #+end_src
+
+Internal Common Lisp dependency derivations are deliberately not exported through =packages=; they remain implementation details of the flake.
 
 ** Build
 #+begin_src shell
@@ -149,7 +182,7 @@ recon starintel.actor
 inventory import inventory.txt
 #+end_example
 
-=nix flake check= includes a dedicated Lish compile/load check plus CLI help and inventory-import smoke tests.
+=nix flake check= verifies the public package/app output contract, Lish compile/load, CLI help, expert entrypoint packaging, and inventory-import persistence smoke test.
 
 * Configure
 Hackmode follows the Lisp tradition of a user init file so the environment can be extended without forking the runtime.
@@ -161,7 +194,7 @@ The shell is backed by Lish and operates on typed Hackmode objects rather than o
 * Migration status
 - Common Lisp runtime: already here.
 - Tek9-backed operation/local database: already here; being hardened rather than replaced casually.
-- Agent Zero development profiles: under =agent-zero/=, with separate database and Hackpert ownership.
+- Agent Zero development profiles: under =agent-zero/=, with separate tooling/shipping and Hackpert/LISH ownership.
 - Emacs package: migration in progress under issue #4.
 - Operation templates: migrated into =templates/= by issue #4.
 - Script collection: source-only curation tracked by issue #5; do not import compiled/generated artifacts.

--- a/README.org
+++ b/README.org
@@ -63,9 +63,17 @@ sudo pacman -S sbcl git
 #+end_src
 
 *** NixOS
-Install direnv, then allow the repository environment:
+The public flake exposes both the command CLI and the interactive expert shell.
+
 #+begin_src shell
-direnv allow
+nix run github:lost-rob0t/hackmode -- --help
+nix run github:lost-rob0t/hackmode#expert
+#+end_src
+
+For a development checkout:
+
+#+begin_src shell
+nix develop
 #+end_src
 
 ** Build
@@ -77,12 +85,78 @@ make build
 sudo make install
 #+end_src
 
+The Makefile installs both =hm= and =hm-expert=.
+
+* Command line
+=hm= is the non-interactive command entry point. Command-mode work is persisted in the current workspace's =.hackmode/= Tek9 store. Set =HACKMODE_OPERATION= to select a named operation explicitly.
+
+** Expert shell
+#+begin_src shell
+hm expert
+#+end_src
+
+The dedicated entry point is equivalent:
+
+#+begin_src shell
+hm-expert
+#+end_src
+
+With Nix:
+
+#+begin_src shell
+nix run github:lost-rob0t/hackmode#expert
+#+end_src
+
+** Scan
+Run Nmap and retain its XML observation in the active Hackmode operation:
+
+#+begin_src shell
+hm scan 192.168.1.0/24
+hm scan 192.168.1.10 -sV
+#+end_src
+
+With Nix:
+
+#+begin_src shell
+nix run github:lost-rob0t/hackmode -- scan 192.168.1.0/24
+#+end_src
+
+** Recon
+Run the baseline domain recon providers, deduplicate discovered domains, and persist typed assets:
+
+#+begin_src shell
+hm recon starintel.actor
+#+end_src
+
+** Inventory import
+Import newline-delimited domains, hosts/IPs, and URLs. Blank lines and =#= comments are ignored.
+
+#+begin_src shell
+hm inventory import inventory.txt
+hm inventory import domains.txt domain
+hm inventory import hosts.txt host
+hm inventory import urls.txt url
+#+end_src
+
+The default =auto= mode recognizes HTTP(S) URLs and IP literals; remaining values are treated as domains.
+
+* Lish commands
+The expert shell calls the same implementations as the public CLI instead of maintaining a second command path:
+
+#+begin_example
+scan 192.168.1.0/24
+recon starintel.actor
+inventory import inventory.txt
+#+end_example
+
+=nix flake check= includes a dedicated Lish compile/load check plus CLI help and inventory-import smoke tests.
+
 * Configure
 Hackmode follows the Lisp tradition of a user init file so the environment can be extended without forking the runtime.
 
 The default init file is =~/.config/hackmode/init.lisp=.
 
-The shell work is inspired by LISH and should operate on typed Hackmode objects, not only strings. Existing commands remain callable as Common Lisp functions outside the interactive shell.
+The shell is backed by Lish and operates on typed Hackmode objects rather than only strings. Existing commands remain callable as Common Lisp functions outside the interactive shell.
 
 * Migration status
 - Common Lisp runtime: already here.

--- a/flake.lock
+++ b/flake.lock
@@ -10,7 +10,7 @@
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699580828,
-        "narHash": "sha256-SQT+801NjseVMQCr0ZVJVsdL9AN4CKxSU2Zf3oIbj+Q=",
-        "owner": "nixos",
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c19f30a07d07d3fceaa2f6fced02c42c43563a8",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,16 +2,15 @@
   description = "Hackmode actor-oriented reconnaissance and investigation environment";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs";
   };
 
   outputs = { self, nixpkgs }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" ];
       eachSystem = f: nixpkgs.lib.genAttrs systems (system: f system);
-    in
-    {
-      packages = eachSystem (system:
+
+      mkSystem = system:
         let
           pkgs = import nixpkgs { inherit system; };
           cl = pkgs.sbcl.pkgs;
@@ -41,8 +40,8 @@
           ];
 
           # Hackmode historically consumed Lish through Quicklisp. Keep the
-          # exact Yew/Lish snapshot explicit so `nix flake check` proves that
-          # the expert shell is actually compilable without a mutable QL tree.
+          # exact Yew/Lish snapshot explicit so the expert shell is buildable
+          # without relying on a mutable local Quicklisp tree.
           yewSrc = builtins.fetchGit {
             url = "https://github.com/lost-rob0t/yew-for-hackmode.git";
             rev = "33e87d3f8e8972da1b8162ba67ffd41bee447cfb";
@@ -257,7 +256,7 @@
             '';
           };
 
-          hmExpert = pkgs.writeShellApplication {
+          expert = pkgs.writeShellApplication {
             name = "hm-expert";
             runtimeInputs = [ hm ];
             text = ''
@@ -267,21 +266,31 @@
 
           hackmode = pkgs.symlinkJoin {
             name = "hackmode-0.2.0";
-            paths = [ hm hmExpert ];
+            paths = [ hm expert ];
           };
         in
         {
-          default = hackmode;
           inherit
+            pkgs
+            runtimeLibs
+            runtimeTools
+            lish
             hackmode
             hm
-            hmExpert
-            lish
-            hackmodeCore
-            hackmodeDatabase
-            providerDns
-            providerRecon
+            expert
             ;
+        };
+    in
+    {
+      # Public package API. Build internals stay private in mkSystem so
+      # `nix flake show` presents a small stable interface to users.
+      packages = eachSystem (system:
+        let
+          built = mkSystem system;
+        in
+        {
+          default = built.hackmode;
+          inherit (built) hm expert;
         });
 
       apps = eachSystem (system: {
@@ -295,17 +304,32 @@
         };
         expert = {
           type = "app";
-          program = "${self.packages.${system}.hmExpert}/bin/hm-expert";
+          program = "${self.packages.${system}.expert}/bin/hm-expert";
         };
       });
 
       checks = eachSystem (system:
         let
-          pkgs = import nixpkgs { inherit system; };
-          packages = self.packages.${system};
-          lishRuntime = pkgs.sbcl.withPackages (_: [ packages.lish ]);
+          built = mkSystem system;
+          pkgs = built.pkgs;
+          lishRuntime = pkgs.sbcl.withPackages (_: [ built.lish ]);
         in
         {
+          public-output-contract =
+            let
+              packageNames = builtins.attrNames self.packages.${system};
+              appNames = builtins.attrNames self.apps.${system};
+            in
+            assert packageNames == [ "default" "expert" "hm" ];
+            assert appNames == [ "default" "expert" "hm" ];
+            pkgs.runCommand "hackmode-public-output-contract" { } ''
+              test -x ${self.packages.${system}.default}/bin/hm
+              test -x ${self.packages.${system}.default}/bin/hm-expert
+              test -x ${self.packages.${system}.hm}/bin/hm
+              test -x ${self.packages.${system}.expert}/bin/hm-expert
+              touch "$out"
+            '';
+
           lish-compiles = pkgs.runCommand "hackmode-lish-compiles" {
             nativeBuildInputs = [ lishRuntime ];
           } ''
@@ -319,7 +343,7 @@
           '';
 
           cli-help = pkgs.runCommand "hackmode-cli-help" {
-            nativeBuildInputs = [ packages.hm ];
+            nativeBuildInputs = [ self.packages.${system}.hm ];
           } ''
             export HOME="$TMPDIR/home"
             mkdir -p "$HOME"
@@ -328,8 +352,16 @@
             touch "$out"
           '';
 
+          expert-entrypoint = pkgs.runCommand "hackmode-expert-entrypoint" {
+            nativeBuildInputs = [ self.packages.${system}.expert ];
+          } ''
+            command -v hm-expert >/dev/null
+            test -x "$(command -v hm-expert)"
+            touch "$out"
+          '';
+
           inventory-import = pkgs.runCommand "hackmode-inventory-import" {
-            nativeBuildInputs = [ packages.hm ];
+            nativeBuildInputs = [ self.packages.${system}.hm ];
           } ''
             export HOME="$TMPDIR/home"
             export XDG_CONFIG_HOME="$HOME/.config"
@@ -345,13 +377,14 @@
 
       devShells = eachSystem (system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          built = mkSystem system;
+          pkgs = built.pkgs;
         in
         {
           default = pkgs.mkShell {
             packages = [
-              self.packages.${system}.hackmode
-              self.packages.${system}.lish
+              built.hackmode
+              built.lish
               pkgs.pkg-config
               pkgs.sbcl
               pkgs.glib
@@ -370,9 +403,10 @@
               pkgs.swi-prolog
             ];
             shellHook = ''
-              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.openssl pkgs.libedit pkgs.libev pkgs.lmdb pkgs.file ]}:''${LD_LIBRARY_PATH:-}
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath built.runtimeLibs}:''${LD_LIBRARY_PATH:-}
               echo "Hackmode development environment"
               echo "Run: hm --help"
+              echo "Expert: hm-expert"
               echo "Check: nix flake check"
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Hackmode is a red teaming toolkit/exploit framework for common lisp";
+  description = "Hackmode actor-oriented reconnaissance and investigation environment";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs";
@@ -7,34 +7,375 @@
 
   outputs = { self, nixpkgs }:
     let
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      eachSystem = f: nixpkgs.lib.genAttrs systems (system: f system);
     in
     {
-      devShell.x86_64-linux =
-        pkgs.mkShell {
-          buildInputs = with pkgs; [
-            pkg-config
-            sbcl
-            sbclPackages.mcclim
-            swiProlog
-            glib
+      packages = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          cl = pkgs.sbcl.pkgs;
+
+          runtimeLibs = with pkgs; [
+            lmdb
             openssl
-            # Hacking tools used
+            libffi
+            libev
+            libedit
+            file
+          ];
+
+          runtimeTools = with pkgs; [
+            curl
+            nmap
             subfinder
             amass
             dnsrecon
             fierce
             asn
             whatweb
-            nmap
             nuclei
             zap
             gospider
+            swiProlog
           ];
 
-        shellHook = ''
-           export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath([pkgs.openssl])}:${pkgs.lib.makeLibraryPath([pkgs.libedit])}:${pkgs.lib.makeLibraryPath([pkgs.libev])}:${pkgs.lib.makeLibraryPath([pkgs.lmdb])}
+          # Hackmode historically consumed Lish through Quicklisp. Keep the
+          # exact Yew/Lish snapshot explicit so `nix flake check` proves that
+          # the expert shell is actually compilable without a mutable QL tree.
+          yewSrc = builtins.fetchGit {
+            url = "https://github.com/lost-rob0t/yew-for-hackmode.git";
+            rev = "33e87d3f8e8972da1b8162ba67ffd41bee447cfb";
+          };
+
+          lish = pkgs.sbcl.buildASDFSystem {
+            pname = "hackmode-lish";
+            version = "0.1.0-hackmode";
+            src = yewSrc;
+            systems = [
+              "dlib"
+              "opsys"
+              "dlib-misc"
+              "stretchy"
+              "char-util"
+              "glob"
+              "table"
+              "table-print"
+              "reader-ext"
+              "dlib-interactive"
+              "completion"
+              "keymap"
+              "terminal"
+              "terminal-ansi"
+              "rl"
+              "fatchar"
+              "fatchar-io"
+              "magic"
+              "theme"
+              "theme-default"
+              "style"
+              "collections"
+              "ostring"
+              "ochar"
+              "grout"
+              "utf8b-stream"
+              "dtime"
+              "locale"
+              "lish"
+            ];
+            nativeLibs = [ pkgs.file ];
+            lispLibs = [
+              cl.alexandria
+              cl.babel
+              cl."bordeaux-threads"
+              cl.cffi
+              cl.chipz
+              cl."cl-ppcre"
+              cl."closer-mop"
+              cl."trivial-gray-streams"
+            ];
+            dontStrip = true;
+          };
+
+          tek9Src = builtins.fetchGit {
+            url = "https://github.com/lost-rob0t/tek9.git";
+            rev = "1cb978084da8b4f1d184b3ef2a1d30057f525608";
+          };
+
+          lmdbLisp = cl.lmdb.overrideLispAttrs (old: {
+            nativeLibs = (old.nativeLibs or [ ]) ++ [ pkgs.lmdb.out ];
+          });
+
+          tek9 = pkgs.sbcl.buildASDFSystem {
+            pname = "tek9";
+            version = "0.2.0";
+            src = tek9Src;
+            systems = [ "tek9" ];
+            nativeLibs = [ pkgs.lmdb.out ];
+            lispLibs = [
+              cl.alexandria
+              cl."bordeaux-threads"
+              cl.serapeum
+              cl.jsown
+              lmdbLisp
+              cl."cl-conspack"
+            ];
+          };
+
+          starClSrc = builtins.fetchGit {
+            url = "https://github.com/lost-rob0t/star-cl.git";
+            rev = "b8dfbe2f9f56065ace8c3313b92ca748a115cdfa";
+          };
+
+          cmsUlid = pkgs.sbcl.buildASDFSystem {
+            pname = "cms-ulid";
+            version = "latest";
+            src = pkgs.fetchgit {
+              url = "https://gitlab.com/colinstrickland/cms-ulid.git";
+              rev = "fff84302dee5db42fb90aafd834af3ffbfd6c2bb";
+              hash = "sha256-B5rekME60bWHk47kDepQpOr9drjgXjZBiRpA+Ob1CuU=";
+            };
+            lispLibs = [
+              cl."local-time"
+              cl.ironclad
+              cl."bit-smasher"
+              cl.serapeum
+            ];
+            dontStrip = true;
+          };
+
+          starintel = pkgs.sbcl.buildASDFSystem {
+            pname = "starintel";
+            version = "0.9.0";
+            src = starClSrc;
+            systems = [ "starintel" ];
+            asdFilesToKeep = [
+              "src/starintel.asd"
+              "starintel-v090.asd"
+              "starintel-test.asd"
+            ];
+            lispLibs = [
+              cl.jsown
+              cl.jzon
+              cl."cl-ppcre"
+              cl.ironclad
+              cl."local-time"
+              cmsUlid
+              cl.str
+              cl."closer-mop"
+            ];
+            dontStrip = true;
+          };
+
+          hackmodeDatabase = pkgs.sbcl.buildASDFSystem {
+            pname = "hackmode-database";
+            version = "0.1.0";
+            src = ./source/hackmode-database;
+            systems = [ "hackmode-database" ];
+            lispLibs = [ tek9 ];
+            nativeLibs = [ pkgs.lmdb.out ];
+            dontStrip = true;
+          };
+
+          hackmodeCore = pkgs.sbcl.buildASDFSystem {
+            pname = "hackmode";
+            version = "0.3.0";
+            src = ./source/hackmode-core;
+            systems = [ "hackmode" ];
+            nativeLibs = runtimeLibs;
+            lispLibs = [
+              cl.serapeum
+              cl."local-time"
+              cl.nfiles
+              cl.nhooks
+              cl."bordeaux-threads"
+              tek9
+              hackmodeDatabase
+              starintel
+              cl.jsown
+              cl."cl-ppcre"
+              cl.dexador
+              cl.sento
+              cl.shellpool
+            ];
+            dontStrip = true;
+          };
+
+          providerDns = pkgs.sbcl.buildASDFSystem {
+            pname = "hackmode-provider-dns";
+            version = "0.1.0";
+            src = ./source/hackmode-providers/dns;
+            systems = [ "hackmode-provider-dns" ];
+            lispLibs = [ hackmodeCore cl.jsown ];
+            nativeLibs = runtimeLibs;
+            dontStrip = true;
+          };
+
+          providerRecon = pkgs.sbcl.buildASDFSystem {
+            pname = "hackmode-provider-recon";
+            version = "0.1.0";
+            src = ./source/hackmode-providers/recon;
+            systems = [ "hackmode-provider-recon" ];
+            lispLibs = [ hackmodeCore cl.jsown cl.dexador ];
+            nativeLibs = runtimeLibs;
+            dontStrip = true;
+          };
+
+          hackmodeUser = pkgs.sbcl.buildASDFSystem {
+            pname = "hackmode-user";
+            version = "0.2.0";
+            src = self;
+            systems = [ "hackmode-user" ];
+            asdFilesToKeep = [ "hackmode-user.asd" ];
+            lispLibs = [
+              hackmodeCore
+              providerDns
+              providerRecon
+              lish
+              cl.shellpool
+            ];
+            nativeLibs = runtimeLibs;
+            dontStrip = true;
+          };
+
+          sbclRuntime = pkgs.sbcl.withPackages (_: [ hackmodeUser ]);
+
+          launcher = pkgs.writeText "hackmode-launcher.lisp" ''
+            (let ((asdf-path (sb-ext:posix-getenv "ASDF")))
+              (when asdf-path
+                (load asdf-path)))
+            (asdf:load-system :hackmode-user)
+            (hackmode-user:main)
           '';
+
+          hm = pkgs.writeShellApplication {
+            name = "hm";
+            runtimeInputs = runtimeTools;
+            text = ''
+              export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath runtimeLibs}:''${LD_LIBRARY_PATH:-}"
+              exec ${sbclRuntime}/bin/sbcl --noinform --script ${launcher} "$@"
+            '';
+          };
+
+          hmExpert = pkgs.writeShellApplication {
+            name = "hm-expert";
+            runtimeInputs = [ hm ];
+            text = ''
+              exec ${hm}/bin/hm expert "$@"
+            '';
+          };
+
+          hackmode = pkgs.symlinkJoin {
+            name = "hackmode-0.2.0";
+            paths = [ hm hmExpert ];
+          };
+        in
+        {
+          default = hackmode;
+          inherit
+            hackmode
+            hm
+            hmExpert
+            lish
+            hackmodeCore
+            hackmodeDatabase
+            providerDns
+            providerRecon
+            ;
+        });
+
+      apps = eachSystem (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.hm}/bin/hm";
         };
+        hm = {
+          type = "app";
+          program = "${self.packages.${system}.hm}/bin/hm";
+        };
+        expert = {
+          type = "app";
+          program = "${self.packages.${system}.hmExpert}/bin/hm-expert";
+        };
+      });
+
+      checks = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          packages = self.packages.${system};
+          lishRuntime = pkgs.sbcl.withPackages (_: [ packages.lish ]);
+        in
+        {
+          lish-compiles = pkgs.runCommand "hackmode-lish-compiles" {
+            nativeBuildInputs = [ lishRuntime ];
+          } ''
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            sbcl --noinform --non-interactive --no-userinit --no-sysinit \
+              --eval '(require :asdf)' \
+              --eval '(asdf:load-system :lish)' \
+              --eval '(assert (find-package :lish))'
+            touch "$out"
+          '';
+
+          cli-help = pkgs.runCommand "hackmode-cli-help" {
+            nativeBuildInputs = [ packages.hm ];
+          } ''
+            export HOME="$TMPDIR/home"
+            mkdir -p "$HOME"
+            hm --help | grep -q 'hm scan TARGET'
+            hm --help | grep -q 'hm inventory import FILE'
+            touch "$out"
+          '';
+
+          inventory-import = pkgs.runCommand "hackmode-inventory-import" {
+            nativeBuildInputs = [ packages.hm ];
+          } ''
+            export HOME="$TMPDIR/home"
+            export XDG_CONFIG_HOME="$HOME/.config"
+            export XDG_DATA_HOME="$HOME/.local/share"
+            mkdir -p "$HOME" "$TMPDIR/work"
+            cd "$TMPDIR/work"
+            printf '%s\n' 'example.internal' '192.0.2.10' > inventory.txt
+            hm inventory import inventory.txt
+            test -f .hackmode/data.mdb
+            touch "$out"
+          '';
+        });
+
+      devShells = eachSystem (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = [
+              self.packages.${system}.hackmode
+              self.packages.${system}.lish
+              pkgs.pkg-config
+              pkgs.sbcl
+              pkgs.glib
+              pkgs.openssl
+              pkgs.lmdb
+              pkgs.subfinder
+              pkgs.amass
+              pkgs.dnsrecon
+              pkgs.fierce
+              pkgs.asn
+              pkgs.whatweb
+              pkgs.nmap
+              pkgs.nuclei
+              pkgs.zap
+              pkgs.gospider
+              pkgs.swiProlog
+            ];
+            shellHook = ''
+              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.openssl pkgs.libedit pkgs.libev pkgs.lmdb pkgs.file ]}:''${LD_LIBRARY_PATH:-}
+              echo "Hackmode development environment"
+              echo "Run: hm --help"
+              echo "Check: nix flake check"
+            '';
+          };
+        });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -166,6 +166,32 @@
             dontStrip = true;
           };
 
+          # Nixpkgs currently exposes an nfiles Lisp derivation that does not
+          # make the `nfiles` ASDF system discoverable from buildASDFSystem.
+          # Pin and build the exact upstream system so Hackmode's dependency is
+          # hermetic instead of falling back to a mutable Quicklisp tree.
+          nfilesSrc = builtins.fetchGit {
+            url = "https://github.com/atlas-engineer/nfiles.git";
+            rev = "b44b06caf20cececeaee2153a747902c508a9c48";
+          };
+
+          nfiles = pkgs.sbcl.buildASDFSystem {
+            pname = "nfiles";
+            version = "1.1.4";
+            src = nfilesSrc;
+            systems = [ "nfiles" ];
+            lispLibs = [
+              cl.alexandria
+              cl.nclasses
+              cl.quri
+              cl.serapeum
+              cl."trivial-garbage"
+              cl."trivial-package-local-nicknames"
+              cl."trivial-types"
+            ];
+            dontStrip = true;
+          };
+
           hackmodeDatabase = pkgs.sbcl.buildASDFSystem {
             pname = "hackmode-database";
             version = "0.1.0";
@@ -185,7 +211,7 @@
             lispLibs = [
               cl.serapeum
               cl."local-time"
-              cl.nfiles
+              nfiles
               cl.nhooks
               cl."bordeaux-threads"
               tek9

--- a/flake.nix
+++ b/flake.nix
@@ -192,6 +192,26 @@
             dontStrip = true;
           };
 
+          # As with nfiles, build the actual nhooks ASDF system explicitly so
+          # Hackmode does not depend on Quicklisp or a non-discoverable wrapper.
+          nhooksSrc = builtins.fetchGit {
+            url = "https://github.com/atlas-engineer/nhooks.git";
+            rev = "3847bc749a6f6eb1103bc21f8ef3b4f6b301e822";
+          };
+
+          nhooks = pkgs.sbcl.buildASDFSystem {
+            pname = "nhooks";
+            version = "1.2.2";
+            src = nhooksSrc;
+            systems = [ "nhooks" ];
+            lispLibs = [
+              cl."bordeaux-threads"
+              cl.serapeum
+              cl."closer-mop"
+            ];
+            dontStrip = true;
+          };
+
           hackmodeDatabase = pkgs.sbcl.buildASDFSystem {
             pname = "hackmode-database";
             version = "0.1.0";
@@ -212,7 +232,7 @@
               cl.serapeum
               cl."local-time"
               nfiles
-              cl.nhooks
+              nhooks
               cl."bordeaux-threads"
               tek9
               hackmodeDatabase

--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,8 @@
             dontStrip = true;
           };
 
+          sento = import ./nix/sento.nix { inherit pkgs cl; };
+
           hackmodeDatabase = pkgs.sbcl.buildASDFSystem {
             pname = "hackmode-database";
             version = "0.1.0";
@@ -240,7 +242,7 @@
               cl.jsown
               cl."cl-ppcre"
               cl.dexador
-              cl.sento
+              sento
               cl.shellpool
             ];
             dontStrip = true;

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
             nuclei
             zap
             gospider
-            swiProlog
+            swi-prolog
           ];
 
           # Hackmode historically consumed Lish through Quicklisp. Keep the
@@ -367,7 +367,7 @@
               pkgs.nuclei
               pkgs.zap
               pkgs.gospider
-              pkgs.swiProlog
+              pkgs.swi-prolog
             ];
             shellHook = ''
               export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.openssl pkgs.libedit pkgs.libev pkgs.lmdb pkgs.file ]}:''${LD_LIBRARY_PATH:-}

--- a/hackmode-user.asd
+++ b/hackmode-user.asd
@@ -1,8 +1,12 @@
 (asdf:defsystem :hackmode-user
-  :version      "0.1.0"
-  :description  "description"
-  :author       "nsaspy@airmail.cc"
-  :serial       t
-  :license      "LGPLv3"
-  :components   ((:file "hackmode"))
-  :depends-on   (#:hackmode #:lish #:hackmode-tools #:shellpool))
+  :version "0.2.0"
+  :description "Hackmode command-line and Lish expert-shell entry points"
+  :author "nsaspy@airmail.cc"
+  :serial t
+  :license "LGPLv3"
+  :components ((:file "hackmode"))
+  :depends-on (#:hackmode
+               #:hackmode-provider-dns
+               #:hackmode-provider-recon
+               #:lish
+               #:shellpool))

--- a/hackmode.lisp
+++ b/hackmode.lisp
@@ -122,9 +122,9 @@ stdout so the complete observation can be retained in the active operation."
     (ensure-cli-operation)
     (labels ((collect-provider (name thunk)
                (handler-case
-                   (progn
+                   (let ((provider-assets (funcall thunk)))
                      (incf successful-providers)
-                     (dolist (asset (funcall thunk))
+                     (dolist (asset provider-assets)
                        (let ((key (hackmode:domain-name asset)))
                          (unless (gethash key seen)
                            (setf (gethash key seen) t)

--- a/hackmode.lisp
+++ b/hackmode.lisp
@@ -1,18 +1,277 @@
-(declaim (optimize (speed 3) (safety 0)))
-(defpackage   :hackmode-user
-  (:export :main)
-  (:use :cl #:hackmode)
-  (:documentation "top level entry function"))
-;; I dont really use hackmode-user
+(declaim (optimize (speed 3) (safety 1)))
+
+(defpackage :hackmode-user
+  (:use :cl)
+  (:export
+   :main
+   :expert-shell
+   :scan-command
+   :recon-command
+   :inventory-import-command)
+  (:documentation "Hackmode CLI and expert-shell entry points."))
+
 (in-package :hackmode-user)
 
+(defun trim-line (value)
+  (string-trim '(#\Space #\Tab #\Newline #\Return) (or value "")))
 
-(defun main ()
-  (in-package :cl-user)
-  (use-package :hackmode)
-  (use-package :hackmode-tools)
-  (setq hackmode::*interactive* t)
-  (load hackmode-init-file)
+(defun load-user-init ()
+  "Load the Hackmode init file when it exists."
+  (let ((path (pathname hackmode:hackmode-init-file)))
+    (when (probe-file path)
+      (load path))))
+
+(defun initialize-runtime (&key interactive)
+  "Initialize shared Hackmode runtime state for CLI or shell use."
+  (setf hackmode::*interactive* interactive)
+  (load-user-init)
+  (nhooks:run-hook hackmode:*startup-hook*)
+  (hackmode-provider-recon:register-recon-providers)
+  (hackmode-provider-dns:register-massdns-provider)
+  t)
+
+(defun default-operation-name ()
+  "Return a stable per-workspace operation name for one-shot CLI commands."
+  (let* ((directory
+           (namestring
+            (uiop:ensure-directory-pathname (uiop:getcwd))))
+         (digest (starintel:digest-id "hackmode-cli-operation" directory)))
+    (format nil "cli-~a" (subseq digest 0 (min 16 (length digest))))))
+
+(defun ensure-cli-operation ()
+  "Select an operation for command-mode work, creating one for CWD if needed."
+  (or (hackmode:current-operation)
+      (let* ((directory
+               (namestring
+                (uiop:ensure-directory-pathname (uiop:getcwd))))
+             (configured-name (uiop:getenv "HACKMODE_OPERATION"))
+             (name
+               (if (and configured-name (plusp (length configured-name)))
+                   configured-name
+                   (default-operation-name))))
+        (unless (hackmode:select-operation name)
+          (hackmode:new-operation
+           name
+           directory
+           "Hackmode CLI operation"))
+        (hackmode:use-operation name))))
+
+(defun print-help (&optional (stream *standard-output*))
+  (format stream
+          "Hackmode~%~%
+Usage:~%
+  hm expert~%
+  hm scan TARGET [NMAP-ARG ...]~%
+  hm recon DOMAIN~%
+  hm inventory import FILE [auto|domain|host|url]~%
+~%
+Environment:~%
+  HACKMODE_OPERATION   operation name for command-mode persistence~%
+~%
+Nix entry points:~%
+  nix run github:lost-rob0t/hackmode~%
+  nix run github:lost-rob0t/hackmode#expert~%")
+  0)
+
+(defun persist-recon-assets (assets)
+  (ensure-cli-operation)
+  (loop for asset in assets
+        do (hackmode:record-recon-asset asset)
+        finally (return assets)))
+
+(defun scan-command (target &optional nmap-arguments)
+  "Run an Nmap XML scan against TARGET and persist the observation locally.
+
+NMAP-ARGUMENTS are passed as separate argv values. Hackmode forces XML output to
+stdout so the complete observation can be retained in the active operation."
+  (when (zerop (length (trim-line target)))
+    (error "SCAN requires a non-empty target."))
+  (ensure-cli-operation)
+  (multiple-value-bind (stdout stderr status)
+      (uiop:run-program
+       (append (list "nmap")
+               nmap-arguments
+               (list "-oX" "-" target))
+       :output :string
+       :error-output :string
+       :ignore-error-status t)
+    (when (plusp (length stdout))
+      (write-string stdout *standard-output*)
+      (finish-output *standard-output*))
+    (when (plusp (length stderr))
+      (write-string stderr *error-output*)
+      (finish-output *error-output*))
+    (when (or (null status) (zerop status))
+      (hackmode:record-recon-asset
+       (make-instance 'hackmode:finding
+                      :document-id target
+                      :finding-type "nmap-xml"
+                      :data stdout
+                      :tool "nmap"
+                      :tags '("scan" "nmap" "xml"))))
+    (if (null status) 0 status)))
+
+(defun recon-command (domain-name)
+  "Run baseline passive/domain recon and persist unique typed domain assets."
+  (let* ((root
+           (make-instance 'hackmode:domain
+                          :record (trim-line domain-name)))
+         (seen (make-hash-table :test #'equal))
+         (assets nil)
+         (successful-providers 0))
+    (ensure-cli-operation)
+    (labels ((collect-provider (name thunk)
+               (handler-case
+                   (progn
+                     (incf successful-providers)
+                     (dolist (asset (funcall thunk))
+                       (let ((key (hackmode:domain-name asset)))
+                         (unless (gethash key seen)
+                           (setf (gethash key seen) t)
+                           (push asset assets)))))
+                 (error (condition)
+                   (format *error-output*
+                           "~&recon provider ~a failed: ~a~%"
+                           name
+                           condition)))))
+      (collect-provider
+       "subfinder"
+       (lambda ()
+         (hackmode-provider-recon:subfinder-enumerate root)))
+      (collect-provider
+       "crt.sh"
+       (lambda ()
+         (hackmode-provider-recon:crtsh-enumerate root))))
+    (setf assets (nreverse assets))
+    (persist-recon-assets assets)
+    (dolist (asset assets)
+      (format t "~a~%" (hackmode:domain-name asset)))
+    (format *error-output*
+            "recon: ~d unique domain asset~:p persisted~%"
+            (length assets))
+    (if (plusp successful-providers) 0 1)))
+
+(defun comment-or-empty-line-p (line)
+  (or (zerop (length line))
+      (char= (char line 0) #\#)))
+
+(defun ipv4-literal-p (value)
+  (not (null
+        (cl-ppcre:scan
+         "^([0-9]{1,3}\\.){3}[0-9]{1,3}$"
+         value))))
+
+(defun url-literal-p (value)
+  (or (and (>= (length value) 7)
+           (string-equal "http://" value :end2 7))
+      (and (>= (length value) 8)
+           (string-equal "https://" value :end2 8))))
+
+(defun make-inventory-asset (line kind)
+  (let* ((value (trim-line line))
+         (normalized-kind (string-downcase (or kind "auto"))))
+    (cond
+      ((string= normalized-kind "domain")
+       (make-instance 'hackmode:domain :record value))
+      ((string= normalized-kind "host")
+       (if (or (ipv4-literal-p value) (find #\: value))
+           (make-instance 'hackmode:host :ip value)
+           (make-instance 'hackmode:host :hostname value)))
+      ((string= normalized-kind "url")
+       (hackmode:parse-url value))
+      ((string= normalized-kind "auto")
+       (cond
+         ((url-literal-p value)
+          (hackmode:parse-url value))
+         ((or (ipv4-literal-p value) (find #\: value))
+          (make-instance 'hackmode:host :ip value))
+         (t
+          (make-instance 'hackmode:domain :record value))))
+      (t
+       (error "Unknown inventory type ~s; expected auto, domain, host, or url."
+              kind)))))
+
+(defun read-inventory-assets (path kind)
+  "Parse PATH completely before any mutation of the operation store."
+  (with-open-file (stream path :direction :input)
+    (loop for raw = (read-line stream nil nil)
+          while raw
+          for line = (trim-line raw)
+          unless (comment-or-empty-line-p line)
+            collect (make-inventory-asset line kind))))
+
+(defun inventory-import-command (path &optional (kind "auto"))
+  "Import newline-delimited inventory from PATH into the active operation."
+  (let ((assets (read-inventory-assets path kind)))
+    (ensure-cli-operation)
+    (persist-recon-assets assets)
+    (format t "inventory: imported ~d asset~:p from ~a~%"
+            (length assets)
+            path)
+    0))
+
+(defun expert-shell ()
+  "Start the interactive Hackmode expert shell backed by Lish."
+  (initialize-runtime :interactive t)
   (shellpool:start)
-  (nhooks:run-hook *startup-hook*)
-  (lish:lish))
+  (setf *package* (find-package :cl-user))
+  (use-package :hackmode :cl-user)
+  (lish:lish)
+  0)
+
+(defun dispatch-command (arguments)
+  (let ((command (first arguments))
+        (rest (rest arguments)))
+    (cond
+      ((or (null command)
+           (member command '("help" "--help" "-h") :test #'string=))
+       (print-help))
+      ((member command '("expert" "shell") :test #'string=)
+       (expert-shell))
+      ((string= command "scan")
+       (unless rest
+         (error "Usage: hm scan TARGET [NMAP-ARG ...]"))
+       (initialize-runtime :interactive nil)
+       (scan-command (first rest) (rest rest)))
+      ((string= command "recon")
+       (unless (= 1 (length rest))
+         (error "Usage: hm recon DOMAIN"))
+       (initialize-runtime :interactive nil)
+       (recon-command (first rest)))
+      ((string= command "inventory")
+       (unless (and (>= (length rest) 2)
+                    (string= (first rest) "import")
+                    (<= (length rest) 3))
+         (error "Usage: hm inventory import FILE [auto|domain|host|url]"))
+       (initialize-runtime :interactive nil)
+       (inventory-import-command
+        (second rest)
+        (or (third rest) "auto")))
+      (t
+       (format *error-output* "Unknown Hackmode command: ~a~%~%" command)
+       (print-help *error-output*)
+       2))))
+
+;; Keep interactive Lish and the public CLI on exactly the same implementation
+;; functions. These are intentionally thin adapters, not parallel command logic.
+(lish:defcommand scan ((target string))
+  "Run a baseline Nmap scan and persist its XML observation."
+  (scan-command target))
+
+(lish:defcommand recon ((domain string))
+  "Run baseline domain reconnaissance and persist discovered domains."
+  (recon-command domain))
+
+(lish:defcommand inventory ((action string) (path string))
+  "Inventory commands. Currently: inventory import FILE."
+  (unless (string-equal action "import")
+    (error "Usage: inventory import FILE"))
+  (inventory-import-command path))
+
+(defun main (&optional (arguments (uiop:command-line-arguments)))
+  "Hackmode executable entry point."
+  (handler-case
+      (uiop:quit (dispatch-command arguments))
+    (error (condition)
+      (format *error-output* "hm: ~a~%" condition)
+      (uiop:quit 1))))

--- a/nix/sento.nix
+++ b/nix/sento.nix
@@ -1,0 +1,28 @@
+{ pkgs, cl }:
+let
+  # Nixpkgs' generated Common Lisp package does not currently expose the
+  # `sento` ASDF system to Hackmode's build reliably. Build the upstream
+  # system explicitly so the actor runtime stays hermetic and discoverable.
+  sentoSrc = builtins.fetchGit {
+    url = "https://github.com/mdbergmann/cl-gserver.git";
+    rev = "48f9b528becc8ed47be6c53fc288512f3fa732b9";
+  };
+in
+pkgs.sbcl.buildASDFSystem {
+  pname = "sento";
+  version = "3.4.4";
+  src = sentoSrc;
+  systems = [ "sento" ];
+  lispLibs = [
+    cl.alexandria
+    cl.log4cl
+    cl."bordeaux-threads"
+    cl."cl-speedy-queue"
+    cl.str
+    cl."binding-arrows"
+    cl."timer-wheel"
+    cl."local-time-duration"
+    cl.atomics
+  ];
+  dontStrip = true;
+}


### PR DESCRIPTION
## What changed

- add public `hm` command dispatch for:
  - `hm scan TARGET [NMAP-ARG ...]`
  - `hm recon DOMAIN`
  - `hm inventory import FILE [auto|domain|host|url]`
  - `hm expert`
- add dedicated `hm-expert` executable / `nix run ...#expert`
- expose the same `scan`, `recon`, and `inventory import` implementations inside Lish
- persist command-mode observations/assets into the current workspace operation store
- replace the dev-shell-only flake with a stable public Nix interface on x86_64-linux and aarch64-linux
- pin Hackmode's Yew/Lish snapshot, Tek9, and StarIntel Common Lisp schema for reproducible builds
- refresh the old 2023 nixpkgs lock to the same current nixpkgs revision used by Tek9
- add `nix flake check` coverage for the public output contract, Lish compile/load, CLI help, expert entrypoint packaging, and inventory import
- add a pinned Nix CI lane

## Public flake contract

```text
packages.<system>.default
packages.<system>.hm
packages.<system>.expert
apps.<system>.default
apps.<system>.hm
apps.<system>.expert
checks.<system>.*
devShells.<system>.default
```

Internal Common Lisp dependency derivations remain private implementation details instead of leaking into `packages`.

## Public usage

```sh
nix flake show github:lost-rob0t/hackmode
nix build github:lost-rob0t/hackmode
nix build github:lost-rob0t/hackmode#hm
nix build github:lost-rob0t/hackmode#expert
nix run github:lost-rob0t/hackmode -- --help
nix run github:lost-rob0t/hackmode#hm -- --help
nix run github:lost-rob0t/hackmode#expert
```

Inside the expert shell:

```text
scan 192.168.1.0/24
recon starintel.actor
inventory import inventory.txt
```

The Lish commands are intentionally thin adapters over the same Common Lisp command functions used by `hm`; there is no parallel implementation to drift.