### PR TITLE
test: freeze Hackpert objective semantic identity values

### DIFF
--- a/source/hackmode-core/expert/objective.lisp
+++ b/source/hackmode-core/expert/objective.lisp
@@ -18,10 +18,21 @@
 
 (defstruct (expert-objective-clause
              (:constructor %make-expert-objective-clause
-                 (&key kind predicate raw-arguments)))
+                 (&key kind predicate raw-arguments))
+             (:conc-name %expert-objective-clause-))
   (kind nil :read-only t)
   (predicate nil :read-only t)
   (raw-arguments nil :read-only t))
+
+(defun expert-objective-clause-kind (clause)
+  "Return CLAUSE's closed structural kind."
+  (check-type clause expert-objective-clause)
+  (%expert-objective-clause-kind clause))
+
+(defun expert-objective-clause-predicate (clause)
+  "Return an independently mutable snapshot of CLAUSE's predicate identity."
+  (check-type clause expert-objective-clause)
+  (copy-seq (%expert-objective-clause-predicate clause)))
 
 (defun make-expert-objective-clause (&key kind predicate arguments)
   "Create one immutable-by-interface objective clause from typed data.
@@ -37,18 +48,29 @@ never interpreted as executable Prolog source by this layer."
     (reject-expert-objective arguments "clause arguments must be a list"))
   (%make-expert-objective-clause
    :kind kind
-   :predicate predicate
+   :predicate (copy-seq predicate)
    :raw-arguments (copy-tree arguments)))
 
 (defun expert-objective-clause-arguments (clause)
   "Return a defensive copy of CLAUSE arguments."
   (check-type clause expert-objective-clause)
-  (copy-tree (expert-objective-clause-raw-arguments clause)))
+  (copy-tree (%expert-objective-clause-raw-arguments clause)))
 
 (defstruct (expert-objective-limit
-             (:constructor %make-expert-objective-limit (&key name maximum)))
+             (:constructor %make-expert-objective-limit (&key name maximum))
+             (:conc-name %expert-objective-limit-))
   (name nil :read-only t)
   (maximum 0 :read-only t))
+
+(defun expert-objective-limit-name (limit)
+  "Return an independently mutable snapshot of LIMIT's stable name."
+  (check-type limit expert-objective-limit)
+  (copy-seq (%expert-objective-limit-name limit)))
+
+(defun expert-objective-limit-maximum (limit)
+  "Return LIMIT's non-negative maximum."
+  (check-type limit expert-objective-limit)
+  (%expert-objective-limit-maximum limit))
 
 (defun make-expert-objective-limit (&key name maximum)
   "Create one named non-negative objective budget limit."
@@ -57,7 +79,7 @@ never interpreted as executable Prolog source by this layer."
   (unless (and (integerp maximum) (not (minusp maximum)))
     (reject-expert-objective maximum
                              "limit maximum must be a non-negative integer"))
-  (%make-expert-objective-limit :name name :maximum maximum))
+  (%make-expert-objective-limit :name (copy-seq name) :maximum maximum))
 
 (defstruct (expert-objective
              (:constructor %make-expert-objective
@@ -86,7 +108,7 @@ never interpreted as executable Prolog source by this layer."
   (unless (every #'expert-action-string-p capabilities)
     (reject-expert-objective capabilities
                              "granted capabilities must be non-empty strings"))
-  (let ((sorted (sort (copy-list capabilities) #'string<)))
+  (let ((sorted (sort (mapcar #'copy-seq capabilities) #'string<)))
     (loop for left on sorted
           while (cdr left)
           when (string= (first left) (second left))
@@ -150,7 +172,7 @@ execution authority and encodes no fixed recon or attack phase ordering."
 (defun expert-objective-granted-capabilities (objective)
   "Return deterministically normalized capability grants for OBJECTIVE."
   (check-type objective expert-objective)
-  (copy-list (%expert-objective-raw-granted-capabilities objective)))
+  (mapcar #'copy-seq (%expert-objective-raw-granted-capabilities objective)))
 
 (export '(+expert-objective-clause-kinds+
           invalid-expert-objective

--- a/source/hackmode-core/tests/expert-objective.lisp
+++ b/source/hackmode-core/tests/expert-objective.lisp
@@ -88,6 +88,55 @@
         (assert-equal "version-1"
                       (hackmode:expert-objective-version isolated)
                       "returned version mutation cannot rewrite objective version")))
+    (let* ((caller-predicate (copy-seq "final_identity"))
+           (caller-limit-name (copy-seq "provider-actions"))
+           (caller-capability (copy-seq "http-probe"))
+           (isolated-clause
+             (hackmode:make-expert-objective-clause
+              :kind :goal
+              :predicate caller-predicate
+              :arguments '(:uid 0)))
+           (isolated-limit
+             (hackmode:make-expert-objective-limit
+              :name caller-limit-name
+              :maximum 3))
+           (isolated
+             (hackmode:make-expert-objective
+              :id "value-freeze"
+              :version "1"
+              :clauses (list isolated-clause)
+              :limits (list isolated-limit)
+              :granted-capabilities (list caller-capability))))
+      (setf (char caller-predicate 0) #\X
+            (char caller-limit-name 0) #\X
+            (char caller-capability 0) #\X)
+      (assert-equal "final_identity"
+                    (hackmode:expert-objective-clause-predicate isolated-clause)
+                    "caller-owned predicate mutation cannot rewrite objective semantics")
+      (assert-equal "provider-actions"
+                    (hackmode:expert-objective-limit-name isolated-limit)
+                    "caller-owned limit-name mutation cannot rewrite objective budget identity")
+      (assert-equal "http-probe"
+                    (first (hackmode:expert-objective-granted-capabilities isolated))
+                    "caller-owned capability mutation cannot rewrite objective grants")
+      (let ((returned-predicate
+              (hackmode:expert-objective-clause-predicate isolated-clause))
+            (returned-limit-name
+              (hackmode:expert-objective-limit-name isolated-limit))
+            (returned-capability
+              (first (hackmode:expert-objective-granted-capabilities isolated))))
+        (setf (char returned-predicate 0) #\Y
+              (char returned-limit-name 0) #\Y
+              (char returned-capability 0) #\Y)
+        (assert-equal "final_identity"
+                      (hackmode:expert-objective-clause-predicate isolated-clause)
+                      "returned predicate mutation cannot rewrite objective semantics")
+        (assert-equal "provider-actions"
+                      (hackmode:expert-objective-limit-name isolated-limit)
+                      "returned limit-name mutation cannot rewrite objective budget identity")
+        (assert-equal "http-probe"
+                      (first (hackmode:expert-objective-granted-capabilities isolated))
+                      "returned capability mutation cannot rewrite objective grants")))
     (dolist (bad `((:clause-kind
                     ,(lambda ()
                        (hackmode:make-expert-objective-clause


### PR DESCRIPTION
## Selected slice

Advances #29 with a bug-first immutability regression for normalized/frozen objectives.

## RED target

Current objective construction copies top-level objective ID/version and list structure, but clause predicates, limit names, and granted-capability strings still alias caller-owned mutable strings. Public accessors can also return those internal strings directly.

The RED test proves that mutating either caller-owned or returned strings must not rewrite:
- clause predicate semantics;
- budget-limit identity;
- granted-capability identity.

## Authority fence

Test-only RED commit. No provider dispatch, Tek9 mutation, scheduler changes, Prolog shell execution, StarIntel work, or product-worker infrastructure.

Implementation follows only after exact-head RED evidence.